### PR TITLE
Add support for decode_responses

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -1489,7 +1489,7 @@ class FakeStrictRedis(object):
         """
         Returns a new FakePubSub instance
         """
-        ps = FakePubSub()
+        ps = FakePubSub(decode_responses=self._decode_responses)
         self._pubsubs.append(ps)
 
         return ps
@@ -1721,7 +1721,7 @@ class FakePubSub(object):
     UNSUBSCRIBE_MESSAGE_TYPES = ['unsubscribe', 'punsubscribe']
     PATTERN_MESSAGE_TYPES = ['psubscribe', 'punsubscribe']
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, decode_responses=False, **kwargs):
         self.channels = {}
         self.patterns = {}
         self._q = Queue()
@@ -1729,6 +1729,8 @@ class FakePubSub(object):
 
         self.ignore_subscribe_messages = kwargs['ignore_subscribe_messages']\
             if 'ignore_subscribe_messages' in kwargs else False
+        if decode_responses:
+            _patch_responses(self)
 
     def put(self, channel, message, message_type, pattern=None):
         """

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -316,7 +316,7 @@ class FakeStrictRedis(object):
             return to_bytes(value)
 
     def __getitem__(self, name):
-        return self._db[name]
+        return self.get(name)
 
     def getbit(self, name, offset):
         """Returns a boolean indicating the value of ``offset`` in ``name``"""
@@ -894,7 +894,7 @@ class FakeStrictRedis(object):
 
     def hvals(self, name):
         "Return the list of values within hash ``name``"
-        return self._db.get(name, {}).values()
+        return list(self._db.get(name, {}).values())
 
     def sadd(self, name, *values):
         "Add ``value`` to set ``name``"

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -181,7 +181,7 @@ def _decode(value):
     if isinstance(value, bytes):
         value = value.decode()
     elif isinstance(value, dict):
-        value = {_decode(k): _decode(v) for k, v in value.items()}
+        value = dict((_decode(k), _decode(v)) for k, v in value.items())
     elif isinstance(value, (list, set, tuple)):
         value = value.__class__(_decode(x) for x in value)
     elif isinstance(value, types.GeneratorType):
@@ -1721,7 +1721,7 @@ class FakePubSub(object):
     UNSUBSCRIBE_MESSAGE_TYPES = ['unsubscribe', 'punsubscribe']
     PATTERN_MESSAGE_TYPES = ['psubscribe', 'punsubscribe']
 
-    def __init__(self, *args, decode_responses=False, **kwargs):
+    def __init__(self, decode_responses=False, *args, **kwargs):
         self.channels = {}
         self.patterns = {}
         self._q = Queue()

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -2648,17 +2648,17 @@ class TestFakeRedis(unittest.TestCase):
             self.redis.pexpire('some_unused_key', 1000.2)
 
 
-class DecodeMixin:
+class DecodeMixin(object):
     decode_responses = True
 
     def assertEqual(self, a, b, msg=None):
-        super().assertEqual(a, fakeredis._decode(b), msg)
+        super(DecodeMixin, self).assertEqual(a, fakeredis._decode(b), msg)
 
     def assertIn(self, member, container, msg=None):
-        super().assertIn(fakeredis._decode(member), container)
+        super(DecodeMixin, self).assertIn(fakeredis._decode(member), container)
 
     def assertItemsEqual(self, a, b):
-        super().assertItemsEqual(a, fakeredis._decode(b))
+        super(DecodeMixin, self).assertItemsEqual(a, fakeredis._decode(b))
 
 
 class TestFakeStrictRedisDecodeResponses(DecodeMixin, TestFakeStrictRedis):

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -1859,13 +1859,13 @@ class TestFakeStrictRedis(unittest.TestCase):
         res = p.execute()
 
         # Check return values returned as list.
-        self.assertEqual([True, b'bar', 1, 2, [b'quux2', b'quux']], res)
+        self.assertEqual(res, [True, b'bar', 1, 2, [b'quux2', b'quux']])
 
         # Check side effects happened as expected.
-        self.assertEqual([b'quux2', b'quux'], self.redis.lrange('baz', 0, -1))
+        self.assertEqual(self.redis.lrange('baz', 0, -1), [b'quux2', b'quux'])
 
         # Check that the command buffer has been emptied.
-        self.assertEqual([], p.execute())
+        self.assertEqual(p.execute(), [])
 
     def test_pipeline_ignore_errors(self):
         """Test the pipeline ignoring errors when asked."""
@@ -1907,7 +1907,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         p = self.redis.pipeline(transaction=False)
         res = p.set('baz', 'quux').get('baz').execute()
 
-        self.assertEqual([True, b'quux'], res)
+        self.assertEqual(res, [True, b'quux'])
 
     def test_pipeline_raises_when_watched_key_changed(self):
         self.redis.set('foo', 'bar')
@@ -1942,7 +1942,7 @@ class TestFakeStrictRedis(unittest.TestCase):
             p.execute()
 
             # Check the commands were executed.
-            self.assertEqual(b'barbaz', self.redis.get('foo'))
+            self.assertEqual(self.redis.get('foo'), b'barbaz')
         finally:
             p.reset()
 
@@ -1961,7 +1961,7 @@ class TestFakeStrictRedis(unittest.TestCase):
             p.execute()
 
             # Check the commands were executed.
-            self.assertEqual(b'barbaz', self.redis.get('foo'))
+            self.assertEqual(self.redis.get('foo'), b'barbaz')
         finally:
             p.reset()
 


### PR DESCRIPTION
This PR adds the `decode_responses` functionality requested in #77, and attempted in #116/#82. 

This implementation is an attempt at adding the required logic without needing to change every method/return-statement. I also wanted this change to be well-tested without rewriting code, so I've written the new test classes using the inheritance pattern already used.

This approach is good because it means internally the library can continue to work with only binary data, and things (*should*) just work. I do see some potential downsides though:
 
1. Method patching is considered by some to be too *magical* (although for a library whose main purpose is unit-testing, patching is more acceptable)
2. Inheriting the tests this way means there are now 1161 tests :grin:
3. Since binary literals were used in all existing test cases, it was necessary to override a few `assert*` methods which rely on the redis expression coming as the first parameter, and the literal as the second. This might be overlooked and could cause problems.

I'd appreciate any feedback! :smile: 