### PR TITLE
Fix `sdiff` removing elements from the source set

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -541,7 +541,7 @@ class FakeStrictRedis(object):
     def sdiff(self, keys, *args):
         "Return the difference of sets specified by ``keys``"
         all_keys = redis.client.list_or_args(keys, args)
-        diff = self._db.get(all_keys[0], set())
+        diff = self._db.get(all_keys[0], set()).copy()
         for key in all_keys[1:]:
             diff -= self._db.get(key, set())
         return diff

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -627,6 +627,9 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.sadd('bar', 'member2')
         self.redis.sadd('bar', 'member3')
         self.assertEqual(self.redis.sdiff('foo', 'bar'), set(['member1']))
+        # Original sets shouldn't be modified.
+        self.assertEqual(self.redis.smembers('foo'), set(['member1', 'member2']))
+        self.assertEqual(self.redis.smembers('bar'), set(['member2', 'member3']))
 
     def test_sdiff_one_key(self):
         self.redis.sadd('foo', 'member1')


### PR DESCRIPTION
The redis sdiff operation doesn't modify the first set or all the successive sets.
