### PR TITLE
Support NX/XX/CH flags in ZADD command

### DIFF
--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -1933,14 +1933,11 @@ class FakeSocket(object):
         ]
         old_len = len(zset)
         changed_items = 0
-        # Cache value to use on each iteration
-        not_nx_nor_xx = not nx and not xx
 
         for item_score, item_name in items:
             if (
-                not_nx_nor_xx
-                or (nx and item_name not in zset)
-                or (xx and item_name in zset)
+                (not nx or item_name not in zset)
+                and (not xx or item_name in zset)
             ):
                 if zset.add(item_name, item_score):
                     changed_items += 1

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -47,6 +47,7 @@ INVALID_SORT_FLOAT_MSG = "One or more scores can't be converted into double"
 SRC_DST_SAME_MSG = "source and destination objects are the same"
 NO_KEY_MSG = "no such key"
 INDEX_ERROR_MSG = "index out of range"
+ZADD_NX_XX_ERROR_MSG = "ZADD allows either 'nx' or 'xx', not both"
 ZUNIONSTORE_KEYS_MSG = "at least 1 input key is needed for ZUNIONSTORE/ZINTERSTORE"
 WRONG_ARGS_MSG = "wrong number of arguments for '{}' command"
 UNKNOWN_COMMAND_MSG = "unknown command '{}'"
@@ -1897,19 +1898,58 @@ class FakeSocket(object):
 
     @command((Key(ZSet), bytes, bytes), (bytes,))
     def zadd(self, key, *args):
-        # TODO: handle NX, XX, CH, INCR
+        # TODO: handle INCR
         zset = key.value
-        if len(args) % 2 != 0:
+
+        i = 0
+        ch = False
+        nx = False
+        xx = False
+        while i < len(args):
+            if casematch(args[i], b'ch'):
+                ch = True
+                i += 1
+            elif casematch(args[i], b'nx'):
+                nx = True
+                i += 1
+            elif casematch(args[i], b'xx'):
+                xx = True
+                i += 1
+            else:
+                # First argument not matching flags indicates the start of
+                # score pairs.
+                break
+
+        if nx and xx:
+            raise redis.ResponseError(ZADD_NX_XX_ERROR_MSG)
+
+        elements = args[i:]
+        if not elements or len(elements) % 2 != 0:
             raise redis.ResponseError(SYNTAX_ERROR_MSG)
-        items = []
         # Parse all scores first, before updating
-        for i in range(0, len(args), 2):
-            score = Float.decode(args[i])
-            items.append((score, args[i + 1]))
+        items = [
+            (Float.decode(elements[j]), elements[j + 1])
+            for j in range(0, len(elements), 2)
+        ]
         old_len = len(zset)
-        for item in items:
-            if zset.add(item[1], item[0]):
-                key.updated()
+        changed_items = 0
+        # Cache value to use on each iteration
+        not_nx_nor_xx = not nx and not xx
+
+        for item_score, item_name in items:
+            if (
+                not_nx_nor_xx
+                or (nx and item_name not in zset)
+                or (xx and item_name in zset)
+            ):
+                if zset.add(item_name, item_score):
+                    changed_items += 1
+
+        if changed_items:
+            key.updated()
+
+        if ch:
+            return changed_items
         return len(zset) - old_len
 
     @command((Key(ZSet),))

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -1803,18 +1803,18 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         updates = [
             {'input': {'four': 2.0, 'three': 1.0},
-             'command_result': 0,
+             'expected_result': 0,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0)]},
             {'input': {'four': 2.0, 'three': 1.0, 'zero': 0.0},
-             'command_result': 1,
+             'expected_result': 1,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]},
             {'input': {'two': 2.0, 'one': 1.0},
-             'command_result': 2,
+             'expected_result': 2,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]},
         ]
 
         for update in updates:
-            self.assertEqual(self.zadd('foo', update['input'], nx=True), update['command_result'])
+            self.assertEqual(self.zadd('foo', update['input'], nx=True), update['expected_result'])
             self.assertItemsEqual(self.redis.zrange('foo', 0, -1, withscores=True), update['expected_zset'])
 
     @redis3_only
@@ -1823,18 +1823,18 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         updates = [
             {'input': {'four': 4.0, 'three': 1.0},
-             'command_result': 1,
+             'expected_result': 1,
              'expected_zset': [(b'four', 4.0), (b'three', 1.0)]},
             {'input': {'four': 4.0, 'three': 3.0, 'zero': 0.0},
-             'command_result': 2,
+             'expected_result': 2,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]},
             {'input': {'two': 2.0, 'one': 1.0},
-             'command_result': 2,
+             'expected_result': 2,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]},
         ]
 
         for update in updates:
-            self.assertEqual(self.zadd('foo', update['input'], ch=True), update['command_result'])
+            self.assertEqual(self.zadd('foo', update['input'], ch=True), update['expected_result'])
             self.assertItemsEqual(self.redis.zrange('foo', 0, -1, withscores=True), update['expected_zset'])
 
     @redis3_only
