### PR TITLE
Added __call__ to make class as callable

### DIFF
--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -2649,8 +2649,10 @@ class FakeRedisMixin:
 
 
 class FakeStrictRedis(FakeRedisMixin, redis.StrictRedis):
-    pass
+    def __call__(self):
+        return self
 
 
 class FakeRedis(FakeRedisMixin, redis.Redis):
-    pass
+    def __call__(self):
+        return self


### PR DESCRIPTION
While mocking a redis connection I faced an issue "FakeStrictRedis is not callable".

```
@mock.patch(app.views.get_redis_connection, new_callable=FakeStrictRedis)
```