### PR TITLE
Migrate project to PyTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - flake8
 script:
   - coverage erase
-  - coverage run --source fakeredis test_fakeredis.py
+  - pytest --cov=fakeredis test_fakeredis.py
 notifications:
   email:
     - js@jamesls.com

--- a/Pipfile
+++ b/Pipfile
@@ -5,8 +5,9 @@ name = "pypi"
 
 
 [dev-packages]
+pytest = "<5.0"
+pytest-cov = "<3.0"
 tox = "*"
-nose = "==1.3.4"
 
 [packages]
 "flake8" = "<3.0.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6cb661ed3b64636951038fa4018fa1c9c5181b6b0a54d195ae848495a2aa0af1"
+            "sha256": "2b983a22c49ba7330b71abe5dbae568e735b245b79c6bf71d1c85a52387d5ddd"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -83,42 +83,129 @@
         }
     },
     "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:08907593569fe59baca0bf152c43f3863201efb6113ecb38ce7e97ce339805a6",
+                "sha256:0be0f1ed45fc0c185cfd4ecc19a1d6532d72f86a2bac9de7e24541febad72650",
+                "sha256:141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5",
+                "sha256:19e4df788a0581238e9390c85a7a09af39c7b539b29f25c89209e6c3e371270d",
+                "sha256:23cc09ed395b03424d1ae30dcc292615c1372bfba7141eb85e11e50efaa6b351",
+                "sha256:245388cda02af78276b479f299bbf3783ef0a6a6273037d7c60dc73b8d8d7755",
+                "sha256:331cb5115673a20fb131dadd22f5bcaf7677ef758741312bee4937d71a14b2ef",
+                "sha256:386e2e4090f0bc5df274e720105c342263423e77ee8826002dcffe0c9533dbca",
+                "sha256:3a794ce50daee01c74a494919d5ebdc23d58873747fa0e288318728533a3e1ca",
+                "sha256:60851187677b24c6085248f0a0b9b98d49cba7ecc7ec60ba6b9d2e5574ac1ee9",
+                "sha256:63a9a5fc43b58735f65ed63d2cf43508f462dc49857da70b8980ad78d41d52fc",
+                "sha256:6b62544bb68106e3f00b21c8930e83e584fdca005d4fffd29bb39fb3ffa03cb5",
+                "sha256:6ba744056423ef8d450cf627289166da65903885272055fb4b5e113137cfa14f",
+                "sha256:7494b0b0274c5072bddbfd5b4a6c6f18fbbe1ab1d22a41e99cd2d00c8f96ecfe",
+                "sha256:826f32b9547c8091679ff292a82aca9c7b9650f9fda3e2ca6bf2ac905b7ce888",
+                "sha256:93715dffbcd0678057f947f496484e906bf9509f5c1c38fc9ba3922893cda5f5",
+                "sha256:9a334d6c83dfeadae576b4d633a71620d40d1c379129d587faa42ee3e2a85cce",
+                "sha256:af7ed8a8aa6957aac47b4268631fa1df984643f07ef00acd374e456364b373f5",
+                "sha256:bf0a7aed7f5521c7ca67febd57db473af4762b9622254291fbcbb8cd0ba5e33e",
+                "sha256:bf1ef9eb901113a9805287e090452c05547578eaab1b62e4ad456fcc049a9b7e",
+                "sha256:c0afd27bc0e307a1ffc04ca5ec010a290e49e3afbe841c5cafc5c5a80ecd81c9",
+                "sha256:dd579709a87092c6dbee09d1b7cfa81831040705ffa12a1b248935274aee0437",
+                "sha256:df6712284b2e44a065097846488f66840445eb987eb81b3cc6e4149e7b6982e1",
+                "sha256:e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c",
+                "sha256:e2ede7c1d45e65e209d6093b762e98e8318ddeff95317d07a27a2140b80cfd24",
+                "sha256:e4ef9c164eb55123c62411f5936b5c2e521b12356037b6e1c2617cef45523d47",
+                "sha256:eca2b7343524e7ba246cab8ff00cab47a2d6d54ada3b02772e908a45675722e2",
+                "sha256:eee64c616adeff7db37cc37da4180a3a5b6177f5c46b187894e633f088fb5b28",
+                "sha256:ef824cad1f980d27f26166f86856efe11eff9912c4fed97d3804820d43fa550c",
+                "sha256:efc89291bd5a08855829a3c522df16d856455297cf35ae827a37edac45f466a7",
+                "sha256:fa964bae817babece5aa2e8c1af841bebb6d0b9add8e637548809d040443fee0",
+                "sha256:ff37757e068ae606659c28c3bd0d923f9d29a85de79bf25b2b34b148473b5025"
+            ],
+            "version": "==4.5.4"
+        },
         "filelock": {
             "hashes": [
-                "sha256:b8d5ca5ca1c815e1574aee746650ea7301de63d87935b3463d26368b76e31633",
-                "sha256:d610c1bb404daf85976d7a82eb2ada120f04671007266b708606565dd03b5be6"
+                "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
+                "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
             ],
-            "version": "==3.0.10"
+            "version": "==3.0.12"
         },
