### PR TITLE
Fix return value from expire and expireat

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -204,16 +204,18 @@ class FakeStrictRedis(object):
             time = int(timedelta_total_seconds(time))
         if self.exists(name):
             self._db.expire(name, datetime.now() + timedelta(seconds=time))
+            return True
         else:
             return False
 
     def expireat(self, name, when):
-        if not self.exists(name):
-            return False
-        if isinstance(when, datetime):
+        if not isinstance(when, datetime):
+            when = datetime.fromtimestamp(when)
+        if self.exists(name):
             self._db.expire(name, when)
+            return True
         else:
-            self._db.expire(name, datetime.fromtimestamp(when))
+            return False
 
     def get(self, name):
         value = self._db.get(name)

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -1768,6 +1768,15 @@ class TestFakeRedis(unittest.TestCase):
         self.assertEqual(self.redis.get('foo'), None)
         self.assertEqual(self.redis.expire('bar', 1), False)
 
+    def test_expire_should_return_true_for_existing_key(self):
+        self.redis.set('foo', 'bar')
+        rv = self.redis.expire('foo', 1)
+        self.assertIs(rv, True)
+
+    def test_expire_should_return_false_for_missing_key(self):
+        rv = self.redis.expire('missing', 1)
+        self.assertIs(rv, False)
+
     @attr('slow')
     def test_expire_should_expire_key_using_timedelta(self):
         self.redis.set('foo', 'bar')
@@ -1794,6 +1803,15 @@ class TestFakeRedis(unittest.TestCase):
         sleep(1.5)
         self.assertEqual(self.redis.get('foo'), None)
         self.assertEqual(self.redis.expire('bar', 1), False)
+
+    def test_expireat_should_return_true_for_existing_key(self):
+        self.redis.set('foo', 'bar')
+        rv = self.redis.expireat('foo', int(time() + 1))
+        self.assertIs(rv, True)
+
+    def test_expireat_should_return_false_for_missing_key(self):
+        rv = self.redis.expireat('missing', int(time() + 1))
+        self.assertIs(rv, False)
 
     def test_ttl_should_return_none_for_non_expiring_key(self):
         self.redis.set('foo', 'bar')


### PR DESCRIPTION
Expire and expireat should return a boolean indicating whether the timeout was successfully set.  In general, this means they return `True` if the specified key exists, `False` otherwise.