### PR TITLE
Add pipeline method

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -946,10 +946,9 @@ class FakePipeline(object):
 
     def execute(self):
         """Run all the commands in the pipeline and return the results."""
-        print self.watching
         if self.watching:
             mismatches = [(k, v, u)
-                for (k, v, u) in [(k, v, self.owner._db[k]) for (k, v) in self.watching.items()]
+                for (k, v, u) in [(k, v, self.owner._db.get(k)) for (k, v) in self.watching.items()]
                 if v != u]
             if mismatches:
                 self.commands = []
@@ -959,8 +958,7 @@ class FakePipeline(object):
                 for name, args, kwargs in self.commands]
 
     def watch(self, *keys):
-        self.watching.update((key, copy.deepcopy(self.owner._db[key])) for key in keys)
-        print self.watching
+        self.watching.update((key, copy.deepcopy(self.owner._db.get(key))) for key in keys)
         self.need_reset = True
         self.is_immediate = True
         pass

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -1062,7 +1062,7 @@ class TestFakeRedis(unittest.TestCase):
         self.redis.rpush('greet', 'hello')
         p = self.redis.pipeline()
         try:
-            p.watch('greet', 'foo')
+            p.watch('greet', 'foo', 'quux')
             nextf = p.get('foo') + 'baz'
             # simulate change happening on another thread:
             self.redis.rpush('greet', 'world')


### PR DESCRIPTION
Here’s a fake version of the Redis-Py Pipeline class that wraps use of the WATCH, MULTI, and EXECUTE commands.

This should be enough to run code that uses the pipeline protocol in a test against a fake Redis. It makes some attempts to raise the right exception when WATCH conflicts occur, but probably would need to be extended to do detailed testing of potential race conditions.
