### PR TITLE
Adding save, bgsave, and lastsave commands.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,6 @@ server
 ------
 
  * bgrewriteaof
- * bgsave
  * client kill
  * client list
  * client getname
@@ -135,7 +134,6 @@ server
  * debug object
  * debug segfault
  * info
- * lastsave
  * memory doctor
  * memory help
  * memory malloc-stats
@@ -144,7 +142,6 @@ server
  * memory usage
  * monitor
  * role
- * save
  * shutdown
  * slaveof
  * slowlog

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -541,6 +541,7 @@ class FakeStrictRedis(object):
         self._encoding_errors = errors
         self._pubsubs = []
         self._decode_responses = decode_responses
+        self._lastsave = datetime.now()
         self.connected = connected
         _patch_responses(self, _check_conn)
 
@@ -784,13 +785,15 @@ class FakeStrictRedis(object):
         return True
 
     def bgsave(self):
-        pass
+        self._lastsave = datetime.now()
+        return True
 
     def save(self):
-        pass
+        self._lastsave = datetime.now()
+        return True
 
     def lastsave(self):
-        pass
+        return self._lastsave
 
     @_lua_reply(_lua_bool_ok)
     @_locked

--- a/fakeredis.py
+++ b/fakeredis.py
@@ -783,6 +783,15 @@ class FakeStrictRedis(object):
     def ping(self):
         return True
 
+    def bgsave(self):
+        pass
+
+    def save(self):
+        pass
+
+    def lastsave(self):
+        pass
+
     @_lua_reply(_lua_bool_ok)
     @_locked
     def rename(self, src, dst):

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -2870,6 +2870,15 @@ class TestFakeStrictRedis(unittest.TestCase):
     def test_ping(self):
         self.assertTrue(self.redis.ping())
 
+    def test_bgsave(self):
+        self.assertTrue(self.redis.bgsave())
+
+    def test_save(self):
+        self.assertTrue(self.redis.save())
+
+    def test_lastsave(self):
+        self.assertTrue(isinstance(self.redis.lastsave(), datetime))
+
     def test_type(self):
         self.redis.set('string_key', "value")
         self.redis.lpush("list_key", "value")

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -2882,15 +2882,16 @@ class TestFakeStrictRedis(unittest.TestCase):
     @attr('slow')
     def test_bgsave_timestamp_update(self):
         early_timestamp = self.redis.lastsave()
-        sleep(2)
+        sleep(1)
         self.assertTrue(self.redis.bgsave())
+        sleep(1)
         late_timestamp = self.redis.lastsave()
         self.assertLess(early_timestamp, late_timestamp)
 
     @attr('slow')
     def test_save_timestamp_update(self):
         early_timestamp = self.redis.lastsave()
-        sleep(2)
+        sleep(1)
         self.assertTrue(self.redis.save())
         late_timestamp = self.redis.lastsave()
         self.assertLess(early_timestamp, late_timestamp)

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -2879,6 +2879,22 @@ class TestFakeStrictRedis(unittest.TestCase):
     def test_lastsave(self):
         self.assertTrue(isinstance(self.redis.lastsave(), datetime))
 
+    @attr('slow')
+    def test_bgsave_timestamp_update(self):
+        early_timestamp = self.redis.lastsave()
+        sleep(1)
+        self.assertTrue(self.redis.bgsave())
+        late_timestamp = self.redis.lastsave()
+        self.assertLess(early_timestamp, late_timestamp)
+
+    @attr('slow')
+    def test_save_timestamp_update(self):
+        early_timestamp = self.redis.lastsave()
+        sleep(1)
+        self.assertTrue(self.redis.save())
+        late_timestamp = self.redis.lastsave()
+        self.assertLess(early_timestamp, late_timestamp)
+
     def test_type(self):
         self.redis.set('string_key', "value")
         self.redis.lpush("list_key", "value")

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -2882,7 +2882,7 @@ class TestFakeStrictRedis(unittest.TestCase):
     @attr('slow')
     def test_bgsave_timestamp_update(self):
         early_timestamp = self.redis.lastsave()
-        sleep(1)
+        sleep(2)
         self.assertTrue(self.redis.bgsave())
         late_timestamp = self.redis.lastsave()
         self.assertLess(early_timestamp, late_timestamp)
@@ -2890,7 +2890,7 @@ class TestFakeStrictRedis(unittest.TestCase):
     @attr('slow')
     def test_save_timestamp_update(self):
         early_timestamp = self.redis.lastsave()
-        sleep(1)
+        sleep(2)
         self.assertTrue(self.redis.save())
         late_timestamp = self.redis.lastsave()
         self.assertLess(early_timestamp, late_timestamp)


### PR DESCRIPTION
Adding the SAVE, BGSAVE, and LASTSAVE commands.  They are backed with a trivial implementation that doesn't perform any flush/backup/save work, but does update the timestamp, emulating a successful save/bgsave from the Redis client's standpoint.