### PR TITLE
fix setbit

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -475,13 +475,16 @@ class FakeStrictRedis(object):
             # bit.
             needed = byte - (len(val) - 1)
             val += b'\x00' * needed
+        old_byte = byte_to_int(val[byte])
         if value == 1:
-            new_byte = byte_to_int(val[byte]) | (1 << actual_bitoffset)
+            new_byte = old_byte | (1 << actual_bitoffset)
         else:
-            new_byte = byte_to_int(val[byte]) ^ (1 << actual_bitoffset)
+            new_byte = old_byte & ~(1 << actual_bitoffset)
+        old_value = value if old_byte == new_byte else not value
         reconstructed = bytearray(val)
         reconstructed[byte] = new_byte
         self._db[name] = bytes(reconstructed)
+        return bool(old_value)
 
     def setex(self, name, time, value):
         if isinstance(time, timedelta):

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -171,6 +171,20 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.setbit('foo', 3, 0)
         self.assertEqual(self.redis.getbit('foo', 3), 0)
 
+    def test_get_set_bits(self):
+        # set bit 5
+        self.assertFalse(self.redis.setbit('a', 5, True))
+        self.assertTrue(self.redis.getbit('a', 5))
+        # unset bit 4
+        self.assertFalse(self.redis.setbit('a', 4, False))
+        self.assertFalse(self.redis.getbit('a', 4))
+        # set bit 4
+        self.assertFalse(self.redis.setbit('a', 4, True))
+        self.assertTrue(self.redis.getbit('a', 4))
+        # set bit 5 again
+        self.assertTrue(self.redis.setbit('a', 5, True))
+        self.assertTrue(self.redis.getbit('a', 5))
+
     def test_setbits_and_getkeys(self):
         # The bit operations and the get commands
         # should play nicely with each other.


### PR DESCRIPTION
1. setbit SHOULD return old_value instead of None
2. there exists bug when setbit to 0

for example:

```
# originally
self.redis.setbit('foo', 4, 0)
value = self.redis.getbit('foo', 4)  # we will get 1, but we should get 0
```