-        "nose": {
+        "importlib-metadata": {
             "hashes": [
-                "sha256:76bc63a4e2d5e5a0df77ca7d18f0f56e2c46cfb62b71103ba92a92c79fab1e03",
-                "sha256:78b03116badd0dbb2ed4dedc96a4a3d42138b94bb89fc2eb99f7f3bdfd199f56",
-                "sha256:cc8aebdec5a5fb989912f157f77b3c21a5e2f2da623af90a7b476b106a834abf"
+                "sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8",
+                "sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"
             ],
-            "index": "pypi",
-            "version": "==1.3.4"
+            "version": "==0.19"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
+                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+            ],
+            "markers": "python_version > '2.7'",
+            "version": "==7.2.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
+                "sha256:c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"
+            ],
+            "version": "==19.1"
         },
         "pluggy": {
             "hashes": [
-                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
-                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
-            "version": "==0.8.0"
+            "version": "==0.12.0"
         },
         "py": {
             "hashes": [
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
-            "version": "==1.7.0"
+            "version": "==1.8.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
+                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+            ],
+            "version": "==2.4.2"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:6aa9bc2f6f6504d7949e9df2a756739ca06e58ffda19b5e53c725f7b03fb4aae",
+                "sha256:b77ae6f2d1a760760902a7676887b665c086f71e3461c64ed2a312afcedc00d6"
+            ],
+            "index": "pypi",
+            "version": "==4.6.4"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6",
+                "sha256:e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"
+            ],
+            "index": "pypi",
+            "version": "==2.7.1"
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         },
         "toml": {
             "hashes": [
@@ -129,18 +216,32 @@
         },
         "tox": {
             "hashes": [
-                "sha256:513e32fdf2f9e2d583c2f248f47ba9886428c949f068ac54a0469cac55df5862",
-                "sha256:75fa30e8329b41b664585f5fb837e23ce1d7e6fa1f7811f2be571c990f9d911b"
+                "sha256:dab0b0160dd187b654fc33d690ee1d7bf328bd5b8dc6ef3bb3cc468969c659ba",
+                "sha256:ee35ffce74933a6c6ac10c9a0182e41763140a5a5070e21b114feca56eaccdcd"
             ],
             "index": "pypi",
-            "version": "==3.5.3"
+            "version": "==3.13.2"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:686176c23a538ecc56d27ed9d5217abd34644823d6391cbeb232f42bf722baad",
-                "sha256:f899fafcd92e1150f40c8215328be38ff24b519cd95357fa6e78e006c7638208"
+                "sha256:6cb2e4c18d22dbbe283d0a0c31bb7d90771a606b2cb3415323eea008eaee6a9d",
+                "sha256:909fe0d3f7c9151b2df0a2cb53e55bdb7b0d61469353ff7a49fd47b0f0ab9285"
             ],
-            "version": "==16.1.0"
+            "version": "==16.7.2"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
+                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
+            ],
+            "version": "==0.5.2"
         }
     }
 }

--- a/README.rst
+++ b/README.rst
@@ -338,7 +338,7 @@ To run all the tests, install the requirements file::
 
 If you just want to run the unittests::
 
-    nosetests test_fakeredis.py:TestFakeStrictRedis test_fakeredis.py:TestFakeRedis
+    pytest test_fakeredis.py::TestFakeStrictRedis test_fakeredis.py::TestFakeRedis
 
 Because this module is attempting to provide the same interface as `redis-py`_,
 the python bindings to redis, a reasonable way to test this to to take each
@@ -346,7 +346,7 @@ unittest and run it against a real redis server.  fakeredis and the real redis
 server should give the same result.  This ensures parity between the two.  You
 can run these "integration" tests like this::
 
