### PR TITLE
Support APPEND to not preexisting key

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -183,6 +183,7 @@ class FakeStrictRedis(object):
 
     # Basic key commands
     def append(self, key, value):
+        self._db.setdefault(key, b'')
         self._db[key] += to_bytes(value)
         return len(self._db[key])
 

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -191,6 +191,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.append('foo', 'baz'), 6)
         self.assertEqual(self.redis.get('foo'), b'barbaz')
 
+    def test_append_with_no_preexisting_key(self):
+        self.assertEqual(self.redis.append('foo', 'bar'), 3)
+        self.assertEqual(self.redis.get('foo'), b'bar')
+
     def test_incr_with_no_preexisting_key(self):
         self.assertEqual(self.redis.incr('foo'), 1)
         self.assertEqual(self.redis.incr('bar', 2), 2)


### PR DESCRIPTION
APPEND operation is allowed to missing key. When it has executed, its behaviour works like SET. 