### PR TITLE
Check keys exist before delete in _StrKeyDict._update_expired_keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 sudo: false
 cache:
   - pip


### PR DESCRIPTION
I was running into an issue when use fakeredis and freezegun to manipulate dates in a unit test. The _StrKeyDict._update_expired_keys was trying to delete keys that appeared the _ex_keys dict, but somehow the keys did not appear in the underlying _dict of the class instance.
This just updates the method to verify that the key is contained in the _ex_keys and _dict objects before calling del.

This method is called repeatedly while existing tests are run and I do not want to add a dependency on freezegun to recreate the circumstances of my specific bug.  So I hope that this PR is ok without new tests.
