### PR TITLE
Implement hscan and sscan methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,18 +91,6 @@ All of the redis commands are implemented in fakeredis with
 these exceptions:
 
 
-set
----
-
- * sscan
-
-
-hash
-----
-
- * hscan
-
-
 generic
 -------
 

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -5,7 +5,6 @@ import inspect
 from functools import wraps
 import sys
 import threading
-from future.utils import viewitems
 
 from nose.plugins.skip import SkipTest
 from nose.plugins.attrib import attr

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -5,6 +5,7 @@ import inspect
 from functools import wraps
 import sys
 import threading
+from future.utils import viewitems
 
 from nose.plugins.skip import SkipTest
 from nose.plugins.attrib import attr
@@ -2027,8 +2028,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         cursor = '0'
         while cursor != 0:
             cursor, data = self.redis.hscan(name, cursor, count=6)
-            for k, v in data.iteritems():
-                results[k] = v
+            results.update(data)
         self.assertDictEqual(expected, results)
 
         # Test the iterator version
@@ -2042,8 +2042,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         cursor = '0'
         while cursor != 0:
             cursor, data = self.redis.hscan(name, cursor, match='*7', count=100)
-            for k, v in data.iteritems():
-                results[k] = v
+            results.update(data)
         self.assertIn('key:7', results)
         self.assertIn('key:17', results)
         self.assertEqual(2, len(results))

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -1965,14 +1965,14 @@ class TestFakeStrictRedis(unittest.TestCase):
         while cursor != 0:
             cursor, data = self.redis.scan(cursor, match='*7', count=100)
             results.extend(data)
-        self.assertIn('scan-test:7', results)
-        self.assertIn('scan-test:17', results)
+        self.assertIn(b'scan-test:7', results)
+        self.assertIn(b'scan-test:17', results)
         self.assertEqual(2, len(results))
 
         # Test the match on iterator
         results = [r for r in self.redis.scan_iter(match='*7')]
-        self.assertIn('scan-test:7', results)
-        self.assertIn('scan-test:17', results)
+        self.assertIn(b'scan-test:7', results)
+        self.assertIn(b'scan-test:17', results)
         self.assertEqual(2, len(results))
 
     def test_sscan(self):
@@ -2002,14 +2002,14 @@ class TestFakeStrictRedis(unittest.TestCase):
         while cursor != 0:
             cursor, data = self.redis.sscan(name, cursor, match='*7', count=100)
             results.extend(data)
-        self.assertIn('sscan-test:7', results)
-        self.assertIn('sscan-test:17', results)
+        self.assertIn(b'sscan-test:7', results)
+        self.assertIn(b'sscan-test:17', results)
         self.assertEqual(2, len(results))
 
         # Test the match on iterator
         results = [r for r in self.redis.sscan_iter(name, match='*7')]
-        self.assertIn('sscan-test:7', results)
-        self.assertIn('sscan-test:17', results)
+        self.assertIn(b'sscan-test:7', results)
+        self.assertIn(b'sscan-test:17', results)
         self.assertEqual(2, len(results))
 
     def test_hscan(self):
@@ -2042,16 +2042,16 @@ class TestFakeStrictRedis(unittest.TestCase):
         while cursor != 0:
             cursor, data = self.redis.hscan(name, cursor, match='*7', count=100)
             results.update(data)
-        self.assertIn('key:7', results)
-        self.assertIn('key:17', results)
+        self.assertIn(b'key:7', results)
+        self.assertIn(b'key:17', results)
         self.assertEqual(2, len(results))
 
         # Test the match on iterator
         results = {}
         for key, val in self.redis.hscan_iter(name, match='*7'):
             results[key] = val
-        self.assertIn('key:7', results)
-        self.assertIn('key:17', results)
+        self.assertIn(b'key:7', results)
+        self.assertIn(b'key:17', results)
         self.assertEqual(2, len(results))
 
 


### PR DESCRIPTION
I centralized some common logic between `scan`, `hscan`, and `sscan`. I also added the associated "*_iter" methods: `hscan_iter` and `sscan_iter`.

These methods should be fully API-compatible with redis-py, but they are NOT designed to be performant with large data sets, though they should be fine with smaller testing-sized data.