### PR TITLE
Fix for KeyError when removing a numeric member from a zset

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -38,7 +38,7 @@ class _StrKeyDict(MutableMapping):
         self._dict[str(key)] = value
 
     def __delitem__(self, key):
-        del self._dict[key]
+        del self._dict[str(key)]
 
     def __len__(self):
         return len(self._dict)

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -902,6 +902,11 @@ class TestFakeStrictRedis(unittest.TestCase):
     def test_zrem_non_existent_member(self):
         self.assertFalse(self.redis.zrem('foo', 'one'))
 
+    def test_zrem_numeric_member(self):
+        self.redis.zadd('foo', **{'128': 13.0, '129': 12.0})
+        self.assertEqual(self.redis.zrem('foo',  128), True)
+        self.assertEqual(self.redis.zrange('foo', 0, -1), ['129'])
+
     def test_zscore(self):
         self.redis.zadd('foo', one=54)
         self.assertEqual(self.redis.zscore('foo', 'one'), 54)


### PR DESCRIPTION
Given you have a sorted set whose members happen to be numbers, when you call `zrem` passing a number as the member, then you get a `KeyError` exception. 

The fix is naturally to wrap `str` around the key in the StrKeyDict.
