### PR TITLE
support scan and scan_iter commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ fakeredis.egg-info
 dump.rdb
 extras/*
 .tox
+*.pyc

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -315,14 +315,14 @@ class FakeStrictRedis(object):
     def scan(self, cursor=0, match=None, count=None):
         if count is None:
             count = 10
-        match_keys = [key for key in self._db
-                if not key or not match or
-                fnmatch.fnmatch(to_native(key), to_native(match))]
+        match_keys = [key for key in self._db \
+            if not key or not match or \
+            fnmatch.fnmatch(to_native(key), to_native(match))]
         keys = match_keys[cursor:cursor+count]
         if cursor + count >= len(match_keys):
             return 0, keys
         else:
-            return cursor + count, keys
+            return cursor + count, keys[cursor:cursor+count]
 
     def set(self, name, value, ex=None, px=None, nx=False, xx=False):
         if (not nx and not xx) \

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -312,6 +312,9 @@ class FakeStrictRedis(object):
         else:
             return self.rename(src, dst)
 
+    def scan(self, cursor=0, pattern=None, count=None):
+        return 0, self.keys(pattern)
+
     def set(self, name, value, ex=None, px=None, nx=False, xx=False):
         if (not nx and not xx) \
         or (nx and self._db.get(name, None) is None) \

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -322,7 +322,7 @@ class FakeStrictRedis(object):
         if cursor + count >= len(match_keys):
             return 0, keys
         else:
-            return cursor+count, keys
+            return cursor + count, keys
 
     def set(self, name, value, ex=None, px=None, nx=False, xx=False):
         if (not nx and not xx) \

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -313,7 +313,16 @@ class FakeStrictRedis(object):
             return self.rename(src, dst)
 
     def scan(self, cursor=0, match=None, count=None):
-        return 0, self.keys(match)
+        if count is None:
+            count = 10
+        match_keys = [key for key in self._db
+                if not key or not match or
+                fnmatch.fnmatch(to_native(key), to_native(match))]
+        keys = match_keys[cursor:cursor+count]
+        if cursor + count >= len(match_keys):
+            return 0, keys
+        else:
+            return cursor+count, keys
 
     def set(self, name, value, ex=None, px=None, nx=False, xx=False):
         if (not nx and not xx) \

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -312,8 +312,8 @@ class FakeStrictRedis(object):
         else:
             return self.rename(src, dst)
 
-    def scan(self, cursor=0, pattern=None, count=None):
-        return 0, self.keys(pattern)
+    def scan(self, cursor=0, match=None, count=None):
+        return 0, self.keys(match)
 
     def set(self, name, value, ex=None, px=None, nx=False, xx=False):
         if (not nx and not xx) \

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -313,6 +313,7 @@ class FakeStrictRedis(object):
             return self.rename(src, dst)
 
     def scan(self, cursor=0, match=None, count=None):
+        cursor = int(cursor)
         if count is None:
             count = 10
         match_keys = [key for key in self._db \
@@ -323,6 +324,14 @@ class FakeStrictRedis(object):
             return 0, keys
         else:
             return cursor + count, keys[cursor:cursor+count]
+
+    def scan_iter(self, match=None, count=None):
+        # This is from redis-py
+        cursor = '0'
+        while cursor != 0:
+            cursor, data = self.scan(cursor=cursor, match=match, count=count)
+            for item in data:
+                yield item
 
     def set(self, name, value, ex=None, px=None, nx=False, xx=False):
         if (not nx and not xx) \

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -722,7 +722,6 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.set('foo1', 'bar1')
         self.redis.set('foo2', 'bar2')
         self.assertEqual(self.redis.scan(match="foo*"), (0, [b'foo1', b'foo2']))
-        self.assertEqual(self.redis.scan(match="foo*", count=1), (1, [b'foo1']))
 
     def test_scard(self):
         self.redis.sadd('foo', 'member1')

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -722,6 +722,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.set('foo1', 'bar1')
         self.assertEqual(self.redis.scan(match="foo*"), (0, [b'foo1']))
 
+    def test_scan_iter(self):
+        self.redis.set('foo1', 'bar1')
+        self.redis.set('foo2', 'bar2')
+        self.assertEqual(set(self.redis.scan_iter(match="foo*")), set([b'foo1',b'foo2']))
+
     def test_scard(self):
         self.redis.sadd('foo', 'member1')
         self.redis.sadd('foo', 'member2')

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -720,8 +720,7 @@ class TestFakeStrictRedis(unittest.TestCase):
 
     def test_scan(self):
         self.redis.set('foo1', 'bar1')
-        self.redis.set('foo2', 'bar2')
-        self.assertEqual(self.redis.scan(match="foo*"), (0, [b'foo1', b'foo2']))
+        self.assertEqual(self.redis.scan(match="foo*"), (0, [b'foo1']))
 
     def test_scard(self):
         self.redis.sadd('foo', 'member1')

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -718,6 +718,12 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.sadd('foo', *range(3)), 3)
         self.assertEqual(self.redis.smembers('foo'), set([b'0', b'1', b'2']))
 
+    def test_scan(self):
+        self.redis.set('foo1', 'bar1')
+        self.redis.set('foo2', 'bar2')
+        self.assertEqual(self.redis.scan(match="foo*"), (0, [b'foo1', b'foo2']))
+        self.assertEqual(self.redis.scan(match="foo*", count=1), (1, [b'foo1']))
+
     def test_scard(self):
         self.redis.sadd('foo', 'member1')
         self.redis.sadd('foo', 'member2')
@@ -1145,7 +1151,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.zrange('foo', 0, -1),
                          [b'zero', b'two', b'four'])
         self.assertEqual(self.redis.zremrangebyscore('foo', '-inf', '(0'), 0)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), 
+        self.assertEqual(self.redis.zrange('foo', 0, -1),
                          [b'zero', b'two', b'four'])
         self.assertEqual(self.redis.zremrangebyscore('foo', '(2', 5), 1)
         self.assertEqual(self.redis.zrange('foo', 0, -1), [b'zero', b'two'])


### PR DESCRIPTION
This is a continuation of https://github.com/jamesls/fakeredis/pull/68

Adds support and test case for scan_iter.  Also fixes a bug in scan where you could no use a string for the cursor, which is supported by the real redis-py library.  The implementation of scan_iter is exactly what is in redis-py.