### PR TITLE
eval's KEYS and ARGV are now lua tables

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -838,8 +838,8 @@ class FakeStrictRedis(object):
         )
         expected_globals = set()
         set_globals(
-            [None] + keys_and_args[:numkeys],
-            [None] + keys_and_args[numkeys:],
+            lua_runtime.table_from(keys_and_args[:numkeys]),
+            lua_runtime.table_from(keys_and_args[numkeys:]),
             functools.partial(self._lua_redis_call, lua_runtime, expected_globals),
             functools.partial(self._lua_redis_pcall, lua_runtime, expected_globals)
         )

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -3311,6 +3311,24 @@ class TestFakeStrictRedis(unittest.TestCase):
         val = self.redis.eval(lua, 0)
         self.assertEqual(val, [[b'foo']])
 
+    def test_eval_iterate_over_argv(self):
+        lua = """
+        for i, v in ipairs(ARGV) do
+        end
+        return ARGV
+        """
+        val = self.redis.eval(lua, 0, "a", "b", "c")
+        self.assertEqual(val, [b"a", b"b", b"c"])
+
+    def test_eval_iterate_over_keys(self):
+        lua = """
+        for i, v in ipairs(KEYS) do
+        end
+        return KEYS
+        """
+        val = self.redis.eval(lua, 2, "a", "b", "c")
+        self.assertEqual(val, [b"a", b"b"])
+
     def test_eval_mget(self):
         self.redis.set('foo1', 'bar1')
         self.redis.set('foo2', 'bar2')


### PR DESCRIPTION
During eval operation, KEYS and ARGV are now passed as Lua tables instead of Python lists.
This allows for iteration over them within the Lua script

This is a fix to the error described in issue [204](https://github.com/jamesls/fakeredis/issues/204)
