### PR TITLE
keep pace with redis-py for zrevrange method

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -1825,19 +1825,19 @@ class FakeStrictRedis(object):
                 found += 1
         return found
 
-    def zrevrange(self, name, start, num, withscores=False, score_cast_func=float):
+    def zrevrange(self, name, start, end, withscores=False, score_cast_func=float):
         """
         Return a range of values from sorted set ``name`` between
-        ``start`` and ``num`` sorted in descending order.
+        ``start`` and ``end`` sorted in descending order.
 
-        ``start`` and ``num`` can be negative, indicating the end of the range.
+        ``start`` and ``end`` can be negative, indicating the end of the range.
 
         ``withscores`` indicates to return the scores along with the values
         The return type is a list of (value, score) pairs
 
         ``score_cast_func`` a callable used to cast the score return value
         """
-        return self.zrange(name, start, num, True, withscores, score_cast_func)
+        return self.zrange(name, start, end, True, withscores, score_cast_func)
 
     def zrevrangebyscore(self, name, max, min, start=None, num=None,
                          withscores=False, score_cast_func=float):


### PR DESCRIPTION
I just tried to use fakeredis to test my code, e.g.

```
data = redis.zrevrange(cls.KEY.format(challenge_id=challenge_id), start=offset, end=offset + limit,
                                       withscores=True)
```

And I found type error:

> TypeError: zrevrange() got an unexpected keyword argument 'end'

So maybe it's better to keep pace with redis-py on zrevrange method?
Also you can check [here](https://github.com/andymccurdy/redis-py/blob/413e802f8fe390738bc1e89716083586e0269fd0/redis/client.py#L1854)

Cheers.

