### PR TITLE
Support for redis-py 3.2 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 env:
   - REDIS_PY=2.10.6
   - REDIS_PY=3.0.1
-  - REDIS_PY=3.2.0
+  - REDIS_PY=3.1.0
 matrix:
   include:
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 env:
   - REDIS_PY=2.10.6
   - REDIS_PY=3.0.1
+  - REDIS_PY=3.2.0
 matrix:
   include:
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - REDIS_PY=2.10.6
   - REDIS_PY=3.0.1
   - REDIS_PY=3.1.0
-  - REDIS_PY=3.2.0
+  - REDIS_PY=3.2.1
 matrix:
   include:
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - REDIS_PY=2.10.6
   - REDIS_PY=3.0.1
   - REDIS_PY=3.1.0
+  - REDIS_PY=3.2.0
 matrix:
   include:
     - python: 3.7

--- a/README.rst
+++ b/README.rst
@@ -371,6 +371,10 @@ they have all been tagged as 'slow' so you can skip them by running::
 Revision history
 ================
 
+1.0.3
+-----
+- `#235 <https://github.com/jamesls/fakeredis/issues/235>`_ Support for ``redis==3.2``
+
 1.0.2
 -----
 - `#235 <https://github.com/jamesls/fakeredis/issues/235>`_ Depend on ``redis<3.2``

--- a/fakeredis/__init__.py
+++ b/fakeredis/__init__.py
@@ -1,4 +1,4 @@
 from ._server import FakeServer, FakeRedis, FakeStrictRedis, FakeConnection   # noqa: F401
 
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -2444,7 +2444,7 @@ class FakeConnection(redis.Connection):
         self._sock = None
 
     def connect(self):
-        super().connect()
+        super(FakeConnection, self).connect()
         # The selector is set in redis.Connection.connect() after _connect() is called
         self._selector = FakeSelector(self._sock)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ attrs==18.2.0
 enum34==1.1.6; python_version<"3"
 nose==1.3.7
 hypothesis==3.86.4
-redis==2.10.6
+redis==3.2.0
 lupa==1.7
 future==0.17.1
 sortedcontainers==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ attrs==18.2.0
 enum34==1.1.6; python_version<"3"
 nose==1.3.7
 hypothesis==3.86.4
-redis==3.2.0
+redis==3.2.1
 lupa==1.7
 future==0.17.1
 sortedcontainers==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='fakeredis',
-    version='1.0.2',
+    version='1.0.3',
     description="Fake implementation of redis API for testing purposes.",
     long_description=open(os.path.join(os.path.dirname(__file__),
                                        'README.rst')).read(),
@@ -28,7 +28,7 @@ setup(
         'Programming Language :: Python :: 3.7'
     ],
     install_requires=[
-        'redis<3.2', 'six>=1.12', 'sortedcontainers'
+        'redis', 'six>=1.12', 'sortedcontainers'
     ],
     extras_require={
         "lua": ['lupa']

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -3286,6 +3286,7 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         pubsub_thread.stop()
         # Newer versions of redis wait for an unsubscribe message, which sometimes comes early
+        # https://github.com/andymccurdy/redis-py/issues/1150
         if pubsub.channels:
             pubsub.channels = {}
         pubsub_thread.join()

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -3285,6 +3285,9 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(retrieved["data"], msg)
 
         pubsub_thread.stop()
+        # Newer versions of redis wait for an unsubscribe message, which sometimes comes early
+        if pubsub.channels:
+            pubsub.channels = {}
         pubsub_thread.join()
         self.assertTrue(not pubsub_thread.is_alive())
 


### PR DESCRIPTION
Fixes #235 

redis-py 3.2 introduces the new concept of a selector. Herein we introduce a `FakeSelector` which marks our fake connections as always ready. The `FakeSocket` also needs to return an integer from `fileno()` since this will be checked when importing `redis.selector`. 

Let me know if you have any feedback, I've run the full test suite with redis-py 2.10.6, 3.1.0 and 3.2.0. I did not contribute a new test since existing tests fail with 3.2.0. 