### PR TITLE
Make the fallback value bytes in getbit()

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -323,7 +323,7 @@ class FakeStrictRedis(object):
 
     def getbit(self, name, offset):
         """Returns a boolean indicating the value of ``offset`` in ``name``"""
-        val = self._db.get(name, '\x00')
+        val = self._db.get(name, b'\x00')
         byte = offset // 8
         remaining = offset % 8
         actual_bitoffset = 7 - remaining


### PR DESCRIPTION
Make the fallback value bytes in `getbit()` otherwise `byte_to_int()` will go bang if `getbit(key, n)` is called before `setbit(key, n, v)`

Specifically, I have a test which fails due to this:

```
b = '\x00'

    def byte_to_int(b):
        if isinstance(b, int):
            return b
>       raise TypeError('an integer is required')
E       TypeError: an integer is required
```