### PR TITLE
Lua redis.log implementation

### DIFF
--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -2339,7 +2339,7 @@ class FakeSocket:
         msg = ' '.join([x.decode('utf-8')
                         if isinstance(x, bytes) else str(x)
                         for x in args if not isinstance(x, bool)])
-        LOGGER.log(REDIS_LOG_LEVELS_TO_LOGGING.get(lvl, logging.WARNING), msg)
+        LOGGER.log(REDIS_LOG_LEVELS_TO_LOGGING[lvl], msg)
 
     @command((bytes, Int), (bytes,), flags='s')
     def eval(self, script, numkeys, *keys_and_args):

--- a/test_fakeredis.py
+++ b/test_fakeredis.py
@@ -4161,7 +4161,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.assertEqual(result, b'42')
 
     def test_lua_log(self):
-        if not isinstance(self.redis, fakeredis.FakeRedis) and not isinstance(self.redis, fakeredis.FakeStrictRedis):
+        if not isinstance(self.redis, (fakeredis.FakeRedis, fakeredis.FakeStrictRedis)):
             pytest.skip("Works only on fakeredis, as testing real redis will require access to its logs")
         logger = fakeredis._server.LOGGER
         script = """
@@ -4177,6 +4177,45 @@ class TestFakeStrictRedis(unittest.TestCase):
                                          'INFO:%s:verbose' % logger.name,
                                          'INFO:%s:notice' % logger.name,
                                          'WARNING:%s:warning' % logger.name])
+
+    def test_lua_log_no_message(self):
+        if not isinstance(self.redis, (fakeredis.FakeRedis, fakeredis.FakeStrictRedis)):
+            pytest.skip("Works only on fakeredis, as testing real redis will require access to its logs")
+        script = "redis.log(redis.LOG_DEBUG)"
+        script = self.redis.register_script(script)
+        with self.assertRaises(redis.ResponseError):
+            script()
+
+    def test_lua_log_different_types(self):
+        if not isinstance(self.redis, (fakeredis.FakeRedis, fakeredis.FakeStrictRedis)):
+            pytest.skip("Works only on fakeredis, as testing real redis will require access to its logs")
+        logger = fakeredis._server.LOGGER
+        script = "redis.log(redis.LOG_DEBUG, 'string', 1, true, 3.14, 'string')"
+        script = self.redis.register_script(script)
+        with self.assertLogs(logger, 'DEBUG') as cm:
+            script()
+        self.assertEqual(cm.output, ['DEBUG:%s:string 1 3.14 string' % logger.name])
+
+    def test_lua_log_wrong_level(self):
+        if not isinstance(self.redis, (fakeredis.FakeRedis, fakeredis.FakeStrictRedis)):
+            pytest.skip("Works only on fakeredis, as testing real redis will require access to its logs")
+        script = "redis.log(10, 'string')"
+        script = self.redis.register_script(script)
+        with self.assertRaises(redis.ResponseError):
+            script()
+
+    def test_lua_log_defined_vars(self):
+        if not isinstance(self.redis, (fakeredis.FakeRedis, fakeredis.FakeStrictRedis)):
+            pytest.skip("Works only on fakeredis, as testing real redis will require access to its logs")
+        logger = fakeredis._server.LOGGER
+        script = """
+            local var='string'
+            redis.log(redis.LOG_DEBUG, var)
+        """
+        script = self.redis.register_script(script)
+        with self.assertLogs(logger, 'DEBUG') as cm:
+            script()
+        self.assertEqual(cm.output, ['DEBUG:%s:string' % logger.name])
 
     @redis3_only
     def test_unlink(self):


### PR DESCRIPTION
Added a very simple `redis.log` Lua call support, wired to the standard python `logging` lib.

Issue #265 