### PR TITLE
Align bool/len behaviour of pipeline

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -2162,6 +2162,9 @@ class FakePipeline(object):
     def __exit__(self, exc_type, exc_value, traceback):
         self.reset()
 
+    def __len__(self):
+        return len(self.commands)
+
     def execute(self, raise_on_error=True):
         """Run all the commands in the pipeline and return the results."""
         try:

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -2766,6 +2766,15 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         self.assertEqual('OUR-RETURN-VALUE', res)
 
+    def test_pipeline_empty(self):
+        p = self.redis.pipeline()
+        self.assertFalse(p)
+
+    def test_pipeline_length(self):
+        p = self.redis.pipeline()
+        p.set('baz', 'quux').get('baz')
+        self.assertEqual(2, len(p))
+
     def test_key_patterns(self):
         self.redis.mset({'one': 1, 'two': 2, 'three': 3, 'four': 4})
         self.assertItemsEqual(self.redis.keys('*o*'),


### PR DESCRIPTION
Upstream Redis Pipeline has a `__len__()` method that causes an empty pipeline to evaluate false-y. This PR adds a similar method to FakeRedis to mimic that behaviour.