### PR TITLE
Fix getbit for initial value of 0 for python3

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -326,7 +326,7 @@ class FakeStrictRedis(object):
 
     def getbit(self, name, offset):
         """Returns a boolean indicating the value of ``offset`` in ``name``"""
-        val = self._db.get(name, '\x00')
+        val = self._db.get(name, b'\x00')
         byte = offset // 8
         remaining = offset % 8
         actual_bitoffset = 7 - remaining

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -148,6 +148,9 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.getbit('foo', 4), 0)
         self.assertEqual(self.redis.getbit('foo', 100), 0)
 
+    def test_getbit_initial_value(self):
+        self.assertEqual(self.redis.getbit('foo', 1), 0)
+
     def test_multiple_bits_set(self):
         self.redis.setbit('foo', 1, 1)
         self.redis.setbit('foo', 3, 1)


### PR DESCRIPTION
When calling the redis.getbit operation with any offset, the initial
value could not be calculated due to a TypeError in the byte_to_int
operation expecting an int.

This commit fixes the getbit command for its initial value by making it
a byte literal