### PR TITLE
Allow FakeRedis constructor to take additional kwargs

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -655,6 +655,8 @@ class FakeRedis(object):
         return len(self._db.get(name, {}))
 
     def zcount(self, name, min, max):
+        min = self._normalize_inf(min)
+        max = self._normalize_inf(max)
         found = 0
         for score in self._db.get(name, {}).values():
             if min <= score <= max:


### PR DESCRIPTION
This would be helpful so we can easily swap a real redis client with this one without having to change construction params.

Our codebase is currently initializing a redis client with this code.
https://gist.github.com/3156549
