### PR TITLE
Fixed setting a None value, it should be set as a string and it was being set as None

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -40,8 +40,6 @@ if sys.version_info[0] == 2:
     int_to_byte = chr
 
     def to_bytes(x, charset=sys.getdefaultencoding(), errors='strict'):
-        if x is None:
-            return None
         if isinstance(x, (bytes, bytearray, buffer)) or hasattr(x, '__str__'):
             return bytes(x)
         if isinstance(x, unicode):
@@ -72,8 +70,6 @@ else:
     int_to_byte = operator.methodcaller('to_bytes', 1, 'big')
 
     def to_bytes(x, charset=sys.getdefaultencoding(), errors='strict'):
-        if x is None:
-            return None
         if isinstance(x, (bytes, bytearray, memoryview)):
             return bytes(x)
         if isinstance(x, str):

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -95,6 +95,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.set('foo', 'bar'), True)
         self.assertEqual(self.redis.get('foo'), b'bar')
 
+    def test_set_None_value(self):
+        self.assertEqual(self.redis.set('foo', None), True)
+        self.assertEqual(self.redis.get('foo'), b'None')
+
     def test_get_does_not_exist(self):
         self.assertEqual(self.redis.get('foo'), None)
 


### PR DESCRIPTION
Setting a `None` value should be set as the string `'None'`, it was being set as `None` because there's a check for a `None` value in the `to_bytes` function, these checks were removed and a test was added, and all the tests are passing under Python 2 and 3.