### PR TITLE
Update behavior of lock to behave closer to redis lock

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -341,7 +341,7 @@ class _Lock(object):
             raise LockError("Cannot release an unlocked lock")
 
         if _decode(self.redis.get(self.name)) != self.id:
-            raise LockError("Cannot extend a lock that's no longer owned")
+            raise LockError("Cannot release a lock that's no longer owned")
 
         self.redis.delete(self.name)
         self.id = None

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -3948,6 +3948,13 @@ class TestFakeRedis(unittest.TestCase):
             acquired = self.redis.lock('bar').acquire(blocking=False)
             self.assertFalse(acquired)
 
+    def test_lock_no_longer_owned(self):
+        lock = self.redis.lock('bar')
+        lock.acquire()
+        self.redis.delete('bar')
+        with self.assertRaises(redis.exceptions.LockError):
+            lock.release()
+
 
 class DecodeMixin(object):
     decode_responses = True


### PR DESCRIPTION
I updated a project to use fakeredis and noticed some tests failing because the fakeredis lock implementation doesn't actually behave like the redis lock. If you create 2 locks with the same key, it doesn't actually fail to acquire the lock.

I added more tests and updated the implementation to handle multiple locks on the same key.