### PR TITLE
add method `incrby` for fakeredis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ fakeredis.egg-info
 dump.rdb
 extras/*
 .tox
+*.pyc

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -277,6 +277,12 @@ class FakeStrictRedis(object):
                                       "range.")
         return self._db[name]
 
+    def incrby(self, name, amount=1):
+        """
+        Alias for command ``incr``
+        """
+        return self.incr(name, amount)
+
     def incrbyfloat(self, name, amount=1.0):
         try:
             self._db[name] = float(self._db.get(name, '0')) + amount

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -195,6 +195,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.incr('foo'), 1)
         self.assertEqual(self.redis.incr('bar', 2), 2)
 
+    def test_incr_by(self):
+        self.assertEqual(self.redis.incrby('foo'), 1)
+        self.assertEqual(self.redis.incrby('bar', 2), 2)
+
     def test_incr_preexisting_key(self):
         self.redis.set('foo', 15)
         self.assertEqual(self.redis.incr('foo', 5), 20)


### PR DESCRIPTION
redis-py client support command `incrby` which fakeredis not support.

https://github.com/andymccurdy/redis-py/blob/master/redis/client.py#L914