### PR TITLE
Look for strtod in msvcrt.lib on Windows; test strtod search behavior

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -94,7 +94,12 @@ else:
 
 DATABASES = {}
 
-_libc = CDLL(find_library('c'))
+_libc_library = find_library('c') or find_library('msvcrt')
+
+if not _libc_library:
+    raise ImportError('fakeredis: unable to find libc or equivalent')
+
+_libc = CDLL(_libc_library)
 _libc.strtod.restype = c_double
 _libc.strtod.argtypes = [c_char_p, POINTER(c_char_p)]
 _strtod = _libc.strtod

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -31,10 +31,14 @@ if sys.version_info[:2] == (2, 6):
 else:
     import unittest
 
+# Try importlib, then imp, then the old builtin `reload`
 try:
     from importlib import reload
 except:
-    pass  # Use builtin on old Python versions
+    try:
+        from imp import reload
+    except:
+        pass
 
 
 def redis_must_be_running(cls):
@@ -2374,7 +2378,7 @@ class TestImportation(unittest.TestCase):
             with self.assertRaises(ImportError):
                 reload(fakeredis)
 
-            self.assertEqual({'c', 'msvcrt'}, searched_libraries)
+            self.assertEqual(set(['c', 'msvcrt']), searched_libraries)
         finally:
             ctypes.util.find_library = old_find_library
 


### PR DESCRIPTION
This patch fixes issue #107.

I verified that the tests pass on Windows using Python 3.5 and on OS X using Python 2.7 and Python 3.5.