### PR TITLE
Support b'bytes' keys in `sinter` and similar.

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -58,6 +58,7 @@ if sys.version_info[0] == 2:
     iteritems = lambda d: d.iteritems()
     from urlparse import urlparse
 else:
+    basestring = str
     text_type = str
     string_types = (str,)
     redis_string_types = (bytes, str)
@@ -1453,11 +1454,15 @@ class FakeStrictRedis(object):
         self._db[dest] = new_zset
 
     def _list_or_args(self, keys, args):
-        # Based off of list_or_args from redis-py.
         # Returns a single list combining keys and args.
-        # A string can be iterated, but indicates
-        # keys wasn't passed as a list.
-        if isinstance(keys, string_types):
+        # Copy of list_or_args from redis-py.
+        try:
+            iter(keys)
+            # a string or bytes instance can be iterated, but indicates
+            # keys wasn't passed as a list
+            if isinstance(keys, (basestring, bytes)):
+                keys = [keys]
+        except TypeError:
             keys = [keys]
         if args:
             keys.extend(args)

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -3,6 +3,7 @@ from time import sleep, time
 from redis.exceptions import ResponseError
 import inspect
 from functools import wraps
+import os
 import sys
 import threading
 
@@ -992,6 +993,16 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.sinter('foo', 'bar'), set([b'member2']))
         self.assertEqual(self.redis.sinter('foo'),
                          set([b'member1', b'member2']))
+
+    def test_sinter_bytes_keys(self):
+        foo = os.urandom(10)
+        bar = os.urandom(10)
+        self.redis.sadd(foo, 'member1')
+        self.redis.sadd(foo, 'member2')
+        self.redis.sadd(bar, 'member2')
+        self.redis.sadd(bar, 'member3')
+        self.assertEqual(self.redis.sinter(foo, bar), set([b'member2']))
+        self.assertEqual(self.redis.sinter(foo), set([b'member1', b'member2']))
 
     def test_sinterstore(self):
         self.redis.sadd('foo', 'member1')


### PR DESCRIPTION
redis-py allows you to pass `bytes` objects as keys. There are many places where fakeredis does not support that and this patch does not fix all of them, but it at least fixes `sinter` and other methods that use `_list_or_args`.