### PR TITLE
Test on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,13 @@ python:
   - pypy
   # Disabled because PyYAML is failing to compile against it
   # - nightly
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 sudo: false
+# Python 3.7 isn't available on trusty, so needs a separate build config
 cache:
   - pip
 services:

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: PYthon :: 3.7'
     ],
     install_requires=[
         'redis',


### PR DESCRIPTION
Adds Travis config to run tests against Python 3.7.