### PR TITLE
Redis operation that returns dict now converted to Lua table when called inside eval operation

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -856,11 +856,12 @@ class FakeStrictRedis(object):
 
     def _convert_redis_result(self, lua_runtime, result):
         if isinstance(result, dict):
-            return [
+            converted = [
                 i
                 for item in result.items()
                 for i in item
             ]
+            return lua_runtime.table_from(converted)
         elif isinstance(result, set):
             converted = sorted(
                 self._convert_redis_result(lua_runtime, item)

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -3346,7 +3346,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         end
         return result
         """
-        val = self.redis.eval(lua, 0, 'foo')
+        val = self.redis.eval(lua, 1, 'foo')
         sorted_val = sorted([val[:2], val[2:]])
         self.assertEqual(
             sorted_val,

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -3346,7 +3346,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         end
         return result
         """
-        val = self.redis.eval(lua, 0)
+        val = self.redis.eval(lua, 0, 'foo')
         sorted_val = sorted([val[:2], val[2:]])
         self.assertEqual(
             sorted_val,

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -3337,6 +3337,22 @@ class TestFakeStrictRedis(unittest.TestCase):
             [[b'k1', b'bar'], [b'k2', b'baz']]
         )
 
+    def test_eval_hgetall_iterate(self):
+        self.redis.hset('foo', 'k1', 'bar')
+        self.redis.hset('foo', 'k2', 'baz')
+        lua = """
+        local result = redis.call("hgetall", "foo")
+        for i, v in ipairs(result) do
+        end
+        return result
+        """
+        val = self.redis.eval(lua, 0)
+        sorted_val = sorted([val[:2], val[2:]])
+        self.assertEqual(
+            sorted_val,
+            [[b'k1', b'bar'], [b'k2', b'baz']]
+        )
+
     def test_eval_list_with_nil(self):
         self.redis.lpush('foo', 'bar')
         self.redis.lpush('foo', None)


### PR DESCRIPTION
During eval operation, results of Redis operations returning dictionaries are now passed as Lua tables instead of python lists
This allows for iteration over them within the Lua script.

This is a fix to the error described in issue [204](https://github.com/jamesls/fakeredis/issues/204)