### PR TITLE
Pass through additional kwargs from `from_url` to the class initializer.

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -210,7 +210,7 @@ class FakeStrictRedis(object):
                 db = int(url.path.replace('/', ''))
             except (AttributeError, ValueError):
                 db = 0
-        return cls(db=db)
+        return cls(db=db, **kwargs)
 
     def __init__(self, db=0, charset='utf-8', errors='strict',
                  decode_responses=False, **kwargs):


### PR DESCRIPTION
When initializing fake redis with `from_url()`, passing additional parameters like `decode_responses=True` will have no effect, since so far it was ignoring them. This breaks `FakeStrictRedis.from_url()` in python 3.

This PR passes them through to the constructor, like redis-py does:
https://redis-py.readthedocs.io/en/latest/_modules/redis/client.html#StrictRedis.from_url