### PR TITLE
Match redis-py's transaction() and pipeline() functions.

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -1267,7 +1267,7 @@ class FakeStrictRedis(object):
             keys.extend(args)
         return keys
 
-    def pipeline(self, transaction=True):
+    def pipeline(self, transaction=True, shard_hint=None):
         """Return an object that can be used to issue Redis commands in a batch.
 
         Arguments --
@@ -1276,17 +1276,25 @@ class FakeStrictRedis(object):
         """
         return FakePipeline(self, transaction)
 
-    def transaction(self, func, *keys):
+    def transaction(self, func, *keys, **kwargs):
+        shard_hint = kwargs.pop('shard_hint', None)
+        value_from_callable = kwargs.pop('value_from_callable', False)
+        watch_delay = kwargs.pop('watch_delay', None)
         # We use a for loop instead of while
         # because if the test this is being used in
         # goes wrong we don't want an infinite loop!
-        with self.pipeline() as p:
+        with self.pipeline(True, shard_hint=shard_hint) as p:
             for _ in range(5):
                 try:
-                    p.watch(*keys)
-                    func(p)
-                    return p.execute()
+                    if keys:
+                        p.watch(*keys)
+                    func_value = func(p)
+                    exec_value = p.execute()
+                    return func_value if value_from_callable else exec_value
                 except redis.WatchError:
+                    if watch_delay is not None and watch_delay > 0:
+                        time.sleep(watch_delay)
+
                     continue
         raise redis.WatchError('Could not run transaction after 5 tries')
 

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -1757,6 +1757,16 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(16, int(self.redis.get('OUR-SEQUENCE-KEY')))
         self.assertEqual(3, len(calls))
 
+    def test_pipeline_transaction_value_from_callable(self):
+        def callback(pipe):
+            # No need to do anything here since we only want the return value
+            return 'OUR-RETURN-VALUE'
+
+        res = self.redis.transaction(callback, 'OUR-SEQUENCE-KEY',
+                                     value_from_callable=True)
+
+        self.assertEqual('OUR-RETURN-VALUE', res)
+
     def test_key_patterns(self):
         self.redis.mset({'one': 1, 'two': 2, 'three': 3, 'four': 4})
         self.assertItemsEqual(self.redis.keys('*o*'),


### PR DESCRIPTION
Match the function signatures, add support for `value_from_callable`
and `watch_delay` kwargs. Add test for `value_from_callable`.

Fixes #78.
