### PR TITLE
ttl should not return None.

### DIFF
--- a/fakeredis.py
+++ b/fakeredis.py
@@ -940,7 +940,7 @@ class FakeStrictRedis(object):
 
         now = datetime.now()
         if now > exp_time:
-            return None
+            return -2  # expired key acts as if it didn't exist
         else:
             return long(round(((exp_time - now).days * 3600 * 24 +
                         (exp_time - now).seconds +


### PR DESCRIPTION
`pttl(key) / 1000` breaks my tests when this returns None.

Similar to #119

I tried adding a test, but in a single threaded env the test passes with or without my patch.

```diff
diff --git a/test_fakeredis.py b/test_fakeredis.py
index eea5f63..9c7eabb 100644
--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -3334,6 +3334,13 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.get('foo'), None)
         self.assertEqual(self.redis.ttl('foo'), -2)
 
+    def test_ttl_should_return_minus_two_for_expired_key(self):
+        self.redis.set('foo', 'bar')
+        self.assertEqual(self.redis.get('foo'), b'bar')
+        self.redis.pexpire('foo', 1)
+        sleep(0.002)
+        self.assertEqual(self.redis.ttl('foo'), -2)
+
     def test_pttl_should_return_minus_one_for_non_expiring_key(self):
         self.redis.set('foo', 'bar')
         self.assertEqual(self.redis.get('foo'), b'bar')
@@ -3343,6 +3350,13 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.get('foo'), None)
         self.assertEqual(self.redis.pttl('foo'), -2)
 
+    def test_pttl_should_return_minus_two_for_expired_key(self):
+        self.redis.set('foo', 'bar')
+        self.assertEqual(self.redis.get('foo'), b'bar')
+        self.redis.pexpire('foo', 1)
+        sleep(0.002)
+        self.assertEqual(self.redis.pttl('foo'), -2)
+
     def test_persist(self):
         self.redis.set('foo', 'bar', ex=20)
         self.redis.persist('foo')
```