### PR TITLE
Fix unit tests failing on 32 bits CPU archs

### DIFF
--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -2656,10 +2656,10 @@ class TestFakeRedis(unittest.TestCase):
         self.assertEqual(self.redis.ttl('foo'), 1)
         self.redis.expire('foo', 2)
         self.assertEqual(self.redis.ttl('foo'), 2)
-        long_long_c_max = 100000000000
         # See https://github.com/antirez/redis/blob/unstable/src/db.c#L632
-        self.redis.expire('foo', long_long_c_max)
-        self.assertEqual(self.redis.ttl('foo'), long_long_c_max)
+        ttl = 1000000000
+        self.redis.expire('foo', ttl)
+        self.assertEqual(self.redis.ttl('foo'), ttl)
 
     def test_pttl_should_return_none_for_non_expiring_key(self):
         self.redis.set('foo', 'bar')
@@ -2673,12 +2673,12 @@ class TestFakeRedis(unittest.TestCase):
         self.assertInRange(self.redis.pttl('foo'), 1000 - d, 1000)
         self.redis.expire('foo', 2)
         self.assertInRange(self.redis.pttl('foo'), 2000 - d, 2000)
-        long_long_c_max = 100000000000
+        ttl = 1000000000
         # See https://github.com/antirez/redis/blob/unstable/src/db.c#L632
-        self.redis.expire('foo', long_long_c_max)
+        self.redis.expire('foo', ttl)
         self.assertInRange(self.redis.pttl('foo'),
-                           long_long_c_max * 1000 - d,
-                           long_long_c_max * 1000)
+                           ttl * 1000 - d,
+                           ttl * 1000)
 
     def test_ttls_should_always_be_long(self):
         self.redis.set('foo', 'bar')


### PR DESCRIPTION
Without this patch, unit tests is failing on i686:

```
======================================================================
ERROR: test_pttl_should_return_value_for_expiring_key (test_fakeredis.TestFakeRedis)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/.pybuild/pythonX.Y_2.7/build/test_fakeredis.py", line 2675, in test_pttl_should_return_value_for_expiring_key
    self.redis.expire('foo', long_long_c_max)
  File "fakeredis.py", line 272, in expire
    return self._expire(name, time)
  File "fakeredis.py", line 281, in _expire
    raise redis.ResponseError("value is not an integer or out of "
ResponseError: value is not an integer or out of range.

======================================================================
ERROR: test_ttl_should_return_value_for_expiring_key (test_fakeredis.TestFakeRedis)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/.pybuild/pythonX.Y_2.7/build/test_fakeredis.py", line 2658, in test_ttl_should_return_value_for_expiring_key
    self.redis.expire('foo', long_long_c_max)
  File "fakeredis.py", line 272, in expire
    return self._expire(name, time)
  File "fakeredis.py", line 281, in _expire
    raise redis.ResponseError("value is not an integer or out of "
ResponseError: value is not an integer or out of range.

======================================================================
ERROR: test_pttl_should_return_value_for_expiring_key (test_fakeredis.TestFakeRedisDecodeResponses)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/.pybuild/pythonX.Y_2.7/build/test_fakeredis.py", line 2675, in test_pttl_should_return_value_for_expiring_key
    self.redis.expire('foo', long_long_c_max)
  File "fakeredis.py", line 194, in decode_response
    val = _decode(func(*args, **kwargs))
  File "fakeredis.py", line 272, in expire
    return self._expire(name, time)
  File "fakeredis.py", line 281, in _expire
    raise redis.ResponseError("value is not an integer or out of "
ResponseError: value is not an integer or out of range.

======================================================================
ERROR: test_ttl_should_return_value_for_expiring_key (test_fakeredis.TestFakeRedisDecodeResponses)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/.pybuild/pythonX.Y_2.7/build/test_fakeredis.py", line 2658, in test_ttl_should_return_value_for_expiring_key
    self.redis.expire('foo', long_long_c_max)
  File "fakeredis.py", line 194, in decode_response
    val = _decode(func(*args, **kwargs))
  File "fakeredis.py", line 272, in expire
    return self._expire(name, time)
  File "fakeredis.py", line 281, in _expire
    raise redis.ResponseError("value is not an integer or out of "
ResponseError: value is not an integer or out of range.

----------------------------------------------------------------------
Ran 1165 tests in 78.766s

FAILED (SKIP=580, errors=4)
```