### PR TITLE
zrevrange results should be sorted by score and keys in reverse order

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -857,7 +857,7 @@ class FakeStrictRedis(object):
             return [(k, all_items[k]) for k in items]
 
     def _get_zelements_in_order(self, all_items, reverse=False):
-        by_keyname = sorted(all_items.items(), key=lambda x: x[0])
+        by_keyname = sorted(all_items.items(), key=lambda x: x[0], reverse=reverse)
         in_order = sorted(by_keyname, key=lambda x: x[1], reverse=reverse)
         return [el[0] for el in in_order]
 

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -928,6 +928,16 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.zrevrange('foo', 0, -1),
                          ['three', 'two', 'one'])
 
+    def test_zrevrange_sorted_keys(self):
+        self.redis.zadd('foo', one=1)
+        self.redis.zadd('foo', two=2)
+        self.redis.zadd('foo', 2, 'two_b')
+        self.redis.zadd('foo', three=3)
+        self.assertEqual(self.redis.zrevrange('foo', 0, 2), ['three', 'two_b', 'two'])
+        self.assertEqual(self.redis.zrevrange('foo', 0, -1),
+                         ['three', 'two_b', 'two', 'one'])
+
+
     def test_zrangebyscore(self):
         self.redis.zadd('foo', zero=0)
         self.redis.zadd('foo', two=2)


### PR DESCRIPTION
Fix for #46 