@@ -1843,18 +1843,18 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         updates = [
             {'input': {'four': 2.0, 'three': 1.0},
-             'command_result': 0,
+             'expected_result': 0,
              'expected_zset': [(b'four', 2.0), (b'three', 1.0)]},
             {'input': {'four': 4.0, 'three': 3.0, 'zero': 0.0},
-             'command_result': 0,
+             'expected_result': 0,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0)]},
             {'input': {'two': 2.0, 'one': 1.0},
-             'command_result': 0,
+             'expected_result': 0,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0)]},
         ]
 
         for update in updates:
-            self.assertEqual(self.zadd('foo', update['input'], xx=True), update['command_result'])
+            self.assertEqual(self.zadd('foo', update['input'], xx=True), update['expected_result'])
             self.assertItemsEqual(self.redis.zrange('foo', 0, -1, withscores=True), update['expected_zset'])
 
     @redis3_only
@@ -1871,18 +1871,18 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         updates = [
             {'input': {'four': 2.0, 'three': 1.0},
-             'command_result': 0,
+             'expected_result': 0,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0)]},
             {'input': {'four': 2.0, 'three': 1.0, 'zero': 0.0},
-             'command_result': 1,
+             'expected_result': 1,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]},
             {'input': {'two': 2.0, 'one': 1.0},
-             'command_result': 2,
+             'expected_result': 2,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]},
         ]
 
         for update in updates:
-            self.assertEqual(self.zadd('foo', update['input'], nx=True, ch=True), update['command_result'])
+            self.assertEqual(self.zadd('foo', update['input'], nx=True, ch=True), update['expected_result'])
             self.assertItemsEqual(self.redis.zrange('foo', 0, -1, withscores=True), update['expected_zset'])
 
     @redis3_only
@@ -1891,18 +1891,18 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         updates = [
             {'input': {'four': 2.0, 'three': 1.0},
-             'command_result': 2,
+             'expected_result': 2,
              'expected_zset': [(b'four', 2.0), (b'three', 1.0)]},
             {'input': {'four': 4.0, 'three': 3.0, 'zero': 0.0},
-             'command_result': 2,
+             'expected_result': 2,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0)]},
             {'input': {'two': 2.0, 'one': 1.0},
-             'command_result': 0,
+             'expected_result': 0,
              'expected_zset': [(b'four', 4.0), (b'three', 3.0)]},
         ]
 
         for update in updates:
-            self.assertEqual(self.zadd('foo', update['input'], xx=True, ch=True), update['command_result'])
+            self.assertEqual(self.zadd('foo', update['input'], xx=True, ch=True), update['expected_result'])
             self.assertItemsEqual(self.redis.zrange('foo', 0, -1, withscores=True), update['expected_zset'])
 
     def test_zrange_same_score(self):

--- a/test_fakeredis_hypothesis.py
+++ b/test_fakeredis_hypothesis.py
@@ -279,8 +279,10 @@ zset_create_commands = (
     commands(st.just('zadd'), keys, st.lists(st.tuples(scores, fields), min_size=1))
 )
 zset_commands = (
-    # TODO: test xx, nx, ch, incr
-    commands(st.just('zadd'), keys, st.lists(st.tuples(scores, fields)))
+    # TODO: test incr
+    commands(st.just('zadd'), keys, st.none() | st.just('nx'),
+             st.none() | st.just('xx'), st.none() | st.just('ch'),
+             st.lists(st.tuples(scores, fields)))
     | commands(st.just('zcard'), keys)
     | commands(st.just('zcount'), keys, score_tests, score_tests)
     | commands(st.just('zincrby'), keys, scores, fields)
@@ -306,8 +308,10 @@ zset_no_score_create_commands = (
     commands(st.just('zadd'), keys, st.lists(st.tuples(st.just(0), fields), min_size=1))
 )
 zset_no_score_commands = (
-    # TODO: test xx, nx, ch, incr
-    commands(st.just('zadd'), keys, st.lists(st.tuples(st.just(0), fields)))
+    # TODO: test incr
+    commands(st.just('zadd'), keys, st.none() | st.just('nx'),
+             st.none() | st.just('xx'), st.none() | st.just('ch'),
+             st.lists(st.tuples(st.just(0), fields)))
     | commands(st.just('zlexcount'), keys, string_tests, string_tests)
     | commands(st.sampled_from(['zrangebylex', 'zrevrangebylex']),
                keys, string_tests, string_tests,


### PR DESCRIPTION
Add support for the new `NX`, `XX`, and `CH` flags in the `ZADD` command, which can only be provided with `redis-py` version 3 installed.

This fixes a subset of what's filed in #232. `INCR` flag will be implemented in a different pull request, as it's completely different to handle.