### PR TITLE
Make __getitem__ raise a KeyError for missing keys

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -469,7 +469,10 @@ class FakeStrictRedis(object):
             return to_bytes(value)
 
     def __getitem__(self, name):
-        return self.get(name)
+        value = self.get(name)
+        if value is not None:
+            return value
+        raise KeyError(name)
 
     def getbit(self, name, offset):
         """Returns a boolean indicating the value of ``offset`` in ``name``"""

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -260,6 +260,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis['foo'] = 'bar'
         self.assertEqual(self.redis['foo'], b'bar')
 
+    def test_getitem_non_existent_key(self):
+        self.assertEqual(self.redis.keys(), [])
+        with self.assertRaises(KeyError):
+            self.redis['noexists']
+
     def test_strlen(self):
         self.redis['foo'] = 'bar'
 


### PR DESCRIPTION
In redis-py, attempting to use __getitem__ with a non-existent key
causes a KeyError to be raised, while fakeredis returns None. This
change makes it so that __getitem__ in fakeredis works the same way as
in redis-py.

Fixes #191