### PR TITLE
Make setex fail if passed an unacceptable expiry time type

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -474,6 +474,9 @@ class FakeStrictRedis(object):
     def setex(self, name, time, value):
         if isinstance(time, timedelta):
             time = int(timedelta_total_seconds(time))
+        if not isinstance(time, int):
+            raise ResponseError(
+                'invalid expire time type {!r}'.format(type(time)))
         return self.set(name, value, ex=time)
 
     def psetex(self, name, time_ms, value):

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -476,7 +476,7 @@ class FakeStrictRedis(object):
             time = int(timedelta_total_seconds(time))
         if not isinstance(time, int):
             raise ResponseError(
-                'invalid expire time type {!r}'.format(type(time)))
+                'value is not an integer or out of range')
         return self.set(name, value, ex=time)
 
     def psetex(self, name, time_ms, value):

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -361,6 +361,10 @@ class TestFakeStrictRedis(unittest.TestCase):
             self.redis.setex('foo', timedelta(seconds=100), 'bar'), True)
         self.assertEqual(self.redis.get('foo'), b'bar')
 
+    def test_setex_using_float(self):
+        self.assertRaisesRegexp(
+            redis.ResponseError, 'type', self.redis.setex, 'foo', 1.2, 'bar')
+
     def test_set_ex(self):
         self.assertEqual(self.redis.set('foo', 'bar', ex=100), True)
         self.assertEqual(self.redis.get('foo'), b'bar')

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -363,7 +363,8 @@ class TestFakeStrictRedis(unittest.TestCase):
 
     def test_setex_using_float(self):
         self.assertRaisesRegexp(
-            redis.ResponseError, 'type', self.redis.setex, 'foo', 1.2, 'bar')
+            redis.ResponseError, 'integer', self.redis.setex, 'foo', 1.2,
+            'bar')
 
     def test_set_ex(self):
         self.assertEqual(self.redis.set('foo', 'bar', ex=100), True)


### PR DESCRIPTION
Real `RedisStrict` raises `ResponseError` if you pass it a `float`; `FakeRedisStrict` currently does not. This PR demonstrates a fairly local way of fixing that. I'm happy to expand to make it more general, but I'm not that au fait with Redis' behaviour in general.