### PR TITLE
Replace fnmatch with hand-coded pattern compiler

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -2002,7 +2002,7 @@ class FakeStrictRedis(object):
         else:
             regex = None
         for val in data[cursor:result_cursor]:
-            if not regex or regex.match(val):
+            if not regex or regex.match(to_bytes(val)):
                 result_data.append(val)
         if result_cursor >= len(data):
             result_cursor = 0

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -415,7 +415,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.keys('a*de'), [b'abcde'])
         # positive groups
         self.assertEqual(sorted(self.redis.keys('abc[d\n]*')),
-                         [b'abc\n', 'abcde'])
+                         [b'abc\n', b'abcde'])
         self.assertEqual(self.redis.keys('abc[c-e]?'), [b'abcde'])
         self.assertEqual(self.redis.keys('abc[e-c]?'), [b'abcde'])
         self.assertEqual(self.redis.keys('abc[e-e]?'), [])

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -2905,7 +2905,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertIn(msg4['channel'], bpatterns)
 
     @attr('slow')
-    def test_pubsub_binary_message(self):
+    def test_pubsub_binary(self):
         if self.decode_responses:
             # Reading the non-UTF-8 message will break if decoding
             # responses.
@@ -2917,14 +2917,14 @@ class TestFakeStrictRedis(unittest.TestCase):
                 pubsub.close()
 
         pubsub = self.redis.pubsub(ignore_subscribe_messages=True)
-        pubsub.subscribe('channel')
+        pubsub.subscribe('channel\r\n\xff')
         sleep(1)
 
         q = Queue()
         t = threading.Thread(target=_listen, args=(pubsub, q))
         t.start()
         msg = b'\x00hello world\r\n\xff'
-        self.redis.publish('channel', msg)
+        self.redis.publish('channel\r\n\xff', msg)
         t.join()
 
         received = q.get()


### PR DESCRIPTION
This matches the quirks in the redis pattern matching, which has some
differences from fnmatch. It also applies all the logic in bytes, rather
than the native character encoding.

Fixes #182.