### PR TITLE
Add the bitcount command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,6 @@ string
  * incrbyfloat
  * bitop
  * psetex
- * bitcount
 
 
 generic

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -59,6 +59,17 @@ class FakeStrictRedis(object):
         self._db[key] += value
         return len(self._db[key])
 
+    def bitcount(self, name, start=0, end=-1):
+        if end == -1:
+            end = None
+        else:
+            end += 1
+        try:
+            s = self._db[name][start:end]
+            return sum([bin(ord(l)).count('1') for l in s])
+        except KeyError:
+            return 0
+
     def decr(self, name, amount=1):
         try:
             self._db[name] = self._db.get(name, 0) - amount

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -114,6 +114,19 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.setbit('foo', 54, 1)
         self.assertEqual(self.redis.get('foo'), 'p@\x00\x00\x00\x00\x02')
 
+    def test_bitcount(self):
+        self.redis.delete('foo')
+        self.assertEqual(self.redis.bitcount('foo'), 0)
+        self.redis.setbit('foo', 1, 1)
+        self.assertEqual(self.redis.bitcount('foo'), 1)
+        self.redis.setbit('foo', 8, 1)
+        self.assertEqual(self.redis.bitcount('foo'), 2)
+        self.assertEqual(self.redis.bitcount('foo', 1, 1), 1)
+        self.redis.setbit('foo', 57, 1)
+        self.assertEqual(self.redis.bitcount('foo'), 3)
+        self.redis.set('foo', ' ')
+        self.assertEqual(self.redis.bitcount('foo'), 1)
+
     def test_getset_not_exist(self):
         val = self.redis.getset('foo', 'bar')
         self.assertEqual(val, None)


### PR DESCRIPTION
I had to bump the redis-py requirement to the most recent version. For whatever reason, 2.6.2 didn't seem to have bitcount.
