### PR TITLE
desc should be used before slizing result in sort()

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -395,10 +395,10 @@ class FakeStrictRedis(object):
                 data.sort(key=self._strtod_key_func)
             else:
                 data.sort()
-            if not (start is None and num is None):
-                data = data[start:start + num]
             if desc:
                 data = list(reversed(data))
+            if not (start is None and num is None):
+                data = data[start:start + num]
             if store is not None:
                 self._db[store] = data
                 return len(data)

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -1191,6 +1191,14 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         self.assertEqual(self.redis.sort('foo', start=0, num=2), ['1', '2'])
 
+    def test_sort_range_offset_range_and_desc(self):
+        self.redis.rpush('foo', '2')
+        self.redis.rpush('foo', '1')
+        self.redis.rpush('foo', '4')
+        self.redis.rpush('foo', '3')
+
+        self.assertEqual(self.redis.sort("foo", start=0, num=1, desc=True), ["4"])
+
     def test_sort_range_offset_norange(self):
         with self.assertRaises(redis.RedisError):
             self.redis.sort('foo', start=1)


### PR DESCRIPTION
When running the following code it outputs wrong data

``` python
>>> from fakeredis import FakeStrictRedis
>>> f = FakeStrictRedis()
>>> f.rpush("foo", "2", "3", "4")
3
>>> f.sort("foo")
['2', '3', '4']
>>> f.sort("1", start=0, num=1)
['2']  # Correct
>>> f.sort("1", start=0, num=1, desc=True)
['2']  # Wrong
```

It should reverse the sorted data before slizing. This is how redis-cli handles the same case

```
127.0.0.1:6379> rpush foo 1 2 3 4 5
(integer) 5
127.0.0.1:6379> lrange foo 0 -1
1) "1"
2) "2"
3) "3"
4) "4"
5) "5"
127.0.0.1:6379> sort foo
1) "1"
2) "2"
3) "3"
4) "4"
5) "5"
127.0.0.1:6379> sort foo DESC
1) "5"
2) "4"
3) "3"
4) "2"
5) "1"
127.0.0.1:6379> sort foo LIMIT 0 1
1) "1"
127.0.0.1:6379> sort foo LIMIT 0 1 DESC
1) "5"
127.0.0.1:6379>
```
