### PR TITLE
Throw `TypeError` if `GET` is used against a hash-type

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -216,6 +216,9 @@ class FakeStrictRedis(object):
 
     def get(self, name):
         value = self._db.get(name)
+        if isinstance(value, _StrKeyDict):
+            raise TypeError('Cannot use operation `get` against hash-type key. Redis would have produced: '
+                            '"(error) WRONGTYPE Operation against a key holding the wrong kind of value".')
         if value is not None:
             return to_bytes(value)
 


### PR DESCRIPTION
See jamesls/fakeredis#62.