-    nosetests test_fakeredis.py:TestRealStrictRedis test_fakeredis.py:TestRealRedis test_fakeredis_hypothesis.py
+    pytest test_fakeredis.py::TestRealStrictRedis test_fakeredis.py::TestRealRedis test_fakeredis_hypothesis.py
 
 In terms of implementation, ``TestRealRedis`` is a subclass of
 ``TestFakeRedis`` that overrides a factory method to create
@@ -355,7 +355,7 @@ instead of ``fakeredis.FakeStrictRedis``.
 
 To run both the unittests and the "integration" tests, run::
 
-    nosetests
+    pytest
 
 If redis is not running and you try to run tests against a real redis server,
 these tests will have a result of 'S' for skipped.
@@ -364,7 +364,7 @@ There are some tests that test redis blocking operations that are somewhat
 slow.  If you want to skip these tests during day to day development,
 they have all been tagged as 'slow' so you can skip them by running::
 
-    nosetests -a '!slow' test_fakeredis.py
+    pytest -m "not slow" test_fakeredis.py
 
 
 Revision history

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,29 @@
-flake8==3.6.0
+atomicwrites==1.3.0
+attrs==18.2.0
 configparser==3.5.0; python_version<"3"
+contextlib2==0.5.5; python_version<"3"
+coverage==4.5.4
+enum34==1.1.6; python_version<"3"
+flake8==3.6.0
+funcsigs==1.0.2; python_version<"3"
+future==0.17.1
+hypothesis==3.86.4
+importlib-metadata==0.20
+lupa==1.8
 mccabe==0.6.1
+more-itertools==5.0.0
+packaging==19.1
+pathlib2==2.3.4; python_version<"3"
+pluggy==0.12.0
+py==1.8.0
 pycodestyle==2.4.0
 pyflakes==2.0.0
-attrs==18.2.0
-enum34==1.1.6; python_version<"3"
+pyparsing==2.4.2
 pytest==4.6.4
 pytest-cov==2.7.1
-hypothesis==3.86.4
 redis==3.2.1
-lupa==1.8
-future==0.17.1
-sortedcontainers==2.1.0
+scandir==1.10.0; python_version<"3"
 six==1.12.0
+sortedcontainers==2.1.0
+wcwidth==0.1.7
+zipp==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ pycodestyle==2.4.0
 pyflakes==2.0.0
 attrs==18.2.0
 enum34==1.1.6; python_version<"3"
-nose==1.3.7
+pytest==4.6.4
+pytest-cov==2.7.1
 hypothesis==3.86.4
 redis==3.2.1
 lupa==1.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ max-line-length = 119
 
 [bdist_wheel]
 universal = 1
+
+[tool:pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -52,8 +52,8 @@ def redis_must_be_running(cls):
     return cls
 
 
-redis2_only = pytest.mark.skipif(REDIS3, "Test is only applicable to redis-py 2.x")
-redis3_only = pytest.mark.skipif(not REDIS3, "Test is only applicable to redis-py 3.x")
+redis2_only = pytest.mark.skipif(REDIS3, reason="Test is only applicable to redis-py 2.x")
+redis3_only = pytest.mark.skipif(not REDIS3, reason="Test is only applicable to redis-py 3.x")
 
 
 def key_val_dict(size=100):
@@ -153,13 +153,13 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(self.redis.set(u'Ñandu', 'foo'), True)
         self.assertEqual(self.redis.get(u'Ñandu'), b'foo')
 
-    @pytest.importorskip('builtins.bytes', reason='future.types not available')
     def test_future_newbytes(self):
+        bytes = pytest.importorskip('builtins', reason='future.types not available').bytes
         self.redis.set(bytes(b'\xc3\x91andu'), 'foo')
         self.assertEqual(self.redis.get(u'Ñandu'), b'foo')
 
-    @pytest.importorskip('builtins.str', reason='future.types not available')
     def test_future_newstr(self):
+        str = pytest.importorskip('builtins', reason='future.types not available').str
         self.redis.set(str(u'Ñandu'), 'foo')
         self.assertEqual(self.redis.get(u'Ñandu'), b'foo')
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
 
 [testenv]
 usedevelop = True
-commands = nosetests -v {posargs}
+commands = pytest -v {posargs}
 extras = lua
 deps =
-    nose
     hypothesis
+    pytest


### PR DESCRIPTION
`nose` is a deprecated project since 2015. Migrate to `pytest`, which will allow to add plugins and improve project's test suite.