### PR TITLE
Prefer readthedocs.io instead of readthedocs.org for doc links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -259,6 +259,6 @@ they have all been tagged as 'slow' so you can skip them by running::
     nosetests -a '!slow'
 
 
-.. _redis-py: http://redis-py.readthedocs.org/en/latest/index.html
+.. _redis-py: https://redis-py.readthedocs.io/
 .. _contributing guide: https://github.com/jamesls/fakeredis/blob/master/CONTRIBUTING.rst
 .. _HelpWanted: https://github.com/jamesls/fakeredis/issues?q=is%3Aissue+is%3Aopen+label%3AHelpWanted


### PR DESCRIPTION
Read the Docs moved hosting to readthedocs.io instead of readthedocs.org. Fix
all links in the project.

For additional details, see:

https://blog.readthedocs.com/securing-subdomains/

> Starting today, Read the Docs will start hosting projects from subdomains on
> the domain readthedocs.io, instead of on readthedocs.org. This change
> addresses some security concerns around site cookies while hosting user
> generated data on the same domain as our dashboard.