### PR TITLE
Add pypy environment for Tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27,py34,py35,py36,py3.7
+envlist =
+    py{27,34,35,36,37,py}
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Travis is already testing using `pypy`. This allows developers to run tests locally using `pypy` too.