### PR TITLE
Remove failing non-alpha sort as this fails in real Redis on Travis CI.

### DIFF
--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -998,8 +998,6 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         self.assertEqual(self.redis.sort('foo', alpha=True),
                          ['1a', '1b', '2a', '2b'])
-        self.assertEqual(self.redis.sort('foo', alpha=False),
-                         ['1b', '1a', '2a', '2b'])
 
     def test_sort_with_store_option(self):
         self.redis.rpush('foo', '2')


### PR DESCRIPTION
Fails in Travis CI with `ResponseError: One or more scores can't be converted into double`
