### PR TITLE
Add hincbryfloat operation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,12 +75,6 @@ All of the redis commands are implemented in fakeredis with
 these exceptions:
 
 
-hash
-----
-
- * hincrbyfloat
-
-
 string
 ------
 

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -692,6 +692,20 @@ class FakeStrictRedis(object):
         self._db[name][key] = new
         return new
 
+    def hincrbyfloat(self, name, key, amount=1.0):
+        "Increment the value of ``key`` in hash ``name`` by floating ``amount``"
+        try:
+            amount = float(amount)
+        except ValueError:
+            raise redis.ResponseError("value is not a valid float")
+        try:
+            current = float(self._db.setdefault(name, _StrKeyDict()).get(key, '0'))
+        except ValueError:
+            raise redis.ResponseError("hash value is not a valid float")
+        new = current + amount
+        self._db[name][key] = new
+        return new
+
     def hkeys(self, name):
         "Return the list of keys within hash ``name``"
         return list(self._db.get(name, {}))

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -685,6 +685,31 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.hincrby('foo', 'counter', 2), 4)
         self.assertEqual(self.redis.hincrby('foo', 'counter', 2), 6)
 
+    def test_hincrbyfloat(self):
+        self.redis.hset('foo', 'counter', 0.0)
+        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 1.0)
+        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 2.0)
+        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 3.0)
+
+    def test_hincrbyfloat_with_no_starting_value(self):
+        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 1.0)
+        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 2.0)
+        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 3.0)
+
+    def test_hincrbyfloat_with_range_param(self):
+        self.assertAlmostEqual(self.redis.hincrbyfloat('foo', 'counter', 0.1), 0.1)
+        self.assertAlmostEqual(self.redis.hincrbyfloat('foo', 'counter', 0.1), 0.2)
+        self.assertAlmostEqual(self.redis.hincrbyfloat('foo', 'counter', 0.1), 0.3)
+
+    def test_hincrbyfloat_on_non_float_value_raises_error(self):
+        self.redis.hset('foo', 'counter', 'cat')
+        with self.assertRaises(redis.ResponseError):
+            self.redis.hincrbyfloat('foo', 'counter')
+
+    def test_hincrbyfloat_with_non_float_amount_raises_error(self):
+        with self.assertRaises(redis.ResponseError):
+            self.redis.hincrbyfloat('foo', 'counter', 'cat')
+
     def test_hsetnx(self):
         self.assertEqual(self.redis.hsetnx('foo', 'newkey', 'v1'), True)
         self.assertEqual(self.redis.hsetnx('foo', 'newkey', 'v1'), False)


### PR DESCRIPTION
Adds support for the `hincrbyfloat` operation, raising `ResponseError`s on the same error conditions as redis does through py-redis.