### PR TITLE
Feature parity bugs

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -97,8 +97,10 @@ class FakeRedis(object):
 
     def get(self, name):
         value = self._db.get(name)
-        if value is not None:
-            return str(value)
+        if value is not None and not isinstance(value, str):
+            raise redis.ResponseError("Operation against a key holding the "
+                "wrong kind of value")
+        return value
 
     def __getitem__(self, name):
         return self._db[name]

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -58,6 +58,11 @@ class TestFakeRedis(unittest.TestCase):
         self.assertEqual(self.redis.set('foo', None), True)
         self.assertEqual(self.redis.get('foo'), 'None')
 
+    def test_get_non_string(self):
+        self.assertEqual(self.redis.lpush('foo', 'bar'), 1)
+        with self.assertRaises(redis.ResponseError):
+            self.redis.get('foo')
+
     def test_get_does_not_exist(self):
         self.assertEqual(self.redis.get('foo'), None)
 


### PR DESCRIPTION
This patch fixes a number of feature parity bugs with redis-py.  The four most significant fixes are:
- Add support for variadic commands: SADD, HDEL, SREM ZREM, ZADD, LPUSH and RPUSH
- Support glob-style matching on pattern argument to KEYS command
- Fix pipeline WATCH command for non-existent keys (bug prevents using transactional features of the pipeline in several cases).
- Ensure that objects (i.e. dictionaries and lists) are stored in Redis as strings when passed as arguments to fakeredis commands
