### PR TITLE
type('a_bad_key') returns the string 'none', not None

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -547,6 +547,9 @@ class FakeStrictRedis(object):
             return b'list'
         elif isinstance(key, set):
             return b'set'
+        else:
+            assert key is None
+            return b'none'
 
     def watch(self, *names):
         pass

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -2090,6 +2090,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.type('set_key'), b'set')
         self.assertEqual(self.redis.type('zset_key'), b'zset')
         self.assertEqual(self.redis.type('hset_key'), b'hash')
+        self.assertEqual(self.redis.type('none_key'), b'none')
 
     @attr('slow')
     def test_pubsub_subscribe(self):


### PR DESCRIPTION
This mimics the behavior of `redis-py`.