### PR TITLE
Use to_bytes to encode publish message

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -1544,8 +1544,8 @@ class FakeStrictRedis(object):
 
     def publish(self, channel, message):
         """
-        Loops throug all available pubsub objects and publishes the
-        ``message`` to then for the given ``channel``.
+        Loops through all available pubsub objects and publishes the
+        ``message`` to them for the given ``channel``.
         """
         count = 0
         for i, ps in enumerate(self._pubsubs):
@@ -1553,7 +1553,7 @@ class FakeStrictRedis(object):
                 del self._pubsubs[i]
                 continue
 
-            count += ps.put(channel, message, 'message')
+            count += ps.put(channel, to_bytes(message), 'message')
 
         return count
 
@@ -1816,7 +1816,7 @@ class FakePubSub(object):
             'type': message_type,
             'pattern': pattern,
             'channel': channel.encode(),
-            'data': data.encode() if type(data) == str else data
+            'data': data
         }
 
         self._q.put(msg)

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -2340,6 +2340,32 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(msg4['data'], msg)
         self.assertIn(msg4['channel'], bpatterns)
 
+    @attr('slow')
+    def test_pubsub_binary_message(self):
+        if self.decode_responses:
+            # Reading the non-UTF-8 message will break if decoding
+            # responses.
+            return
+
+        def _listen(pubsub, q):
+            for message in pubsub.listen():
+                q.put(message)
+                pubsub.close()
+
+        pubsub = self.redis.pubsub(ignore_subscribe_messages=True)
+        pubsub.subscribe('channel')
+        sleep(1)
+
+        q = Queue()
+        t = threading.Thread(target=_listen, args=(pubsub, q))
+        t.start()
+        msg = b'\x00hello world\r\n\xff'
+        self.redis.publish('channel', msg)
+        t.join()
+
+        received = q.get()
+        self.assertEqual(received['data'], msg)
+
     def test_pfadd(self):
         key = "hll-pfadd"
         self.assertEqual(


### PR DESCRIPTION
It used to call `.encode()` lower down if the type was `str`, which
- if not desirable on Python 2, since bytes == str and the message may
  already have been encoded
- does not specify the encoding
- ignores all the other things handled by to_bytes

This partially addresses #146. It does not try to address binary channel
names, but looking at the code for redis-py it's not clear that it fully
supports them either.