### PR TITLE
Fix `zunionstore` and `zinterstore` commands to work with normal sets

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -879,6 +879,9 @@ class FakeStrictRedis(object):
             keys_weights = [(k, 1) for k in keys]
         for key, weight in keys_weights:
             current_zset = self._db.get(key, {})
+            if isinstance(current_zset, set):
+                # When casting set to zset redis uses a default score of 1.0
+                current_zset = dict((k, 1.0) for k in current_zset)
             for el in current_zset:
                 if not should_include(el):
                     continue

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -969,6 +969,16 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
                          [('one', 3), ('two', 6), ('four', 8)])
 
+    def test_zunionstore_mixed_set_types(self):
+        self.redis.sadd('foo', 'one') # no score, redis will use 1.0
+        self.redis.sadd('foo', 'two') # no score, redis will use 1.0
+        self.redis.zadd('bar', one=1)
+        self.redis.zadd('bar', two=2)
+        self.redis.zadd('bar', three=3)
+        self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='SUM')
+        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
+                         [('one', 2), ('three', 3), ('two', 3)])
+
     def test_zunionstore_badkey(self):
         self.redis.zadd('foo', one=1)
         self.redis.zadd('foo', two=2)
@@ -988,6 +998,16 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.zinterstore('baz', ['foo', 'bar'], aggregate='SUM')
         self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
                          [('one', 2), ('two', 4)])
+
+    def test_zinterstore_mixed_set_types(self):
+        self.redis.sadd('foo', 'one') # no score, redis will use 1.0
+        self.redis.sadd('foo', 'two') # no score, redis will use 1.0
+        self.redis.zadd('bar', one=1)
+        self.redis.zadd('bar', two=2)
+        self.redis.zadd('bar', three=3)
+        self.redis.zinterstore('baz', ['foo', 'bar'], aggregate='SUM')
+        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
+                         [('one', 2), ('two', 3)])
 
     def test_zinterstore_max(self):
         self.redis.zadd('foo', one=0)


### PR DESCRIPTION
The native redis zunionstore and zinterstore commands can handle normal sets besides
sorted sets as input.
