### PR TITLE
Fix bugs related to inconsistent storage of bytes/strings

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -760,6 +760,7 @@ class FakeStrictRedis(object):
     def rpoplpush(self, src, dst):
         el = self.rpop(src)
         if el is not None:
+            el = to_bytes(el)
             try:
                 self._db[dst].insert(0, el)
             except KeyError:
@@ -793,6 +794,7 @@ class FakeStrictRedis(object):
     def brpoplpush(self, src, dst, timeout=0):
         el = self.rpop(src)
         if el is not None:
+            el = to_bytes(el)
             try:
                 self._db[dst].insert(0, el)
             except KeyError:
@@ -921,7 +923,7 @@ class FakeStrictRedis(object):
         set named ``dest``.  Returns the number of keys in the new set.
         """
         diff = self.sdiff(keys, *args)
-        self._db[dest] = diff
+        self._db[dest] = set(to_bytes(x) for x in diff)
         return len(diff)
 
     def sinter(self, keys, *args):
@@ -938,7 +940,7 @@ class FakeStrictRedis(object):
         set named ``dest``.  Returns the number of keys in the new set.
         """
         intersect = self.sinter(keys, *args)
-        self._db[dest] = intersect
+        self._db[dest] = set(to_bytes(x) for x in intersect)
         return len(intersect)
 
     def sismember(self, name, value):
@@ -993,7 +995,7 @@ class FakeStrictRedis(object):
         set named ``dest``.  Returns the number of keys in the new set.
         """
         union = self.sunion(keys, *args)
-        self._db[dest] = union
+        self._db[dest] = set(to_bytes(x) for x in union)
         return len(union)
 
     def _get_zelement_range_filter_func(self, min_val, max_val):

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -651,6 +651,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.lrange('foo', 0, -1), [b'one'])
         self.assertEqual(self.redis.lrange('bar', 0, -1), [b'two', b'one'])
 
+        # Catch instances where we store bytes and strings inconsistently
+        # and thus bar = ['two', b'one']
+        self.assertEqual(self.redis.lrem('bar', -1, 'two'), 1)
+
     def test_rpoplpush_to_nonexistent_destination(self):
         self.redis.rpush('foo', 'one')
         self.assertEqual(self.redis.rpoplpush('foo', 'bar'), b'one')
@@ -710,6 +714,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.brpoplpush('foo', 'bar', timeout=1),
                          b'two')
         self.assertEqual(self.redis.lrange('bar', 0, -1), [b'two'])
+
+        # Catch instances where we store bytes and strings inconsistently
+        # and thus bar = ['two']
+        self.assertEqual(self.redis.lrem('bar', -1, 'two'), 1)
 
     @attr('slow')
     def test_blocking_operations_when_empty(self):
@@ -962,6 +970,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.sadd('bar', 'member3')
         self.assertEqual(self.redis.sdiffstore('baz', 'foo', 'bar'), 1)
 
+        # Catch instances where we store bytes and strings inconsistently
+        # and thus baz = {'member1', b'member1'}
+        self.redis.sadd('baz', 'member1')
+        self.assertEqual(self.redis.scard('baz'), 1)
+
     def test_sinter(self):
         self.redis.sadd('foo', 'member1')
         self.redis.sadd('foo', 'member2')
@@ -977,6 +990,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.sadd('bar', 'member2')
         self.redis.sadd('bar', 'member3')
         self.assertEqual(self.redis.sinterstore('baz', 'foo', 'bar'), 1)
+
+        # Catch instances where we store bytes and strings inconsistently
+        # and thus baz = {'member2', b'member2'}
+        self.redis.sadd('baz', 'member2')
+        self.assertEqual(self.redis.scard('baz'), 1)
 
     def test_sismember(self):
         self.assertEqual(self.redis.sismember('foo', 'member1'), False)
@@ -1038,6 +1056,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.sunionstore('baz', 'foo', 'bar'), 3)
         self.assertEqual(self.redis.smembers('baz'),
                          set([b'member1', b'member2', b'member3']))
+
+        # Catch instances where we store bytes and strings inconsistently
+        # and thus baz = {b'member1', b'member2', b'member3', 'member3'}
+        self.redis.sadd('baz', 'member3')
+        self.assertEqual(self.redis.scard('baz'), 3)
 
     def test_zadd(self):
         self.redis.zadd('foo', four=4)


### PR DESCRIPTION
This PR fixes a few issues that arise when methods with decoded responses are called within the implementation of a redis command, and then these decoded results are stored without being converted back to bytes.

For example in `sdiffstore()`:
```python
def sdiffstore(self, dest, keys, *args):
    """
    Store the difference of sets specified by ``keys`` into a new
    set named ``dest``.  Returns the number of keys in the new set.
    """
    diff = self.sdiff(keys, *args)
    self._db[dest] = diff  # this line is problematic
    return len(diff)
```

And just to demo this behaviour:
```python
>>> from fakeredis import FakeStrictRedis
>>> r = FakeStrictRedis(decode_responses=True)
>>> r.sadd('foo', '1', '2')
>>> r.sadd('bar', '2', '3')
>>> r.sdiffstore('baz', 'foo', 'bar')

# things look okay at first
>>> r.smembers('baz')
{'1'}
>>> r.scard('baz')
1

# but, the following should have no effect, and does
>>> r.sadd('baz', '1')
>>> r.smembers('baz')
{'1'}
>>> r.scard('baz')
2  # uh oh...

# upon taking a deeper look, the cause is quite obvious:
>>> r._db.__dict__
{'_ex_keys': {}, '_dict': {b'baz': {'1', b'1'}, b'bar': {b'3', b'2'}, b'foo': {b'1', b'2'}}}
```

So yeah, some methods that have decoded responses are being called internally and then their results are saved inconsistently as bytes and strings. To solve this we just need to ensure we use `to_bytes()` properly when storing values as is already done in most methods. 