### PR TITLE
[Fix bug & fix code style] TypeError: zadd() keywords must be strings when using FakeRedis.

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -1287,6 +1287,7 @@ class FakeRedis(FakeStrictRedis):
 
         The ``value`` and ``score`` arguments are deprecated.
         """
+        print pairs
         if value is not None or score is not None:
             if value is None or score is None:
                 raise redis.RedisError(
@@ -1294,7 +1295,7 @@ class FakeRedis(FakeStrictRedis):
             warnings.warn(DeprecationWarning(
                 "Passing 'value' and 'score' has been deprecated. "
                 "Please pass via kwargs instead."))
-            super(FakeRedis, self).zadd(name, value, score)
+            pairs = {str(value): score}
         elif not pairs:
             raise redis.RedisError("ZADD is missing kwargs param")
         return super(FakeRedis, self).zadd(name, **pairs)

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -1287,7 +1287,6 @@ class FakeRedis(FakeStrictRedis):
 
         The ``value`` and ``score`` arguments are deprecated.
         """
-        print pairs
         if value is not None or score is not None:
             if value is None or score is None:
                 raise redis.RedisError(

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -148,10 +148,8 @@ class _ZSet(_StrKeyDict):
     redis_type = b'zset'
 
 
-
 class _Hash(_StrKeyDict):
     redis_type = b'hash'
-
 
 
 class FakeStrictRedis(object):
@@ -361,7 +359,7 @@ class FakeStrictRedis(object):
             key for key in self._db if not match or
             fnmatch.fnmatch(to_native(key), to_native(match))
         ]
-        keys = match_keys[cursor:cursor+count]
+        keys = match_keys[cursor:cursor + count]
         if cursor + count >= len(match_keys):
             return 0, keys
         else:
@@ -1296,7 +1294,7 @@ class FakeRedis(FakeStrictRedis):
             warnings.warn(DeprecationWarning(
                 "Passing 'value' and 'score' has been deprecated. "
                 "Please pass via kwargs instead."))
-            pairs = {value: score}
+            super(FakeRedis, self).zadd(name, value, score)
         elif not pairs:
             raise redis.RedisError("ZADD is missing kwargs param")
         return super(FakeRedis, self).zadd(name, **pairs)

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -1849,6 +1849,11 @@ class TestFakeRedis(unittest.TestCase):
         self.assertEqual(result, 2)
         self.assertEqual(self.redis.zrange('foo', 0, -1), [b'bar', b'baz'])
 
+    def test_zadd_with_name_is_non_string(self):
+        result = self.redis.zadd('foo', 1, 9)
+        self.assertEqual(result, 1)
+        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'1'])
+
     def test_set_nx_doesnt_set_value_twice(self):
         self.assertEqual(self.redis.set('foo', 'bar', nx=True), True)
         self.assertEqual(self.redis.set('foo', 'bar', nx=True), None)


### PR DESCRIPTION
When call method `zadd(name, value, score)` and value is integer, it will lead to raise TypeError zadd() keywords must be strings.

For example:

```
from fakeredis import FakeRedis

f = FakeRedis()
f.zadd('foo', 1, 1)
```

The version 0.6.2 will raise TypeError: zadd() keywords must be strings