### PR TITLE
Fix Issue #101 - Should raise an error when attempting to get a key holding a list 

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -16,6 +16,8 @@ import redis
 from redis.exceptions import ResponseError
 import redis.client
 
+import pdb
+
 try:
     # Python 2.6, 2.7
     from Queue import Queue, Empty
@@ -305,6 +307,10 @@ class FakeStrictRedis(object):
 
     def get(self, name):
         value = self._db.get(name)
+        #pdb.set_trace()
+        if isinstance(value, list) or isinstance(value, set):
+            raise redis.ResponseError("WRONGTYPE Operation against a key "
+                                      "holding the wrong kind of value") 
         if isinstance(value, _StrKeyDict):
             raise redis.ResponseError("WRONGTYPE Operation against a key "
                                       "holding the wrong kind of value")

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -305,6 +305,9 @@ class FakeStrictRedis(object):
 
     def get(self, name):
         value = self._db.get(name)
+        if isinstance(value, list) or isinstance(value, set):
+            raise redis.ResponseError("WRONGTYPE Operation against a key "
+                                      "holding the wrong kind of value") 
         if isinstance(value, _StrKeyDict):
             raise redis.ResponseError("WRONGTYPE Operation against a key "
                                       "holding the wrong kind of value")

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -16,8 +16,6 @@ import redis
 from redis.exceptions import ResponseError
 import redis.client
 
-import pdb
-
 try:
     # Python 2.6, 2.7
     from Queue import Queue, Empty
@@ -307,10 +305,6 @@ class FakeStrictRedis(object):
 
     def get(self, name):
         value = self._db.get(name)
-        #pdb.set_trace()
-        if isinstance(value, list) or isinstance(value, set):
-            raise redis.ResponseError("WRONGTYPE Operation against a key "
-                                      "holding the wrong kind of value") 
         if isinstance(value, _StrKeyDict):
             raise redis.ResponseError("WRONGTYPE Operation against a key "
                                       "holding the wrong kind of value")

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -111,6 +111,21 @@ class TestFakeStrictRedis(unittest.TestCase):
         with self.assertRaises(redis.ResponseError):
             self.redis.get('foo')
 
+    def test_get_invalid_type_list(self):
+        self.assertEqual(self.redis.rpush('foo', 'bar'), True)        
+        with self.assertRaises(redis.ResponseError):
+            self.redis.get('foo')        
+
+    def test_get_invalid_type_set(self):
+        self.assertEqual(self.redis.sadd('foo', 'bar'), True)        
+        with self.assertRaises(redis.ResponseError):
+            self.redis.get('foo')
+
+    def test_get_invalid_type_sorted_set(self):
+        self.assertEqual(self.redis.zadd('foo', 1, 'bar'), True)        
+        with self.assertRaises(redis.ResponseError):
+            self.redis.get('foo')
+            
     def test_set_non_str_keys(self):
         self.assertEqual(self.redis.set(2, 'bar'), True)
         self.assertEqual(self.redis.get(2), b'bar')


### PR DESCRIPTION
It fixes Issue  https://github.com/jamesls/fakeredis/issues/101 
This bug also extends to Set and SortedSet structures (and not only list)
It updates `FakeRedis.get` method in order to raise the error while doing get from a list.

@jamesls 