### PR TITLE
Update sadd to write values as strings

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -664,7 +664,7 @@ class FakeStrictRedis(object):
         "Add ``value`` to set ``name``"
         a_set = self._db.setdefault(name, set())
         card = len(a_set)
-        a_set |= set(values)
+        a_set |= set(map(str, values))
         return len(a_set) - card
 
     def scard(self, name):


### PR DESCRIPTION
Pyredis writes values as strings for most things, including sadd. This change writes sets as strings:

In [2]: redis.sadd('test_set', *range(3))
Out[2]: 3
In [3]: redis.smembers('test_set')
Out[3]: set(['1', '0', '2'])
