### PR TITLE
Make unit tests more pytest-onic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -331,7 +331,7 @@ bugs in Github.
    generally not produce the same results, and in Python versions before 3.6
    may produce different results each time the process is re-run.
 
-7. SCAN/ZSCAN/HSCAN/SSCAN will not necessary iterate all items if items are
+7. SCAN/ZSCAN/HSCAN/SSCAN will not necessarily iterate all items if items are
    deleted or renamed during iteration. They also won't necessarily iterate in
    the same chunk sizes or the same order as redis.
 
@@ -355,43 +355,38 @@ To ensure parity with the real redis, there are a set of integration tests
 that mirror the unittests.  For every unittest that is written, the same
 test is run against a real redis instance using a real redis-py client
 instance.  In order to run these tests you must have a redis server running
-on localhost, port 6379 (the default settings).  The integration tests use
-db=10 in order to minimize collisions with an existing redis instance.
+on localhost, port 6379 (the default settings). **WARNING**: the tests will
+completely wipe your database!
 
 
-To run all the tests, install the requirements file::
+First install the requirements file::
 
     pip install -r requirements.txt
 
-If you just want to run the unittests::
+To run all the tests::
 
-    pytest test_fakeredis.py::TestFakeStrictRedis test_fakeredis.py::TestFakeRedis
+    pytest
+
+If you only want to run tests against fake redis, without a real redis::
+
+    pytest -m fake
 
 Because this module is attempting to provide the same interface as `redis-py`_,
 the python bindings to redis, a reasonable way to test this to to take each
 unittest and run it against a real redis server.  fakeredis and the real redis
-server should give the same result.  This ensures parity between the two.  You
-can run these "integration" tests like this::
+server should give the same result. To run tests against a real redis instance
+instead::
 
-    pytest test_fakeredis.py::TestRealStrictRedis test_fakeredis.py::TestRealRedis test_fakeredis_hypothesis.py
-
-In terms of implementation, ``TestRealRedis`` is a subclass of
-``TestFakeRedis`` that overrides a factory method to create
-an instance of ``redis.Redis`` (an actual python client for redis)
-instead of ``fakeredis.FakeStrictRedis``.
-
-To run both the unittests and the "integration" tests, run::
-
-    pytest
+    pytest -m real
 
 If redis is not running and you try to run tests against a real redis server,
-these tests will have a result of 'S' for skipped.
+these tests will have a result of 's' for skipped.
 
 There are some tests that test redis blocking operations that are somewhat
 slow.  If you want to skip these tests during day to day development,
 they have all been tagged as 'slow' so you can skip them by running::
 
-    pytest -m "not slow" test_fakeredis.py
+    pytest -m "not slow"
 
 
 Revision history

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,10 @@
 aioredis
-asynctest
 coverage
 flake8
 hypothesis
 lupa
 pytest
+pytest-asyncio
 pytest-cov
 redis==3.4.1       # Latest at time of writing
 six

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 aioredis
+async_generator
 coverage
 flake8
 hypothesis

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,17 +4,16 @@
 #
 #    pip-compile requirements.in
 #
-aioredis==1.3.1
+aioredis==1.3.1           # via -r requirements.in
 async-timeout==3.0.1      # via aioredis
-asynctest==0.13.0
 attrs==19.3.0             # via hypothesis, pytest
-coverage==5.0.3
+coverage==5.0.3           # via -r requirements.in, pytest-cov
 entrypoints==0.3          # via flake8
-flake8==3.7.9
+flake8==3.7.9             # via -r requirements.in
 hiredis==1.0.1            # via aioredis
-hypothesis==5.4.1
+hypothesis==5.4.1         # via -r requirements.in
 importlib-metadata==1.5.0  # via pluggy, pytest
-lupa==1.9
+lupa==1.9                 # via -r requirements.in
 mccabe==0.6.1             # via flake8
 more-itertools==8.2.0     # via pytest
 packaging==20.1           # via pytest
@@ -23,10 +22,11 @@ py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pyparsing==2.4.6          # via packaging
-pytest-cov==2.8.1
-pytest==5.3.5
-redis==3.4.1
-six==1.14.0
-sortedcontainers==2.1.0
+pytest-asyncio==0.14.0    # via -r requirements.in
+pytest-cov==2.8.1         # via -r requirements.in
+pytest==5.4.3             # via -r requirements.in, pytest-asyncio, pytest-cov
+redis==3.4.1              # via -r requirements.in
+six==1.14.0               # via -r requirements.in, packaging
+sortedcontainers==2.1.0   # via -r requirements.in, hypothesis
 wcwidth==0.1.8            # via pytest
-zipp==1.1.0
+zipp==1.1.0               # via -r requirements.in, importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 #    pip-compile requirements.in
 #
 aioredis==1.3.1           # via -r requirements.in
+async-generator==1.10     # via -r requirements.in
 async-timeout==3.0.1      # via aioredis
 attrs==19.3.0             # via hypothesis, pytest
 coverage==5.0.3           # via -r requirements.in, pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,5 @@ max-line-length = 119
 [tool:pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    disconnected
+    decode_responses

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,7 @@ max-line-length = 119
 [tool:pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    real: tests that run only against a real redis server
+    fake: tests that run only against fakeredis and do not require a real redis
     disconnected
     decode_responses

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+import redis
+
+import fakeredis
+
+
+@pytest.fixture(scope="session")
+def is_redis_running():
+    try:
+        r = redis.StrictRedis('localhost', port=6379)
+        r.ping()
+        return True
+    except redis.ConnectionError:
+        return False
+    finally:
+        if hasattr(r, 'close'):
+            r.close()      # Absent in older versions of redis-py
+
+
+@pytest.fixture
+def fake_server(request):
+    server = fakeredis.FakeServer()
+    server.connected = request.node.get_closest_marker('disconnected') is None
+    return server

--- a/test/test_aioredis.py
+++ b/test/test_aioredis.py
@@ -1,6 +1,5 @@
 import asyncio
 
-import asynctest
 import pytest
 import aioredis
 

--- a/test/test_aioredis.py
+++ b/test/test_aioredis.py
@@ -7,134 +7,152 @@ import aioredis
 import fakeredis.aioredis
 
 
-class TestFakeCommands(asynctest.TestCase):
-    async def setUp(self):
-        self.redis = await fakeredis.aioredis.create_redis_pool()
-
-    async def tearDown(self):
-        self.redis.close()
-        await self.redis.wait_closed()
-
-    async def test_ping(self):
-        pong = await self.redis.ping()
-        assert pong == b'PONG'
-
-    async def test_types(self):
-        await self.redis.hmset_dict('hash', key1='value1', key2='value2', key3=123)
-        result = await self.redis.hgetall('hash', encoding='utf-8')
-        assert result == {
-            'key1': 'value1',
-            'key2': 'value2',
-            'key3': '123'
-        }
-
-    async def test_transaction(self):
-        tr = self.redis.multi_exec()
-        tr.set('key1', 'value1')
-        tr.set('key2', 'value2')
-        ok1, ok2 = await tr.execute()
-        assert ok1
-        assert ok2
-        result = await self.redis.get('key1')
-        assert result == b'value1'
-
-    async def test_transaction_fail(self):
-        # ensure that the WATCH applies to the same connection as the MULTI/EXEC.
-        await self.redis.set('foo', '1')
-        with await self.redis as r:
-            await r.watch('foo')
-            await self.redis.set('foo', '2')    # Different connection
-            tr = r.multi_exec()
-            tr.get('foo')
-            with pytest.raises(aioredis.MultiExecError):
-                await tr.execute()
-
-    async def test_pubsub(self):
-        ch, = await self.redis.subscribe('channel')
-        queue = asyncio.Queue()
-
-        async def reader(channel):
-            async for message in ch.iter():
-                queue.put_nowait(message)
-
-        task = self.loop.create_task(reader(ch))
-        await self.redis.publish('channel', 'message1')
-        await self.redis.publish('channel', 'message2')
-        result1 = await queue.get()
-        result2 = await queue.get()
-        assert result1 == b'message1'
-        assert result2 == b'message2'
-        ch.close()
-        await task
-
-    async def test_blocking_ready(self):
-        """Blocking command which does not need to block."""
-        self.redis.rpush('list', 'x')
-        with await self.redis as r:
-            result = await r.blpop('list', timeout=1)
-        assert result == [b'list', b'x']
-
-    @pytest.mark.slow
-    async def test_blocking_timeout(self):
-        """Blocking command that times out without completing."""
-        with await self.redis as r:
-            result = await r.blpop('missing', timeout=1)
-        assert result is None
-
-    @pytest.mark.slow
-    async def test_blocking_unblock(self):
-        """Blocking command that gets unblocked after some time."""
-        async def unblock():
-            await asyncio.sleep(0.1)
-            await self.redis.rpush('list', 'y')
-
-        with await self.redis as r:
-            task = self.loop.create_task(unblock())
-            result = await r.blpop('list', timeout=1)
-        assert result == [b'list', b'y']
-        await task
-
-    @pytest.mark.slow
-    async def test_blocking_pipeline(self):
-        """Blocking command with another command issued behind it."""
-        with await self.redis as r:   # Ensure commands use same connection
-            await r.set('foo', 'bar')
-            fut = asyncio.ensure_future(r.blpop('list', timeout=1))
-            assert (await r.get('foo')) == b'bar'
-            assert (await fut) is None
-
-    async def test_wrongtype_error(self):
-        await self.redis.set('foo', 'bar')
-        with pytest.raises(aioredis.ReplyError) as excinfo:
-            await self.redis.rpush('foo', 'baz')
-        assert str(excinfo.value).startswith('WRONGTYPE ')
-
-    async def test_syntax_error(self):
-        with pytest.raises(aioredis.ReplyError) as excinfo:
-            await self.redis.execute('get')
-        assert str(excinfo.value) == "ERR wrong number of arguments for 'get' command"
-
-    async def test_no_script_error(self):
-        with pytest.raises(aioredis.ReplyError) as excinfo:
-            await self.redis.evalsha('0123456789abcdef0123456789abcdef')
-        assert str(excinfo.value).startswith('NOSCRIPT ')
-
-    async def test_failed_script_error(self):
-        await self.redis.set('foo', 'bar')
-        with pytest.raises(aioredis.ReplyError) as excinfo:
-            await self.redis.eval(
-                'return redis.call("ZCOUNT", KEYS[1])', ['foo'])
-        assert str(excinfo.value).startswith('ERR Error running script')
+@pytest.fixture(params=['fake', 'real'])
+def r(request, event_loop):
+    if request.param == 'fake':
+        ret = event_loop.run_until_complete(fakeredis.aioredis.create_redis_pool())
+    else:
+        if not request.getfixturevalue('is_redis_running'):
+            pytest.skip('Redis is not running')
+        ret = event_loop.run_until_complete(aioredis.create_redis_pool('redis://localhost'))
+    event_loop.run_until_complete(ret.flushall())
+    yield ret
+    event_loop.run_until_complete(ret.flushall())
+    ret.close()
+    event_loop.run_until_complete(ret.wait_closed())
 
 
-class TestRealCommands(TestFakeCommands):
-    async def setUp(self):
-        try:
-            self.redis = await aioredis.create_redis_pool('redis://localhost')
-            await self.redis.flushall()
-        except ConnectionRefusedError:
-            pytest.skip('redis is not running')
+@pytest.fixture
+def conn(r, event_loop):
+    """A single connection, rather than a pool."""
+    conn = event_loop.run_until_complete(r)
+    with conn:
+        yield conn
 
-    async def tearDown(self):
-        await self.redis.flushall()
-        await super().tearDown()
+
+@pytest.mark.asyncio
+async def test_ping(r):
+    pong = await r.ping()
+    assert pong == b'PONG'
+
+
+@pytest.mark.asyncio
+async def test_types(r):
+    await r.hmset_dict('hash', key1='value1', key2='value2', key3=123)
+    result = await r.hgetall('hash', encoding='utf-8')
+    assert result == {
+        'key1': 'value1',
+        'key2': 'value2',
+        'key3': '123'
+    }
+
+
+@pytest.mark.asyncio
+async def test_transaction(r):
+    tr = r.multi_exec()
+    tr.set('key1', 'value1')
+    tr.set('key2', 'value2')
+    ok1, ok2 = await tr.execute()
+    assert ok1
+    assert ok2
+    result = await r.get('key1')
+    assert result == b'value1'
+
+
+@pytest.mark.asyncio
+async def test_transaction_fail(r, conn):
+    # ensure that the WATCH applies to the same connection as the MULTI/EXEC.
+    await r.set('foo', '1')
+    await conn.watch('foo')
+    await conn.set('foo', '2')    # Different connection
+    tr = conn.multi_exec()
+    tr.get('foo')
+    with pytest.raises(aioredis.MultiExecError):
+        await tr.execute()
+
+
+@pytest.mark.asyncio
+async def test_pubsub(r, event_loop):
+    ch, = await r.subscribe('channel')
+    queue = asyncio.Queue()
+
+    async def reader(channel):
+        async for message in ch.iter():
+            queue.put_nowait(message)
+
+    task = event_loop.create_task(reader(ch))
+    await r.publish('channel', 'message1')
+    await r.publish('channel', 'message2')
+    result1 = await queue.get()
+    result2 = await queue.get()
+    assert result1 == b'message1'
+    assert result2 == b'message2'
+    ch.close()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_blocking_ready(r, conn):
+    """Blocking command which does not need to block."""
+    await r.rpush('list', 'x')
+    result = await conn.blpop('list', timeout=1)
+    assert result == [b'list', b'x']
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_blocking_timeout(conn):
+    """Blocking command that times out without completing."""
+    result = await conn.blpop('missing', timeout=1)
+    assert result is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_blocking_unblock(r, conn, event_loop):
+    """Blocking command that gets unblocked after some time."""
+    async def unblock():
+        await asyncio.sleep(0.1)
+        await r.rpush('list', 'y')
+
+    task = event_loop.create_task(unblock())
+    result = await conn.blpop('list', timeout=1)
+    assert result == [b'list', b'y']
+    await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_blocking_pipeline(conn):
+    """Blocking command with another command issued behind it."""
+    await conn.set('foo', 'bar')
+    fut = asyncio.ensure_future(conn.blpop('list', timeout=1))
+    assert (await conn.get('foo')) == b'bar'
+    assert (await fut) is None
+
+
+@pytest.mark.asyncio
+async def test_wrongtype_error(r):
+    await r.set('foo', 'bar')
+    with pytest.raises(aioredis.ReplyError, match='^WRONGTYPE'):
+        await r.rpush('foo', 'baz')
+
+
+@pytest.mark.asyncio
+async def test_syntax_error(r):
+    with pytest.raises(aioredis.ReplyError,
+                       match="^ERR wrong number of arguments for 'get' command$"):
+        await r.execute('get')
+
+
+@pytest.mark.asyncio
+async def test_no_script_error(r):
+    with pytest.raises(aioredis.ReplyError, match='^NOSCRIPT '):
+        await r.evalsha('0123456789abcdef0123456789abcdef')
+
+
+@pytest.mark.asyncio
+async def test_failed_script_error(r):
+    await r.set('foo', 'bar')
+    with pytest.raises(aioredis.ReplyError, match='^ERR Error running script'):
+        await r.eval('return redis.call("ZCOUNT", KEYS[1])', ['foo'])

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -82,15 +82,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.flushall()
         del self.redis
 
-    if sys.version_info >= (3,):
-        def assertItemsEqual(self, a, b):
-            return self.assertCountEqual(a, b)
-
     def create_redis(self, db=0):
         return fakeredis.FakeStrictRedis(db=db, server=self.server)
 
     def _round_str(self, x):
-        self.assertIsInstance(x, bytes)
+        assert isinstance(x, bytes)
         return round(float(x))
 
     def raw_command(self, *args):
@@ -117,91 +113,89 @@ class TestFakeStrictRedis(unittest.TestCase):
 
     def test_large_command(self):
         self.redis.set('foo', 'bar' * 10000)
-        self.assertEqual(self.redis.get('foo'), b'bar' * 10000)
+        assert self.redis.get('foo') == b'bar' * 10000
 
     def test_dbsize(self):
-        self.assertEqual(self.redis.dbsize(), 0)
+        assert self.redis.dbsize() == 0
         self.redis.set('foo', 'bar')
         self.redis.set('bar', 'foo')
-        self.assertEqual(self.redis.dbsize(), 2)
+        assert self.redis.dbsize() == 2
 
     def test_flushdb(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.keys(), [b'foo'])
-        self.assertEqual(self.redis.flushdb(), True)
-        self.assertEqual(self.redis.keys(), [])
+        assert self.redis.keys() == [b'foo']
+        assert self.redis.flushdb() == True
+        assert self.redis.keys() == []
 
     def test_set_then_get(self):
-        self.assertEqual(self.redis.set('foo', 'bar'), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.set('foo', 'bar') == True
+        assert self.redis.get('foo') == b'bar'
 
     @redis2_only
     def test_set_None_value(self):
-        self.assertEqual(self.redis.set('foo', None), True)
-        self.assertEqual(self.redis.get('foo'), b'None')
+        assert self.redis.set('foo', None) == True
+        assert self.redis.get('foo') == b'None'
 
     def test_set_float_value(self):
         x = 1.23456789123456789
         self.redis.set('foo', x)
-        self.assertEqual(float(self.redis.get('foo')), x)
+        assert float(self.redis.get('foo')) == x
 
     def test_saving_non_ascii_chars_as_value(self):
-        self.assertEqual(self.redis.set('foo', 'Ñandu'), True)
-        self.assertEqual(self.redis.get('foo'),
-                         'Ñandu'.encode())
+        assert self.redis.set('foo', 'Ñandu') == True
+        assert self.redis.get('foo') == 'Ñandu'.encode()
 
     def test_saving_unicode_type_as_value(self):
-        self.assertEqual(self.redis.set('foo', 'Ñandu'), True)
-        self.assertEqual(self.redis.get('foo'),
-                         'Ñandu'.encode())
+        assert self.redis.set('foo', 'Ñandu') == True
+        assert self.redis.get('foo') == 'Ñandu'.encode()
 
     def test_saving_non_ascii_chars_as_key(self):
-        self.assertEqual(self.redis.set('Ñandu', 'foo'), True)
-        self.assertEqual(self.redis.get('Ñandu'), b'foo')
+        assert self.redis.set('Ñandu', 'foo') == True
+        assert self.redis.get('Ñandu') == b'foo'
 
     def test_saving_unicode_type_as_key(self):
-        self.assertEqual(self.redis.set('Ñandu', 'foo'), True)
-        self.assertEqual(self.redis.get('Ñandu'), b'foo')
+        assert self.redis.set('Ñandu', 'foo') == True
+        assert self.redis.get('Ñandu') == b'foo'
 
     def test_future_newbytes(self):
         bytes = pytest.importorskip('builtins', reason='future.types not available').bytes
         self.redis.set(bytes(b'\xc3\x91andu'), 'foo')
-        self.assertEqual(self.redis.get('Ñandu'), b'foo')
+        assert self.redis.get('Ñandu') == b'foo'
 
     def test_future_newstr(self):
         str = pytest.importorskip('builtins', reason='future.types not available').str
         self.redis.set(str('Ñandu'), 'foo')
-        self.assertEqual(self.redis.get('Ñandu'), b'foo')
+        assert self.redis.get('Ñandu') == b'foo'
 
     def test_get_does_not_exist(self):
-        self.assertEqual(self.redis.get('foo'), None)
+        assert self.redis.get('foo') is None
 
     def test_get_with_non_str_keys(self):
-        self.assertEqual(self.redis.set('2', 'bar'), True)
-        self.assertEqual(self.redis.get(2), b'bar')
+        assert self.redis.set('2', 'bar') == True
+        assert self.redis.get(2) == b'bar'
 
     def test_get_invalid_type(self):
-        self.assertEqual(self.redis.hset('foo', 'key', 'value'), 1)
-        with self.assertRaises(redis.ResponseError):
+        assert self.redis.hset('foo', 'key', 'value') == 1
+        with pytest.raises(redis.ResponseError):
             self.redis.get('foo')
 
     def test_set_non_str_keys(self):
-        self.assertEqual(self.redis.set(2, 'bar'), True)
-        self.assertEqual(self.redis.get(2), b'bar')
-        self.assertEqual(self.redis.get('2'), b'bar')
+        assert self.redis.set(2, 'bar') == True
+        assert self.redis.get(2) == b'bar'
+        assert self.redis.get('2') == b'bar'
 
     def test_getbit(self):
         self.redis.setbit('foo', 3, 1)
-        self.assertEqual(self.redis.getbit('foo', 0), 0)
-        self.assertEqual(self.redis.getbit('foo', 1), 0)
-        self.assertEqual(self.redis.getbit('foo', 2), 0)
-        self.assertEqual(self.redis.getbit('foo', 3), 1)
-        self.assertEqual(self.redis.getbit('foo', 4), 0)
-        self.assertEqual(self.redis.getbit('foo', 100), 0)
+        assert self.redis.getbit('foo', 0) == 0
+        assert self.redis.getbit('foo', 1) == 0
+        assert self.redis.getbit('foo', 2) == 0
+        assert self.redis.getbit('foo', 3) == 1
+        assert self.redis.getbit('foo', 4) == 0
+        assert self.redis.getbit('foo', 100) == 0
 
     def test_getbit_wrong_type(self):
         self.redis.rpush('foo', b'x')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.getbit('foo', 1)
 
     def test_multiple_bits_set(self):
@@ -209,237 +203,237 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.setbit('foo', 3, 1)
         self.redis.setbit('foo', 5, 1)
 
-        self.assertEqual(self.redis.getbit('foo', 0), 0)
-        self.assertEqual(self.redis.getbit('foo', 1), 1)
-        self.assertEqual(self.redis.getbit('foo', 2), 0)
-        self.assertEqual(self.redis.getbit('foo', 3), 1)
-        self.assertEqual(self.redis.getbit('foo', 4), 0)
-        self.assertEqual(self.redis.getbit('foo', 5), 1)
-        self.assertEqual(self.redis.getbit('foo', 6), 0)
+        assert self.redis.getbit('foo', 0) == 0
+        assert self.redis.getbit('foo', 1) == 1
+        assert self.redis.getbit('foo', 2) == 0
+        assert self.redis.getbit('foo', 3) == 1
+        assert self.redis.getbit('foo', 4) == 0
+        assert self.redis.getbit('foo', 5) == 1
+        assert self.redis.getbit('foo', 6) == 0
 
     def test_unset_bits(self):
         self.redis.setbit('foo', 1, 1)
         self.redis.setbit('foo', 2, 0)
         self.redis.setbit('foo', 3, 1)
-        self.assertEqual(self.redis.getbit('foo', 1), 1)
+        assert self.redis.getbit('foo', 1) == 1
         self.redis.setbit('foo', 1, 0)
-        self.assertEqual(self.redis.getbit('foo', 1), 0)
+        assert self.redis.getbit('foo', 1) == 0
         self.redis.setbit('foo', 3, 0)
-        self.assertEqual(self.redis.getbit('foo', 3), 0)
+        assert self.redis.getbit('foo', 3) == 0
 
     def test_get_set_bits(self):
         # set bit 5
-        self.assertFalse(self.redis.setbit('a', 5, True))
-        self.assertTrue(self.redis.getbit('a', 5))
+        assert not self.redis.setbit('a', 5, True)
+        assert self.redis.getbit('a', 5)
         # unset bit 4
-        self.assertFalse(self.redis.setbit('a', 4, False))
-        self.assertFalse(self.redis.getbit('a', 4))
+        assert not self.redis.setbit('a', 4, False)
+        assert not self.redis.getbit('a', 4)
         # set bit 4
-        self.assertFalse(self.redis.setbit('a', 4, True))
-        self.assertTrue(self.redis.getbit('a', 4))
+        assert not self.redis.setbit('a', 4, True)
+        assert self.redis.getbit('a', 4)
         # set bit 5 again
-        self.assertTrue(self.redis.setbit('a', 5, True))
-        self.assertTrue(self.redis.getbit('a', 5))
+        assert self.redis.setbit('a', 5, True)
+        assert self.redis.getbit('a', 5)
 
     def test_setbits_and_getkeys(self):
         # The bit operations and the get commands
         # should play nicely with each other.
         self.redis.setbit('foo', 1, 1)
-        self.assertEqual(self.redis.get('foo'), b'@')
+        assert self.redis.get('foo') == b'@'
         self.redis.setbit('foo', 2, 1)
-        self.assertEqual(self.redis.get('foo'), b'`')
+        assert self.redis.get('foo') == b'`'
         self.redis.setbit('foo', 3, 1)
-        self.assertEqual(self.redis.get('foo'), b'p')
+        assert self.redis.get('foo') == b'p'
         self.redis.setbit('foo', 9, 1)
-        self.assertEqual(self.redis.get('foo'), b'p@')
+        assert self.redis.get('foo') == b'p@'
         self.redis.setbit('foo', 54, 1)
-        self.assertEqual(self.redis.get('foo'), b'p@\x00\x00\x00\x00\x02')
+        assert self.redis.get('foo') == b'p@\x00\x00\x00\x00\x02'
 
     def test_setbit_wrong_type(self):
         self.redis.rpush('foo', b'x')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.setbit('foo', 0, 1)
 
     def test_setbit_expiry(self):
         self.redis.set('foo', b'0x00', ex=10)
         self.redis.setbit('foo', 1, 1)
-        self.assertGreater(self.redis.ttl('foo'), 0)
+        assert self.redis.ttl('foo') > 0
 
     def test_bitcount(self):
         self.redis.delete('foo')
-        self.assertEqual(self.redis.bitcount('foo'), 0)
+        assert self.redis.bitcount('foo') == 0
         self.redis.setbit('foo', 1, 1)
-        self.assertEqual(self.redis.bitcount('foo'), 1)
+        assert self.redis.bitcount('foo') == 1
         self.redis.setbit('foo', 8, 1)
-        self.assertEqual(self.redis.bitcount('foo'), 2)
-        self.assertEqual(self.redis.bitcount('foo', 1, 1), 1)
+        assert self.redis.bitcount('foo') == 2
+        assert self.redis.bitcount('foo', 1, 1) == 1
         self.redis.setbit('foo', 57, 1)
-        self.assertEqual(self.redis.bitcount('foo'), 3)
+        assert self.redis.bitcount('foo') == 3
         self.redis.set('foo', ' ')
-        self.assertEqual(self.redis.bitcount('foo'), 1)
+        assert self.redis.bitcount('foo') == 1
 
     def test_bitcount_wrong_type(self):
         self.redis.rpush('foo', b'x')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.bitcount('foo')
 
     def test_getset_not_exist(self):
         val = self.redis.getset('foo', 'bar')
-        self.assertEqual(val, None)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert val is None
+        assert self.redis.get('foo') == b'bar'
 
     def test_getset_exists(self):
         self.redis.set('foo', 'bar')
         val = self.redis.getset('foo', b'baz')
-        self.assertEqual(val, b'bar')
+        assert val == b'bar'
         val = self.redis.getset('foo', b'baz2')
-        self.assertEqual(val, b'baz')
+        assert val == b'baz'
 
     def test_getset_wrong_type(self):
         self.redis.rpush('foo', b'x')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.getset('foo', 'bar')
 
     def test_setitem_getitem(self):
-        self.assertEqual(self.redis.keys(), [])
+        assert self.redis.keys() == []
         self.redis['foo'] = 'bar'
-        self.assertEqual(self.redis['foo'], b'bar')
+        assert self.redis['foo'] == b'bar'
 
     def test_getitem_non_existent_key(self):
-        self.assertEqual(self.redis.keys(), [])
-        with self.assertRaises(KeyError):
+        assert self.redis.keys() == []
+        with pytest.raises(KeyError):
             self.redis['noexists']
 
     def test_strlen(self):
         self.redis['foo'] = 'bar'
 
-        self.assertEqual(self.redis.strlen('foo'), 3)
-        self.assertEqual(self.redis.strlen('noexists'), 0)
+        assert self.redis.strlen('foo') == 3
+        assert self.redis.strlen('noexists') == 0
 
     def test_strlen_wrong_type(self):
         self.redis.rpush('foo', b'x')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.strlen('foo')
 
     def test_substr(self):
         self.redis['foo'] = 'one_two_three'
-        self.assertEqual(self.redis.substr('foo', 0), b'one_two_three')
-        self.assertEqual(self.redis.substr('foo', 0, 2), b'one')
-        self.assertEqual(self.redis.substr('foo', 4, 6), b'two')
-        self.assertEqual(self.redis.substr('foo', -5), b'three')
-        self.assertEqual(self.redis.substr('foo', -4, -5), b'')
-        self.assertEqual(self.redis.substr('foo', -5, -3), b'thr')
+        assert self.redis.substr('foo', 0) == b'one_two_three'
+        assert self.redis.substr('foo', 0, 2) == b'one'
+        assert self.redis.substr('foo', 4, 6) == b'two'
+        assert self.redis.substr('foo', -5) == b'three'
+        assert self.redis.substr('foo', -4, -5) == b''
+        assert self.redis.substr('foo', -5, -3) == b'thr'
 
     def test_substr_noexist_key(self):
-        self.assertEqual(self.redis.substr('foo', 0), b'')
-        self.assertEqual(self.redis.substr('foo', 10), b'')
-        self.assertEqual(self.redis.substr('foo', -5, -1), b'')
+        assert self.redis.substr('foo', 0) == b''
+        assert self.redis.substr('foo', 10) == b''
+        assert self.redis.substr('foo', -5, -1) == b''
 
     def test_substr_wrong_type(self):
         self.redis.rpush('foo', b'x')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.substr('foo', 0)
 
     def test_append(self):
-        self.assertTrue(self.redis.set('foo', 'bar'))
-        self.assertEqual(self.redis.append('foo', 'baz'), 6)
-        self.assertEqual(self.redis.get('foo'), b'barbaz')
+        assert self.redis.set('foo', 'bar')
+        assert self.redis.append('foo', 'baz') == 6
+        assert self.redis.get('foo') == b'barbaz'
 
     def test_append_with_no_preexisting_key(self):
-        self.assertEqual(self.redis.append('foo', 'bar'), 3)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.append('foo', 'bar') == 3
+        assert self.redis.get('foo') == b'bar'
 
     def test_append_wrong_type(self):
         self.redis.rpush('foo', b'x')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.append('foo', b'x')
 
     def test_incr_with_no_preexisting_key(self):
-        self.assertEqual(self.redis.incr('foo'), 1)
-        self.assertEqual(self.redis.incr('bar', 2), 2)
+        assert self.redis.incr('foo') == 1
+        assert self.redis.incr('bar', 2) == 2
 
     def test_incr_by(self):
-        self.assertEqual(self.redis.incrby('foo'), 1)
-        self.assertEqual(self.redis.incrby('bar', 2), 2)
+        assert self.redis.incrby('foo') == 1
+        assert self.redis.incrby('bar', 2) == 2
 
     def test_incr_preexisting_key(self):
         self.redis.set('foo', 15)
-        self.assertEqual(self.redis.incr('foo', 5), 20)
-        self.assertEqual(self.redis.get('foo'), b'20')
+        assert self.redis.incr('foo', 5) == 20
+        assert self.redis.get('foo') == b'20'
 
     def test_incr_expiry(self):
         self.redis.set('foo', 15, ex=10)
         self.redis.incr('foo', 5)
-        self.assertGreater(self.redis.ttl('foo'), 0)
+        assert self.redis.ttl('foo') > 0
 
     def test_incr_bad_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.incr('foo', 15)
         self.redis.rpush('foo2', 1)
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.incr('foo2', 15)
 
     def test_incr_with_float(self):
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.incr('foo', 2.0)
 
     def test_incr_followed_by_mget(self):
         self.redis.set('foo', 15)
-        self.assertEqual(self.redis.incr('foo', 5), 20)
-        self.assertEqual(self.redis.get('foo'), b'20')
+        assert self.redis.incr('foo', 5) == 20
+        assert self.redis.get('foo') == b'20'
 
     def test_incr_followed_by_mget_returns_strings(self):
         self.redis.incr('foo', 1)
-        self.assertEqual(self.redis.mget(['foo']), [b'1'])
+        assert self.redis.mget(['foo']) == [b'1']
 
     def test_incrbyfloat(self):
         self.redis.set('foo', 0)
-        self.assertEqual(self.redis.incrbyfloat('foo', 1.0), 1.0)
-        self.assertEqual(self.redis.incrbyfloat('foo', 1.0), 2.0)
+        assert self.redis.incrbyfloat('foo', 1.0) == 1.0
+        assert self.redis.incrbyfloat('foo', 1.0) == 2.0
 
     def test_incrbyfloat_with_noexist(self):
-        self.assertEqual(self.redis.incrbyfloat('foo', 1.0), 1.0)
-        self.assertEqual(self.redis.incrbyfloat('foo', 1.0), 2.0)
+        assert self.redis.incrbyfloat('foo', 1.0) == 1.0
+        assert self.redis.incrbyfloat('foo', 1.0) == 2.0
 
     def test_incrbyfloat_expiry(self):
         self.redis.set('foo', 1.5, ex=10)
         self.redis.incrbyfloat('foo', 2.5)
-        self.assertGreater(self.redis.ttl('foo'), 0)
+        assert self.redis.ttl('foo') > 0
 
     def test_incrbyfloat_bad_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaisesRegex(redis.ResponseError, 'not a valid float'):
+        with pytest.raises(redis.ResponseError, match='not a valid float'):
             self.redis.incrbyfloat('foo', 1.0)
         self.redis.rpush('foo2', 1)
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.incrbyfloat('foo2', 1.0)
 
     def test_incrbyfloat_precision(self):
         x = 1.23456789123456789
-        self.assertEqual(self.redis.incrbyfloat('foo', x), x)
-        self.assertEqual(float(self.redis.get('foo')), x)
+        assert self.redis.incrbyfloat('foo', x) == x
+        assert float(self.redis.get('foo')) == x
 
     def test_decr(self):
         self.redis.set('foo', 10)
-        self.assertEqual(self.redis.decr('foo'), 9)
-        self.assertEqual(self.redis.get('foo'), b'9')
+        assert self.redis.decr('foo') == 9
+        assert self.redis.get('foo') == b'9'
 
     def test_decr_newkey(self):
         self.redis.decr('foo')
-        self.assertEqual(self.redis.get('foo'), b'-1')
+        assert self.redis.get('foo') == b'-1'
 
     def test_decr_expiry(self):
         self.redis.set('foo', 10, ex=10)
         self.redis.decr('foo', 5)
-        self.assertGreater(self.redis.ttl('foo'), 0)
+        assert self.redis.ttl('foo') > 0
 
     def test_decr_badtype(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.decr('foo', 15)
         self.redis.rpush('foo2', 1)
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.decr('foo2', 15)
 
     def test_keys(self):
@@ -448,103 +442,96 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.set('abc\\', '')
         self.redis.set('abcde', '')
         if self.decode_responses:
-            self.assertEqual(sorted(self.redis.keys()),
-                             [b'', b'abc\n', b'abc\\', b'abcde'])
+            assert sorted(self.redis.keys()) == [b'', b'abc\n', b'abc\\', b'abcde']
         else:
             self.redis.set(b'\xfe\xcd', '')
-            self.assertEqual(sorted(self.redis.keys()),
-                             [b'', b'abc\n', b'abc\\', b'abcde', b'\xfe\xcd'])
-            self.assertEqual(self.redis.keys('??'), [b'\xfe\xcd'])
+            assert sorted(self.redis.keys()) == [b'', b'abc\n', b'abc\\', b'abcde', b'\xfe\xcd']
+            assert self.redis.keys('??') == [b'\xfe\xcd']
         # empty pattern not the same as no pattern
-        self.assertEqual(self.redis.keys(''), [b''])
+        assert self.redis.keys('') == [b'']
         # ? must match \n
-        self.assertEqual(sorted(self.redis.keys('abc?')),
-                         [b'abc\n', b'abc\\'])
+        assert sorted(self.redis.keys('abc?')) == [b'abc\n', b'abc\\']
         # must be anchored at both ends
-        self.assertEqual(self.redis.keys('abc'), [])
-        self.assertEqual(self.redis.keys('bcd'), [])
+        assert self.redis.keys('abc') == []
+        assert self.redis.keys('bcd') == []
         # wildcard test
-        self.assertEqual(self.redis.keys('a*de'), [b'abcde'])
+        assert self.redis.keys('a*de') == [b'abcde']
         # positive groups
-        self.assertEqual(sorted(self.redis.keys('abc[d\n]*')),
-                         [b'abc\n', b'abcde'])
-        self.assertEqual(self.redis.keys('abc[c-e]?'), [b'abcde'])
-        self.assertEqual(self.redis.keys('abc[e-c]?'), [b'abcde'])
-        self.assertEqual(self.redis.keys('abc[e-e]?'), [])
-        self.assertEqual(self.redis.keys('abcd[ef'), [b'abcde'])
-        self.assertEqual(self.redis.keys('abcd[]'), [])
+        assert sorted(self.redis.keys('abc[d\n]*')) == [b'abc\n', b'abcde']
+        assert self.redis.keys('abc[c-e]?') == [b'abcde']
+        assert self.redis.keys('abc[e-c]?') == [b'abcde']
+        assert self.redis.keys('abc[e-e]?') == []
+        assert self.redis.keys('abcd[ef') == [b'abcde']
+        assert self.redis.keys('abcd[]') == []
         # negative groups
-        self.assertEqual(self.redis.keys('abc[^d\\\\]*'), [b'abc\n'])
-        self.assertEqual(self.redis.keys('abc[^]e'), [b'abcde'])
+        assert self.redis.keys('abc[^d\\\\]*') == [b'abc\n']
+        assert self.redis.keys('abc[^]e') == [b'abcde']
         # escaping
-        self.assertEqual(self.redis.keys(r'abc\?e'), [])
-        self.assertEqual(self.redis.keys(r'abc\de'), [b'abcde'])
-        self.assertEqual(self.redis.keys(r'abc[\d]e'), [b'abcde'])
+        assert self.redis.keys(r'abc\?e') == []
+        assert self.redis.keys(r'abc\de') == [b'abcde']
+        assert self.redis.keys(r'abc[\d]e') == [b'abcde']
         # some escaping cases that redis handles strangely
-        self.assertEqual(self.redis.keys('abc\\'), [b'abc\\'])
-        self.assertEqual(self.redis.keys(r'abc[\c-e]e'), [])
-        self.assertEqual(self.redis.keys(r'abc[c-\e]e'), [])
+        assert self.redis.keys('abc\\') == [b'abc\\']
+        assert self.redis.keys(r'abc[\c-e]e') == []
+        assert self.redis.keys(r'abc[c-\e]e') == []
 
     def test_exists(self):
-        self.assertFalse('foo' in self.redis)
+        assert 'foo' not in self.redis
         self.redis.set('foo', 'bar')
-        self.assertTrue('foo' in self.redis)
+        assert 'foo' in self.redis
 
     def test_contains(self):
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
         self.redis.set('foo', 'bar')
-        self.assertTrue(self.redis.exists('foo'))
+        assert self.redis.exists('foo')
 
     def test_rename(self):
         self.redis.set('foo', 'unique value')
-        self.assertTrue(self.redis.rename('foo', 'bar'))
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.get('bar'), b'unique value')
+        assert self.redis.rename('foo', 'bar')
+        assert self.redis.get('foo') is None
+        assert self.redis.get('bar') == b'unique value'
 
     def test_rename_nonexistent_key(self):
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.rename('foo', 'bar')
 
     def test_renamenx_doesnt_exist(self):
         self.redis.set('foo', 'unique value')
-        self.assertTrue(self.redis.renamenx('foo', 'bar'))
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.get('bar'), b'unique value')
+        assert self.redis.renamenx('foo', 'bar')
+        assert self.redis.get('foo') is None
+        assert self.redis.get('bar') == b'unique value'
 
     def test_rename_does_exist(self):
         self.redis.set('foo', 'unique value')
         self.redis.set('bar', 'unique value2')
-        self.assertFalse(self.redis.renamenx('foo', 'bar'))
-        self.assertEqual(self.redis.get('foo'), b'unique value')
-        self.assertEqual(self.redis.get('bar'), b'unique value2')
+        assert not self.redis.renamenx('foo', 'bar')
+        assert self.redis.get('foo') == b'unique value'
+        assert self.redis.get('bar') == b'unique value2'
 
     def test_rename_expiry(self):
         self.redis.set('foo', 'value1', ex=10)
         self.redis.set('bar', 'value2')
         self.redis.rename('foo', 'bar')
-        self.assertGreater(self.redis.ttl('bar'), 0)
+        assert self.redis.ttl('bar') > 0
 
     def test_mget(self):
         self.redis.set('foo', 'one')
         self.redis.set('bar', 'two')
-        self.assertEqual(self.redis.mget(['foo', 'bar']), [b'one', b'two'])
-        self.assertEqual(self.redis.mget(['foo', 'bar', 'baz']),
-                         [b'one', b'two', None])
-        self.assertEqual(self.redis.mget('foo', 'bar'), [b'one', b'two'])
+        assert self.redis.mget(['foo', 'bar']) == [b'one', b'two']
+        assert self.redis.mget(['foo', 'bar', 'baz']) == [b'one', b'two', None]
+        assert self.redis.mget('foo', 'bar') == [b'one', b'two']
 
     @redis2_only
     def test_mget_none(self):
         self.redis.set('foo', 'one')
         self.redis.set('bar', 'two')
-        self.assertEqual(self.redis.mget('foo', 'bar', None),
-                         [b'one', b'two', None])
+        assert self.redis.mget('foo', 'bar', None) == [b'one', b'two', None]
 
     def test_mget_with_no_keys(self):
         if REDIS3:
-            self.assertEqual(self.redis.mget([]), [])
+            assert self.redis.mget([]) == []
         else:
-            with self.assertRaisesRegex(
-                    redis.ResponseError, 'wrong number of arguments'):
+            with pytest.raises(redis.ResponseError, match='wrong number of arguments'):
                 self.redis.mget([])
 
     def test_mget_mixed_types(self):
@@ -553,140 +540,131 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.sadd('set', 'member')
         self.redis.rpush('list', 'item1')
         self.redis.set('string', 'value')
-        self.assertEqual(
-            self.redis.mget(['hash', 'zset', 'set', 'string', 'absent']),
-            [None, None, None, b'value', None])
+        assert (
+            self.redis.mget(['hash', 'zset', 'set', 'string', 'absent'])
+            == [None, None, None, b'value', None]
+        )
 
     def test_mset_with_no_keys(self):
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.mset({})
 
     def test_mset(self):
-        self.assertEqual(self.redis.mset({'foo': 'one', 'bar': 'two'}), True)
-        self.assertEqual(self.redis.mset({'foo': 'one', 'bar': 'two'}), True)
-        self.assertEqual(self.redis.mget('foo', 'bar'), [b'one', b'two'])
+        assert self.redis.mset({'foo': 'one', 'bar': 'two'}) == True
+        assert self.redis.mset({'foo': 'one', 'bar': 'two'}) == True
+        assert self.redis.mget('foo', 'bar') == [b'one', b'two']
 
     @redis2_only
     def test_mset_accepts_kwargs(self):
-        self.assertEqual(
-            self.redis.mset(foo='one', bar='two'), True)
-        self.assertEqual(
-            self.redis.mset(foo='one', baz='three'), True)
-        self.assertEqual(self.redis.mget('foo', 'bar', 'baz'),
-                         [b'one', b'two', b'three'])
+        assert self.redis.mset(foo='one', bar='two') == True
+        assert self.redis.mset(foo='one', baz='three') == True
+        assert self.redis.mget('foo', 'bar', 'baz') == [b'one', b'two', b'three']
 
     def test_msetnx(self):
-        self.assertEqual(self.redis.msetnx({'foo': 'one', 'bar': 'two'}),
-                         True)
-        self.assertEqual(self.redis.msetnx({'bar': 'two', 'baz': 'three'}),
-                         False)
-        self.assertEqual(self.redis.mget('foo', 'bar', 'baz'),
-                         [b'one', b'two', None])
+        assert self.redis.msetnx({'foo': 'one', 'bar': 'two'}) == True
+        assert self.redis.msetnx({'bar': 'two', 'baz': 'three'}) == False
+        assert self.redis.mget('foo', 'bar', 'baz') == [b'one', b'two', None]
 
     def test_setex(self):
-        self.assertEqual(self.redis.setex('foo', 100, 'bar'), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.setex('foo', 100, 'bar') == True
+        assert self.redis.get('foo') == b'bar'
 
     def test_setex_using_timedelta(self):
-        self.assertEqual(
-            self.redis.setex('foo', timedelta(seconds=100), 'bar'), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.setex('foo', timedelta(seconds=100), 'bar') == True
+        assert self.redis.get('foo') == b'bar'
 
     def test_setex_using_float(self):
-        self.assertRaisesRegex(
-            redis.ResponseError, 'integer', self.redis.setex, 'foo', 1.2,
-            'bar')
+        with pytest.raises(redis.ResponseError, match='integer'):
+            self.redis.setex('foo', 1.2, 'bar')
 
     def test_set_ex(self):
-        self.assertEqual(self.redis.set('foo', 'bar', ex=100), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.set('foo', 'bar', ex=100) == True
+        assert self.redis.get('foo') == b'bar'
 
     def test_set_ex_using_timedelta(self):
-        self.assertEqual(
-            self.redis.set('foo', 'bar', ex=timedelta(seconds=100)), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.set('foo', 'bar', ex=timedelta(seconds=100)) == True
+        assert self.redis.get('foo') == b'bar'
 
     def test_set_px(self):
-        self.assertEqual(self.redis.set('foo', 'bar', px=100), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.set('foo', 'bar', px=100) == True
+        assert self.redis.get('foo') == b'bar'
 
     def test_set_px_using_timedelta(self):
-        self.assertEqual(
-            self.redis.set('foo', 'bar', px=timedelta(milliseconds=100)), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.set('foo', 'bar', px=timedelta(milliseconds=100)) == True
+        assert self.redis.get('foo') == b'bar'
 
     def test_set_raises_wrong_ex(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.set('foo', 'bar', ex=-100)
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.set('foo', 'bar', ex=0)
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     def test_set_using_timedelta_raises_wrong_ex(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.set('foo', 'bar', ex=timedelta(seconds=-100))
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.set('foo', 'bar', ex=timedelta(seconds=0))
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     def test_set_raises_wrong_px(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.set('foo', 'bar', px=-100)
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.set('foo', 'bar', px=0)
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     def test_set_using_timedelta_raises_wrong_px(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.set('foo', 'bar', px=timedelta(milliseconds=-100))
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.set('foo', 'bar', px=timedelta(milliseconds=0))
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     def test_setex_raises_wrong_ex(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.setex('foo', -100, 'bar')
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.setex('foo', 0, 'bar')
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     def test_setex_using_timedelta_raises_wrong_ex(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.setex('foo', timedelta(seconds=-100), 'bar')
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.setex('foo', timedelta(seconds=-100), 'bar')
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     def test_setnx(self):
-        self.assertEqual(self.redis.setnx('foo', 'bar'), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
-        self.assertEqual(self.redis.setnx('foo', 'baz'), False)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.setnx('foo', 'bar') == True
+        assert self.redis.get('foo') == b'bar'
+        assert self.redis.setnx('foo', 'baz') == False
+        assert self.redis.get('foo') == b'bar'
 
     def test_set_nx(self):
-        self.assertEqual(self.redis.set('foo', 'bar', nx=True), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
-        self.assertEqual(self.redis.set('foo', 'bar', nx=True), None)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.set('foo', 'bar', nx=True) == True
+        assert self.redis.get('foo') == b'bar'
+        assert self.redis.set('foo', 'bar', nx=True) is None
+        assert self.redis.get('foo') == b'bar'
 
     def test_set_xx(self):
-        self.assertEqual(self.redis.set('foo', 'bar', xx=True), None)
+        assert self.redis.set('foo', 'bar', xx=True) is None
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.set('foo', 'bar', xx=True), True)
+        assert self.redis.set('foo', 'bar', xx=True) == True
 
     def test_del_operator(self):
         self.redis['foo'] = 'bar'
         del self.redis['foo']
-        self.assertEqual(self.redis.get('foo'), None)
+        assert self.redis.get('foo') is None
 
     def test_delete(self):
         self.redis['foo'] = 'bar'
-        self.assertEqual(self.redis.delete('foo'), True)
-        self.assertEqual(self.redis.get('foo'), None)
+        assert self.redis.delete('foo') == True
+        assert self.redis.get('foo') is None
 
     def test_echo(self):
-        self.assertEqual(self.redis.echo(b'hello'), b'hello')
-        self.assertEqual(self.redis.echo('hello'), b'hello')
+        assert self.redis.echo(b'hello') == b'hello'
+        assert self.redis.echo('hello') == b'hello'
 
     @pytest.mark.slow
     def test_delete_expire(self):
@@ -694,102 +672,91 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.delete("foo")
         self.redis.set("foo", "bar")
         sleep(2)
-        self.assertEqual(self.redis.get("foo"), b'bar')
+        assert self.redis.get("foo") == b'bar'
 
     def test_delete_multiple(self):
         self.redis['one'] = 'one'
         self.redis['two'] = 'two'
         self.redis['three'] = 'three'
         # Since redis>=2.7.6 returns number of deleted items.
-        self.assertEqual(self.redis.delete('one', 'two'), 2)
-        self.assertEqual(self.redis.get('one'), None)
-        self.assertEqual(self.redis.get('two'), None)
-        self.assertEqual(self.redis.get('three'), b'three')
-        self.assertEqual(self.redis.delete('one', 'two'), 0)
+        assert self.redis.delete('one', 'two') == 2
+        assert self.redis.get('one') is None
+        assert self.redis.get('two') is None
+        assert self.redis.get('three') == b'three'
+        assert self.redis.delete('one', 'two') == 0
         # If any keys are deleted, True is returned.
-        self.assertEqual(self.redis.delete('two', 'three', 'three'), 1)
-        self.assertEqual(self.redis.get('three'), None)
+        assert self.redis.delete('two', 'three', 'three') == 1
+        assert self.redis.get('three') is None
 
     def test_delete_nonexistent_key(self):
-        self.assertEqual(self.redis.delete('foo'), False)
+        assert self.redis.delete('foo') == False
 
     # Tests for the list type.
 
     @redis2_only
     def test_rpush_then_lrange_with_nested_list1(self):
-        self.assertEqual(self.redis.rpush('foo', [12345, 6789]), 1)
-        self.assertEqual(self.redis.rpush('foo', [54321, 9876]), 2)
-        self.assertEqual(self.redis.lrange(
-            'foo', 0, -1), [b'[12345, 6789]', b'[54321, 9876]'])
+        assert self.redis.rpush('foo', [12345, 6789]) == 1
+        assert self.redis.rpush('foo', [54321, 9876]) == 2
+        assert self.redis.lrange('foo', 0, -1) == [b'[12345, 6789]', b'[54321, 9876]']
 
     @redis2_only
     def test_rpush_then_lrange_with_nested_list2(self):
-        self.assertEqual(self.redis.rpush('foo', [12345, 'banana']), 1)
-        self.assertEqual(self.redis.rpush('foo', [54321, 'elephant']), 2)
-        self.assertEqual(self.redis.lrange(
-            'foo', 0, -1),
-            [b'[12345, \'banana\']', b'[54321, \'elephant\']'])
+        assert self.redis.rpush('foo', [12345, 'banana']) == 1
+        assert self.redis.rpush('foo', [54321, 'elephant']) == 2
+        assert self.redis.lrange('foo', 0, -1), [b'[12345, \'banana\']', b'[54321, \'elephant\']']
 
     @redis2_only
     def test_rpush_then_lrange_with_nested_list3(self):
-        self.assertEqual(self.redis.rpush('foo', [12345, []]), 1)
-        self.assertEqual(self.redis.rpush('foo', [54321, []]), 2)
-
-        self.assertEqual(self.redis.lrange(
-            'foo', 0, -1), [b'[12345, []]', b'[54321, []]'])
+        assert self.redis.rpush('foo', [12345, []]) == 1
+        assert self.redis.rpush('foo', [54321, []]) == 2
+        assert self.redis.lrange('foo', 0, -1) == [b'[12345, []]', b'[54321, []]']
 
     def test_lpush_then_lrange_all(self):
-        self.assertEqual(self.redis.lpush('foo', 'bar'), 1)
-        self.assertEqual(self.redis.lpush('foo', 'baz'), 2)
-        self.assertEqual(self.redis.lpush('foo', 'bam', 'buzz'), 4)
-        self.assertEqual(self.redis.lrange('foo', 0, -1),
-                         [b'buzz', b'bam', b'baz', b'bar'])
+        assert self.redis.lpush('foo', 'bar') == 1
+        assert self.redis.lpush('foo', 'baz') == 2
+        assert self.redis.lpush('foo', 'bam', 'buzz') == 4
+        assert self.redis.lrange('foo', 0, -1) == [b'buzz', b'bam', b'baz', b'bar']
 
     def test_lpush_then_lrange_portion(self):
         self.redis.lpush('foo', 'one')
         self.redis.lpush('foo', 'two')
         self.redis.lpush('foo', 'three')
         self.redis.lpush('foo', 'four')
-        self.assertEqual(self.redis.lrange('foo', 0, 2),
-                         [b'four', b'three', b'two'])
-        self.assertEqual(self.redis.lrange('foo', 0, 3),
-                         [b'four', b'three', b'two', b'one'])
+        assert self.redis.lrange('foo', 0, 2) == [b'four', b'three', b'two']
+        assert self.redis.lrange('foo', 0, 3) == [b'four', b'three', b'two', b'one']
 
     def test_lrange_negative_indices(self):
         self.redis.rpush('foo', 'a', 'b', 'c')
-        self.assertEqual(self.redis.lrange('foo', -1, -2), [])
-        self.assertEqual(self.redis.lrange('foo', -2, -1),
-                         [b'b', b'c'])
+        assert self.redis.lrange('foo', -1, -2) == []
+        assert self.redis.lrange('foo', -2, -1) == [b'b', b'c']
 
     def test_lpush_key_does_not_exist(self):
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [])
+        assert self.redis.lrange('foo', 0, -1) == []
 
     def test_lpush_with_nonstr_key(self):
         self.redis.lpush(1, 'one')
         self.redis.lpush(1, 'two')
         self.redis.lpush(1, 'three')
-        self.assertEqual(self.redis.lrange(1, 0, 2),
-                         [b'three', b'two', b'one'])
-        self.assertEqual(self.redis.lrange('1', 0, 2),
-                         [b'three', b'two', b'one'])
+        assert self.redis.lrange(1, 0, 2) == [b'three', b'two', b'one']
+        assert self.redis.lrange('1', 0, 2) == [b'three', b'two', b'one']
 
     def test_lpush_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.lpush('foo', 'element')
 
     def test_llen(self):
         self.redis.lpush('foo', 'one')
         self.redis.lpush('foo', 'two')
         self.redis.lpush('foo', 'three')
-        self.assertEqual(self.redis.llen('foo'), 3)
+        assert self.redis.llen('foo') == 3
 
     def test_llen_no_exist(self):
-        self.assertEqual(self.redis.llen('foo'), 0)
+        assert self.redis.llen('foo') == 0
 
     def test_llen_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.llen('foo')
 
     def test_lrem_positive_count(self):
@@ -797,7 +764,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.lpush('foo', 'same')
         self.redis.lpush('foo', 'different')
         self.redis.lrem('foo', 2, 'same')
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [b'different'])
+        assert self.redis.lrange('foo', 0, -1) == [b'different']
 
     def test_lrem_negative_count(self):
         self.redis.lpush('foo', 'removeme')
@@ -808,22 +775,21 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.lrem('foo', -1, 'removeme')
         # Should remove it from the end of the list,
         # leaving the 'removeme' from the front of the list alone.
-        self.assertEqual(self.redis.lrange('foo', 0, -1),
-                         [b'removeme', b'one', b'two', b'three'])
+        assert self.redis.lrange('foo', 0, -1) == [b'removeme', b'one', b'two', b'three']
 
     def test_lrem_zero_count(self):
         self.redis.lpush('foo', 'one')
         self.redis.lpush('foo', 'one')
         self.redis.lpush('foo', 'one')
         self.redis.lrem('foo', 0, 'one')
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [])
+        assert self.redis.lrange('foo', 0, -1) == []
 
     def test_lrem_default_value(self):
         self.redis.lpush('foo', 'one')
         self.redis.lpush('foo', 'one')
         self.redis.lpush('foo', 'one')
         self.redis.lrem('foo', 0, 'one')
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [])
+        assert self.redis.lrange('foo', 0, -1) == []
 
     def test_lrem_does_not_exist(self):
         self.redis.lpush('foo', 'one')
@@ -835,12 +801,12 @@ class TestFakeStrictRedis(unittest.TestCase):
     def test_lrem_return_value(self):
         self.redis.lpush('foo', 'one')
         count = self.redis.lrem('foo', 0, 'one')
-        self.assertEqual(count, 1)
-        self.assertEqual(self.redis.lrem('foo', 0, 'one'), 0)
+        assert count == 1
+        assert self.redis.lrem('foo', 0, 'one') == 0
 
     def test_lrem_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.lrem('foo', 0, 'element')
 
     def test_rpush(self):
@@ -848,33 +814,32 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.rpush('foo', 'two')
         self.redis.rpush('foo', 'three')
         self.redis.rpush('foo', 'four', 'five')
-        self.assertEqual(self.redis.lrange('foo', 0, -1),
-                         [b'one', b'two', b'three', b'four', b'five'])
+        assert self.redis.lrange('foo', 0, -1) == [b'one', b'two', b'three', b'four', b'five']
 
     def test_rpush_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.rpush('foo', 'element')
 
     def test_lpop(self):
-        self.assertEqual(self.redis.rpush('foo', 'one'), 1)
-        self.assertEqual(self.redis.rpush('foo', 'two'), 2)
-        self.assertEqual(self.redis.rpush('foo', 'three'), 3)
-        self.assertEqual(self.redis.lpop('foo'), b'one')
-        self.assertEqual(self.redis.lpop('foo'), b'two')
-        self.assertEqual(self.redis.lpop('foo'), b'three')
+        assert self.redis.rpush('foo', 'one') == 1
+        assert self.redis.rpush('foo', 'two') == 2
+        assert self.redis.rpush('foo', 'three') == 3
+        assert self.redis.lpop('foo') == b'one'
+        assert self.redis.lpop('foo') == b'two'
+        assert self.redis.lpop('foo') == b'three'
 
     def test_lpop_empty_list(self):
         self.redis.rpush('foo', 'one')
         self.redis.lpop('foo')
-        self.assertEqual(self.redis.lpop('foo'), None)
+        assert self.redis.lpop('foo') is None
         # Verify what happens if we try to pop from a key
         # we've never seen before.
-        self.assertEqual(self.redis.lpop('noexists'), None)
+        assert self.redis.lpop('noexists') is None
 
     def test_lpop_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.lpop('foo')
 
     def test_lset(self):
@@ -883,29 +848,28 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.rpush('foo', 'three')
         self.redis.lset('foo', 0, 'four')
         self.redis.lset('foo', -2, 'five')
-        self.assertEqual(self.redis.lrange('foo', 0, -1),
-                         [b'four', b'five', b'three'])
+        assert self.redis.lrange('foo', 0, -1) == [b'four', b'five', b'three']
 
     def test_lset_index_out_of_range(self):
         self.redis.rpush('foo', 'one')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.lset('foo', 3, 'three')
 
     def test_lset_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.lset('foo', 0, 'element')
 
     def test_rpushx(self):
         self.redis.rpush('foo', 'one')
         self.redis.rpushx('foo', 'two')
         self.redis.rpushx('bar', 'three')
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [b'one', b'two'])
-        self.assertEqual(self.redis.lrange('bar', 0, -1), [])
+        assert self.redis.lrange('foo', 0, -1) == [b'one', b'two']
+        assert self.redis.lrange('bar', 0, -1) == []
 
     def test_rpushx_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.rpushx('foo', 'element')
 
     def test_ltrim(self):
@@ -914,167 +878,155 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.rpush('foo', 'three')
         self.redis.rpush('foo', 'four')
 
-        self.assertTrue(self.redis.ltrim('foo', 1, 3))
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [b'two', b'three',
-                                                           b'four'])
-        self.assertTrue(self.redis.ltrim('foo', 1, -1))
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [b'three', b'four'])
+        assert self.redis.ltrim('foo', 1, 3)
+        assert self.redis.lrange('foo', 0, -1) == [b'two', b'three', b'four']
+        assert self.redis.ltrim('foo', 1, -1)
+        assert self.redis.lrange('foo', 0, -1) == [b'three', b'four']
 
     def test_ltrim_with_non_existent_key(self):
-        self.assertTrue(self.redis.ltrim('foo', 0, -1))
+        assert self.redis.ltrim('foo', 0, -1)
 
     def test_ltrim_expiry(self):
         self.redis.rpush('foo', 'one', 'two', 'three')
         self.redis.expire('foo', 10)
         self.redis.ltrim('foo', 1, 2)
-        self.assertGreater(self.redis.ttl('foo'), 0)
+        assert self.redis.ttl('foo') > 0
 
     def test_ltrim_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.ltrim('foo', 1, -1)
 
     def test_lindex(self):
         self.redis.rpush('foo', 'one')
         self.redis.rpush('foo', 'two')
-        self.assertEqual(self.redis.lindex('foo', 0), b'one')
-        self.assertEqual(self.redis.lindex('foo', 4), None)
-        self.assertEqual(self.redis.lindex('bar', 4), None)
+        assert self.redis.lindex('foo', 0) == b'one'
+        assert self.redis.lindex('foo', 4) is None
+        assert self.redis.lindex('bar', 4) is None
 
     def test_lindex_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.lindex('foo', 0)
 
     def test_lpushx(self):
         self.redis.lpush('foo', 'two')
         self.redis.lpushx('foo', 'one')
         self.redis.lpushx('bar', 'one')
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [b'one', b'two'])
-        self.assertEqual(self.redis.lrange('bar', 0, -1), [])
+        assert self.redis.lrange('foo', 0, -1) == [b'one', b'two']
+        assert self.redis.lrange('bar', 0, -1) == []
 
     def test_lpushx_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.lpushx('foo', 'element')
 
     def test_rpop(self):
-        self.assertEqual(self.redis.rpop('foo'), None)
+        assert self.redis.rpop('foo') is None
         self.redis.rpush('foo', 'one')
         self.redis.rpush('foo', 'two')
-        self.assertEqual(self.redis.rpop('foo'), b'two')
-        self.assertEqual(self.redis.rpop('foo'), b'one')
-        self.assertEqual(self.redis.rpop('foo'), None)
+        assert self.redis.rpop('foo') == b'two'
+        assert self.redis.rpop('foo') == b'one'
+        assert self.redis.rpop('foo') is None
 
     def test_rpop_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.rpop('foo')
 
     def test_linsert_before(self):
         self.redis.rpush('foo', 'hello')
         self.redis.rpush('foo', 'world')
-        self.assertEqual(self.redis.linsert('foo', 'before', 'world', 'there'),
-                         3)
-        self.assertEqual(self.redis.lrange('foo', 0, -1),
-                         [b'hello', b'there', b'world'])
+        assert self.redis.linsert('foo', 'before', 'world', 'there') == 3
+        assert self.redis.lrange('foo', 0, -1) == [b'hello', b'there', b'world']
 
     def test_linsert_after(self):
         self.redis.rpush('foo', 'hello')
         self.redis.rpush('foo', 'world')
-        self.assertEqual(self.redis.linsert('foo', 'after', 'hello', 'there'),
-                         3)
-        self.assertEqual(self.redis.lrange('foo', 0, -1),
-                         [b'hello', b'there', b'world'])
+        assert self.redis.linsert('foo', 'after', 'hello', 'there') == 3
+        assert self.redis.lrange('foo', 0, -1) == [b'hello', b'there', b'world']
 
     def test_linsert_no_pivot(self):
         self.redis.rpush('foo', 'hello')
         self.redis.rpush('foo', 'world')
-        self.assertEqual(self.redis.linsert('foo', 'after', 'goodbye', 'bar'),
-                         -1)
-        self.assertEqual(self.redis.lrange('foo', 0, -1),
-                         [b'hello', b'world'])
+        assert self.redis.linsert('foo', 'after', 'goodbye', 'bar') == -1
+        assert self.redis.lrange('foo', 0, -1) == [b'hello', b'world']
 
     def test_linsert_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.linsert('foo', 'after', 'bar', 'element')
 
     def test_rpoplpush(self):
-        self.assertEqual(self.redis.rpoplpush('foo', 'bar'), None)
-        self.assertEqual(self.redis.lpop('bar'), None)
+        assert self.redis.rpoplpush('foo', 'bar') is None
+        assert self.redis.lpop('bar') is None
         self.redis.rpush('foo', 'one')
         self.redis.rpush('foo', 'two')
         self.redis.rpush('bar', 'one')
 
-        self.assertEqual(self.redis.rpoplpush('foo', 'bar'), b'two')
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [b'one'])
-        self.assertEqual(self.redis.lrange('bar', 0, -1), [b'two', b'one'])
+        assert self.redis.rpoplpush('foo', 'bar') == b'two'
+        assert self.redis.lrange('foo', 0, -1) == [b'one']
+        assert self.redis.lrange('bar', 0, -1) == [b'two', b'one']
 
         # Catch instances where we store bytes and strings inconsistently
         # and thus bar = ['two', b'one']
-        self.assertEqual(self.redis.lrem('bar', -1, 'two'), 1)
+        assert self.redis.lrem('bar', -1, 'two') == 1
 
     def test_rpoplpush_to_nonexistent_destination(self):
         self.redis.rpush('foo', 'one')
-        self.assertEqual(self.redis.rpoplpush('foo', 'bar'), b'one')
-        self.assertEqual(self.redis.rpop('bar'), b'one')
+        assert self.redis.rpoplpush('foo', 'bar') == b'one'
+        assert self.redis.rpop('bar') == b'one'
 
     def test_rpoplpush_expiry(self):
         self.redis.rpush('foo', 'one')
         self.redis.rpush('bar', 'two')
         self.redis.expire('bar', 10)
         self.redis.rpoplpush('foo', 'bar')
-        self.assertGreater(self.redis.ttl('bar'), 0)
+        assert self.redis.ttl('bar') > 0
 
     def test_rpoplpush_one_to_self(self):
         self.redis.rpush('list', 'element')
-        self.assertEqual(self.redis.brpoplpush('list', 'list'), b'element')
-        self.assertEqual(self.redis.lrange('list', 0, -1), [b'element'])
+        assert self.redis.brpoplpush('list', 'list') == b'element'
+        assert self.redis.lrange('list', 0, -1) == [b'element']
 
     def test_rpoplpush_wrong_type(self):
         self.redis.set('foo', 'bar')
         self.redis.rpush('list', 'element')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.rpoplpush('foo', 'list')
-        self.assertEqual(self.redis.get('foo'), b'bar')
-        self.assertEqual(self.redis.lrange('list', 0, -1), [b'element'])
-        with self.assertRaises(redis.ResponseError):
+        assert self.redis.get('foo') == b'bar'
+        assert self.redis.lrange('list', 0, -1) == [b'element']
+        with pytest.raises(redis.ResponseError):
             self.redis.rpoplpush('list', 'foo')
-        self.assertEqual(self.redis.get('foo'), b'bar')
-        self.assertEqual(self.redis.lrange('list', 0, -1), [b'element'])
+        assert self.redis.get('foo') == b'bar'
+        assert self.redis.lrange('list', 0, -1) == [b'element']
 
     def test_blpop_single_list(self):
         self.redis.rpush('foo', 'one')
         self.redis.rpush('foo', 'two')
         self.redis.rpush('foo', 'three')
-        self.assertEqual(self.redis.blpop(['foo'], timeout=1),
-                         (b'foo', b'one'))
+        assert self.redis.blpop(['foo'], timeout=1) == (b'foo', b'one')
 
     def test_blpop_test_multiple_lists(self):
         self.redis.rpush('baz', 'zero')
-        self.assertEqual(self.redis.blpop(['foo', 'baz'], timeout=1),
-                         (b'baz', b'zero'))
-        self.assertFalse(self.redis.exists('baz'))
+        assert self.redis.blpop(['foo', 'baz'], timeout=1) == (b'baz', b'zero')
+        assert not self.redis.exists('baz')
 
         self.redis.rpush('foo', 'one')
         self.redis.rpush('foo', 'two')
         # bar has nothing, so the returned value should come
         # from foo.
-        self.assertEqual(self.redis.blpop(['bar', 'foo'], timeout=1),
-                         (b'foo', b'one'))
+        assert self.redis.blpop(['bar', 'foo'], timeout=1) == (b'foo', b'one')
         self.redis.rpush('bar', 'three')
         # bar now has something, so the returned value should come
         # from bar.
-        self.assertEqual(self.redis.blpop(['bar', 'foo'], timeout=1),
-                         (b'bar', b'three'))
-        self.assertEqual(self.redis.blpop(['bar', 'foo'], timeout=1),
-                         (b'foo', b'two'))
+        assert self.redis.blpop(['bar', 'foo'], timeout=1) == (b'bar', b'three')
+        assert self.redis.blpop(['bar', 'foo'], timeout=1) == (b'foo', b'two')
 
     def test_blpop_allow_single_key(self):
         # blpop converts single key arguments to a one element list.
         self.redis.rpush('foo', 'one')
-        self.assertEqual(self.redis.blpop('foo', timeout=1), (b'foo', b'one'))
+        assert self.redis.blpop('foo', timeout=1) == (b'foo', b'one')
 
     @pytest.mark.slow
     def test_blpop_block(self):
@@ -1089,14 +1041,14 @@ class TestFakeStrictRedis(unittest.TestCase):
         thread = threading.Thread(target=push_thread)
         thread.start()
         try:
-            self.assertEqual(self.redis.blpop('foo'), (b'foo', b'value1'))
-            self.assertEqual(self.redis.blpop('foo', timeout=5), (b'foo', b'value2'))
+            assert self.redis.blpop('foo') == (b'foo', b'value1')
+            assert self.redis.blpop('foo', timeout=5) == (b'foo', b'value2')
         finally:
             thread.join()
 
     def test_blpop_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.blpop('foo', timeout=1)
 
     def test_blpop_transaction(self):
@@ -1105,30 +1057,26 @@ class TestFakeStrictRedis(unittest.TestCase):
         p.blpop('missing', timeout=1000)
         result = p.execute()
         # Blocking commands behave like non-blocking versions in transactions
-        self.assertEqual(result, [None])
+        assert result == [None]
 
     def test_eval_blpop(self):
         self.redis.rpush('foo', 'bar')
-        with self.assertRaises(redis.ResponseError) as cm:
+        with pytest.raises(redis.ResponseError, match='not allowed from scripts'):
             self.redis.eval('return redis.pcall("BLPOP", KEYS[1], 1)', 1, 'foo')
-        self.assertIn('not allowed from scripts', str(cm.exception))
 
     def test_brpop_test_multiple_lists(self):
         self.redis.rpush('baz', 'zero')
-        self.assertEqual(self.redis.brpop(['foo', 'baz'], timeout=1),
-                         (b'baz', b'zero'))
-        self.assertFalse(self.redis.exists('baz'))
+        assert self.redis.brpop(['foo', 'baz'], timeout=1) == (b'baz', b'zero')
+        assert not self.redis.exists('baz')
 
         self.redis.rpush('foo', 'one')
         self.redis.rpush('foo', 'two')
-        self.assertEqual(self.redis.brpop(['bar', 'foo'], timeout=1),
-                         (b'foo', b'two'))
+        assert self.redis.brpop(['bar', 'foo'], timeout=1) == (b'foo', b'two')
 
     def test_brpop_single_key(self):
         self.redis.rpush('foo', 'one')
         self.redis.rpush('foo', 'two')
-        self.assertEqual(self.redis.brpop('foo', timeout=1),
-                         (b'foo', b'two'))
+        assert self.redis.brpop('foo', timeout=1) == (b'foo', b'two')
 
     @pytest.mark.slow
     def test_brpop_block(self):
@@ -1143,143 +1091,140 @@ class TestFakeStrictRedis(unittest.TestCase):
         thread = threading.Thread(target=push_thread)
         thread.start()
         try:
-            self.assertEqual(self.redis.brpop('foo'), (b'foo', b'value1'))
-            self.assertEqual(self.redis.brpop('foo', timeout=5), (b'foo', b'value2'))
+            assert self.redis.brpop('foo') == (b'foo', b'value1')
+            assert self.redis.brpop('foo', timeout=5) == (b'foo', b'value2')
         finally:
             thread.join()
 
     def test_brpop_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.brpop('foo', timeout=1)
 
     def test_brpoplpush_multi_keys(self):
-        self.assertEqual(self.redis.lpop('bar'), None)
+        assert self.redis.lpop('bar') is None
         self.redis.rpush('foo', 'one')
         self.redis.rpush('foo', 'two')
-        self.assertEqual(self.redis.brpoplpush('foo', 'bar', timeout=1),
-                         b'two')
-        self.assertEqual(self.redis.lrange('bar', 0, -1), [b'two'])
+        assert self.redis.brpoplpush('foo', 'bar', timeout=1) == b'two'
+        assert self.redis.lrange('bar', 0, -1) == [b'two']
 
         # Catch instances where we store bytes and strings inconsistently
         # and thus bar = ['two']
-        self.assertEqual(self.redis.lrem('bar', -1, 'two'), 1)
+        assert self.redis.lrem('bar', -1, 'two') == 1
 
     def test_brpoplpush_wrong_type(self):
         self.redis.set('foo', 'bar')
         self.redis.rpush('list', 'element')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.brpoplpush('foo', 'list')
-        self.assertEqual(self.redis.get('foo'), b'bar')
-        self.assertEqual(self.redis.lrange('list', 0, -1), [b'element'])
-        with self.assertRaises(redis.ResponseError):
+        assert self.redis.get('foo') == b'bar'
+        assert self.redis.lrange('list', 0, -1) == [b'element']
+        with pytest.raises(redis.ResponseError):
             self.redis.brpoplpush('list', 'foo')
-        self.assertEqual(self.redis.get('foo'), b'bar')
-        self.assertEqual(self.redis.lrange('list', 0, -1), [b'element'])
+        assert self.redis.get('foo') == b'bar'
+        assert self.redis.lrange('list', 0, -1) == [b'element']
 
     @pytest.mark.slow
     def test_blocking_operations_when_empty(self):
-        self.assertEqual(self.redis.blpop(['foo'], timeout=1),
-                         None)
-        self.assertEqual(self.redis.blpop(['bar', 'foo'], timeout=1),
-                         None)
-        self.assertEqual(self.redis.brpop('foo', timeout=1),
-                         None)
-        self.assertEqual(self.redis.brpoplpush('foo', 'bar', timeout=1),
-                         None)
+        assert self.redis.blpop(['foo'], timeout=1) is None
+        assert self.redis.blpop(['bar', 'foo'], timeout=1) is None
+        assert self.redis.brpop('foo', timeout=1) is None
+        assert self.redis.brpoplpush('foo', 'bar', timeout=1) is None
 
     def test_empty_list(self):
         self.redis.rpush('foo', 'bar')
         self.redis.rpop('foo')
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     # Tests for the hash type.
 
     def test_hstrlen_missing(self):
-        self.assertEqual(self.redis.hstrlen('foo', 'doesnotexist'), 0)
+        assert self.redis.hstrlen('foo', 'doesnotexist') == 0
 
         self.redis.hset('foo', 'key', 'value')
-        self.assertEqual(self.redis.hstrlen('foo', 'doesnotexist'), 0)
+        assert self.redis.hstrlen('foo', 'doesnotexist') == 0
 
     def test_hstrlen(self):
         self.redis.hset('foo', 'key', 'value')
-        self.assertEqual(self.redis.hstrlen('foo', 'key'), 5)
+        assert self.redis.hstrlen('foo', 'key') == 5
 
     def test_hset_then_hget(self):
-        self.assertEqual(self.redis.hset('foo', 'key', 'value'), 1)
-        self.assertEqual(self.redis.hget('foo', 'key'), b'value')
+        assert self.redis.hset('foo', 'key', 'value') == 1
+        assert self.redis.hget('foo', 'key') == b'value'
 
     def test_hset_update(self):
-        self.assertEqual(self.redis.hset('foo', 'key', 'value'), 1)
-        self.assertEqual(self.redis.hset('foo', 'key', 'value'), 0)
+        assert self.redis.hset('foo', 'key', 'value') == 1
+        assert self.redis.hset('foo', 'key', 'value') == 0
 
     def test_hset_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hset('foo', 'key', 'value')
 
     def test_hgetall(self):
-        self.assertEqual(self.redis.hset('foo', 'k1', 'v1'), 1)
-        self.assertEqual(self.redis.hset('foo', 'k2', 'v2'), 1)
-        self.assertEqual(self.redis.hset('foo', 'k3', 'v3'), 1)
-        self.assertEqual(self.redis.hgetall('foo'), {b'k1': b'v1',
-                                                     b'k2': b'v2',
-                                                     b'k3': b'v3'})
+        assert self.redis.hset('foo', 'k1', 'v1') == 1
+        assert self.redis.hset('foo', 'k2', 'v2') == 1
+        assert self.redis.hset('foo', 'k3', 'v3') == 1
+        assert self.redis.hgetall('foo') == {
+            b'k1': b'v1',
+            b'k2': b'v2',
+            b'k3': b'v3'
+        }
 
     @redis2_only
     def test_hgetall_with_tuples(self):
-        self.assertEqual(self.redis.hset('foo', (1, 2), (1, 2, 3)), 1)
-        self.assertEqual(self.redis.hgetall('foo'), {b'(1, 2)': b'(1, 2, 3)'})
+        assert self.redis.hset('foo', (1, 2), (1, 2, 3)) == 1
+        assert self.redis.hgetall('foo') == {b'(1, 2)': b'(1, 2, 3)'}
 
     def test_hgetall_empty_key(self):
-        self.assertEqual(self.redis.hgetall('foo'), {})
+        assert self.redis.hgetall('foo') == {}
 
     def test_hgetall_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hgetall('foo')
 
     def test_hexists(self):
         self.redis.hset('foo', 'bar', 'v1')
-        self.assertEqual(self.redis.hexists('foo', 'bar'), 1)
-        self.assertEqual(self.redis.hexists('foo', 'baz'), 0)
-        self.assertEqual(self.redis.hexists('bar', 'bar'), 0)
+        assert self.redis.hexists('foo', 'bar') == 1
+        assert self.redis.hexists('foo', 'baz') == 0
+        assert self.redis.hexists('bar', 'bar') == 0
 
     def test_hexists_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hexists('foo', 'key')
 
     def test_hkeys(self):
         self.redis.hset('foo', 'k1', 'v1')
         self.redis.hset('foo', 'k2', 'v2')
-        self.assertEqual(set(self.redis.hkeys('foo')), {b'k1', b'k2'})
-        self.assertEqual(set(self.redis.hkeys('bar')), set())
+        assert set(self.redis.hkeys('foo')) == {b'k1', b'k2'}
+        assert set(self.redis.hkeys('bar')) == set()
 
     def test_hkeys_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hkeys('foo')
 
     def test_hlen(self):
         self.redis.hset('foo', 'k1', 'v1')
         self.redis.hset('foo', 'k2', 'v2')
-        self.assertEqual(self.redis.hlen('foo'), 2)
+        assert self.redis.hlen('foo') == 2
 
     def test_hlen_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hlen('foo')
 
     def test_hvals(self):
         self.redis.hset('foo', 'k1', 'v1')
         self.redis.hset('foo', 'k2', 'v2')
-        self.assertEqual(set(self.redis.hvals('foo')), {b'v1', b'v2'})
-        self.assertEqual(set(self.redis.hvals('bar')), set())
+        assert set(self.redis.hvals('foo')) == {b'v1', b'v2'}
+        assert set(self.redis.hvals('bar')) == set()
 
     def test_hvals_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hvals('foo')
 
     def test_hmget(self):
@@ -1287,221 +1232,201 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.hset('foo', 'k2', 'v2')
         self.redis.hset('foo', 'k3', 'v3')
         # Normal case.
-        self.assertEqual(self.redis.hmget('foo', ['k1', 'k3']), [b'v1', b'v3'])
-        self.assertEqual(self.redis.hmget('foo', 'k1', 'k3'), [b'v1', b'v3'])
+        assert self.redis.hmget('foo', ['k1', 'k3']) == [b'v1', b'v3']
+        assert self.redis.hmget('foo', 'k1', 'k3') == [b'v1', b'v3']
         # Key does not exist.
-        self.assertEqual(self.redis.hmget('bar', ['k1', 'k3']), [None, None])
-        self.assertEqual(self.redis.hmget('bar', 'k1', 'k3'), [None, None])
+        assert self.redis.hmget('bar', ['k1', 'k3']) == [None, None]
+        assert self.redis.hmget('bar', 'k1', 'k3') == [None, None]
         # Some keys in the hash do not exist.
-        self.assertEqual(self.redis.hmget('foo', ['k1', 'k500']),
-                         [b'v1', None])
-        self.assertEqual(self.redis.hmget('foo', 'k1', 'k500'),
-                         [b'v1', None])
+        assert self.redis.hmget('foo', ['k1', 'k500']) == [b'v1', None]
+        assert self.redis.hmget('foo', 'k1', 'k500') == [b'v1', None]
 
     def test_hmget_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hmget('foo', 'key1', 'key2')
 
     def test_hdel(self):
         self.redis.hset('foo', 'k1', 'v1')
         self.redis.hset('foo', 'k2', 'v2')
         self.redis.hset('foo', 'k3', 'v3')
-        self.assertEqual(self.redis.hget('foo', 'k1'), b'v1')
-        self.assertEqual(self.redis.hdel('foo', 'k1'), True)
-        self.assertEqual(self.redis.hget('foo', 'k1'), None)
-        self.assertEqual(self.redis.hdel('foo', 'k1'), False)
+        assert self.redis.hget('foo', 'k1') == b'v1'
+        assert self.redis.hdel('foo', 'k1') == True
+        assert self.redis.hget('foo', 'k1') is None
+        assert self.redis.hdel('foo', 'k1') == False
         # Since redis>=2.7.6 returns number of deleted items.
-        self.assertEqual(self.redis.hdel('foo', 'k2', 'k3'), 2)
-        self.assertEqual(self.redis.hget('foo', 'k2'), None)
-        self.assertEqual(self.redis.hget('foo', 'k3'), None)
-        self.assertEqual(self.redis.hdel('foo', 'k2', 'k3'), False)
+        assert self.redis.hdel('foo', 'k2', 'k3') == 2
+        assert self.redis.hget('foo', 'k2') is None
+        assert self.redis.hget('foo', 'k3') is None
+        assert self.redis.hdel('foo', 'k2', 'k3') == False
 
     def test_hdel_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hdel('foo', 'key')
 
     def test_hincrby(self):
         self.redis.hset('foo', 'counter', 0)
-        self.assertEqual(self.redis.hincrby('foo', 'counter'), 1)
-        self.assertEqual(self.redis.hincrby('foo', 'counter'), 2)
-        self.assertEqual(self.redis.hincrby('foo', 'counter'), 3)
+        assert self.redis.hincrby('foo', 'counter') == 1
+        assert self.redis.hincrby('foo', 'counter') == 2
+        assert self.redis.hincrby('foo', 'counter') == 3
 
     def test_hincrby_with_no_starting_value(self):
-        self.assertEqual(self.redis.hincrby('foo', 'counter'), 1)
-        self.assertEqual(self.redis.hincrby('foo', 'counter'), 2)
-        self.assertEqual(self.redis.hincrby('foo', 'counter'), 3)
+        assert self.redis.hincrby('foo', 'counter') == 1
+        assert self.redis.hincrby('foo', 'counter') == 2
+        assert self.redis.hincrby('foo', 'counter') == 3
 
     def test_hincrby_with_range_param(self):
-        self.assertEqual(self.redis.hincrby('foo', 'counter', 2), 2)
-        self.assertEqual(self.redis.hincrby('foo', 'counter', 2), 4)
-        self.assertEqual(self.redis.hincrby('foo', 'counter', 2), 6)
+        assert self.redis.hincrby('foo', 'counter', 2) == 2
+        assert self.redis.hincrby('foo', 'counter', 2) == 4
+        assert self.redis.hincrby('foo', 'counter', 2) == 6
 
     def test_hincrby_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hincrby('foo', 'key', 2)
 
     def test_hincrbyfloat(self):
         self.redis.hset('foo', 'counter', 0.0)
-        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 1.0)
-        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 2.0)
-        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 3.0)
+        assert self.redis.hincrbyfloat('foo', 'counter') == 1.0
+        assert self.redis.hincrbyfloat('foo', 'counter') == 2.0
+        assert self.redis.hincrbyfloat('foo', 'counter') == 3.0
 
     def test_hincrbyfloat_with_no_starting_value(self):
-        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 1.0)
-        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 2.0)
-        self.assertEqual(self.redis.hincrbyfloat('foo', 'counter'), 3.0)
+        assert self.redis.hincrbyfloat('foo', 'counter') == 1.0
+        assert self.redis.hincrbyfloat('foo', 'counter') == 2.0
+        assert self.redis.hincrbyfloat('foo', 'counter') == 3.0
 
     def test_hincrbyfloat_with_range_param(self):
-        self.assertAlmostEqual(
-            self.redis.hincrbyfloat('foo', 'counter', 0.1), 0.1)
-        self.assertAlmostEqual(
-            self.redis.hincrbyfloat('foo', 'counter', 0.1), 0.2)
-        self.assertAlmostEqual(
-            self.redis.hincrbyfloat('foo', 'counter', 0.1), 0.3)
+        assert self.redis.hincrbyfloat('foo', 'counter', 0.1) == pytest.approx(0.1)
+        assert self.redis.hincrbyfloat('foo', 'counter', 0.1) == pytest.approx(0.2)
+        assert self.redis.hincrbyfloat('foo', 'counter', 0.1) == pytest.approx(0.3)
 
     def test_hincrbyfloat_on_non_float_value_raises_error(self):
         self.redis.hset('foo', 'counter', 'cat')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hincrbyfloat('foo', 'counter')
 
     def test_hincrbyfloat_with_non_float_amount_raises_error(self):
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hincrbyfloat('foo', 'counter', 'cat')
 
     def test_hincrbyfloat_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hincrbyfloat('foo', 'key', 0.1)
 
     def test_hincrbyfloat_precision(self):
         x = 1.23456789123456789
-        self.assertEqual(self.redis.hincrbyfloat('foo', 'bar', x), x)
-        self.assertEqual(float(self.redis.hget('foo', 'bar')), x)
+        assert self.redis.hincrbyfloat('foo', 'bar', x) == x
+        assert float(self.redis.hget('foo', 'bar')) == x
 
     def test_hsetnx(self):
-        self.assertEqual(self.redis.hsetnx('foo', 'newkey', 'v1'), True)
-        self.assertEqual(self.redis.hsetnx('foo', 'newkey', 'v1'), False)
-        self.assertEqual(self.redis.hget('foo', 'newkey'), b'v1')
+        assert self.redis.hsetnx('foo', 'newkey', 'v1') == True
+        assert self.redis.hsetnx('foo', 'newkey', 'v1') == False
+        assert self.redis.hget('foo', 'newkey') == b'v1'
 
     def test_hmsetset_empty_raises_error(self):
-        with self.assertRaises(redis.DataError):
+        with pytest.raises(redis.DataError):
             self.redis.hmset('foo', {})
 
     def test_hmsetset(self):
         self.redis.hset('foo', 'k1', 'v1')
-        self.assertEqual(self.redis.hmset('foo', {'k2': 'v2', 'k3': 'v3'}),
-                         True)
+        assert self.redis.hmset('foo', {'k2': 'v2', 'k3': 'v3'}) == True
 
     @redis2_only
     def test_hmset_convert_values(self):
         self.redis.hmset('foo', {'k1': True, 'k2': 1})
-        self.assertEqual(
-            self.redis.hgetall('foo'), {b'k1': b'True', b'k2': b'1'})
+        assert self.redis.hgetall('foo') == {b'k1': b'True', b'k2': b'1'}
 
     @redis2_only
     def test_hmset_does_not_mutate_input_params(self):
         original = {'key': [123, 456]}
         self.redis.hmset('foo', original)
-        self.assertEqual(original, {'key': [123, 456]})
+        assert original == {'key': [123, 456]}
 
     def test_hmset_wrong_type(self):
         self.zadd('foo', {'bar': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.hmset('foo', {'key': 'value'})
 
     def test_empty_hash(self):
         self.redis.hset('foo', 'bar', 'baz')
         self.redis.hdel('foo', 'bar')
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     def test_sadd(self):
-        self.assertEqual(self.redis.sadd('foo', 'member1'), 1)
-        self.assertEqual(self.redis.sadd('foo', 'member1'), 0)
-        self.assertEqual(self.redis.smembers('foo'), {b'member1'})
-        self.assertEqual(self.redis.sadd('foo', 'member2', 'member3'), 2)
-        self.assertEqual(self.redis.smembers('foo'),
-                         {b'member1', b'member2', b'member3'})
-        self.assertEqual(self.redis.sadd('foo', 'member3', 'member4'), 1)
-        self.assertEqual(self.redis.smembers('foo'),
-                         {b'member1', b'member2', b'member3', b'member4'})
+        assert self.redis.sadd('foo', 'member1') == 1
+        assert self.redis.sadd('foo', 'member1') == 0
+        assert self.redis.smembers('foo') == {b'member1'}
+        assert self.redis.sadd('foo', 'member2', 'member3') == 2
+        assert self.redis.smembers('foo') == {b'member1', b'member2', b'member3'}
+        assert self.redis.sadd('foo', 'member3', 'member4') == 1
+        assert self.redis.smembers('foo') == {b'member1', b'member2', b'member3', b'member4'}
 
     def test_sadd_as_str_type(self):
-        self.assertEqual(self.redis.sadd('foo', *range(3)), 3)
-        self.assertEqual(self.redis.smembers('foo'), {b'0', b'1', b'2'})
+        assert self.redis.sadd('foo', *range(3)) == 3
+        assert self.redis.smembers('foo') == {b'0', b'1', b'2'}
 
     def test_sadd_wrong_type(self):
         self.zadd('foo', {'member': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.sadd('foo', 'member2')
 
     def test_scan_single(self):
         self.redis.set('foo1', 'bar1')
-        self.assertEqual(self.redis.scan(match="foo*"), (0, [b'foo1']))
+        assert self.redis.scan(match="foo*") == (0, [b'foo1'])
 
     def test_scan_iter_single_page(self):
         self.redis.set('foo1', 'bar1')
         self.redis.set('foo2', 'bar2')
-        self.assertEqual(set(self.redis.scan_iter(match="foo*")),
-                         {b'foo1', b'foo2'})
-        self.assertEqual(set(self.redis.scan_iter()),
-                         {b'foo1', b'foo2'})
-        self.assertEqual(set(self.redis.scan_iter(match="")),
-                         set())
+        assert set(self.redis.scan_iter(match="foo*")) == {b'foo1', b'foo2'}
+        assert set(self.redis.scan_iter()) == {b'foo1', b'foo2'}
+        assert set(self.redis.scan_iter(match="")) == set()
 
     def test_scan_iter_multiple_pages(self):
         all_keys = key_val_dict(size=100)
-        self.assertTrue(
-            all(self.redis.set(k, v) for k, v in all_keys.items()))
-        self.assertEqual(
-            set(self.redis.scan_iter()),
-            set(all_keys))
+        assert all(self.redis.set(k, v) for k, v in all_keys.items())
+        assert set(self.redis.scan_iter()) == set(all_keys)
 
     def test_scan_iter_multiple_pages_with_match(self):
         all_keys = key_val_dict(size=100)
-        self.assertTrue(
-            all(self.redis.set(k, v) for k, v in all_keys.items()))
+        assert all(self.redis.set(k, v) for k, v in all_keys.items())
         # Now add a few keys that don't match the key:<number> pattern.
         self.redis.set('otherkey', 'foo')
         self.redis.set('andanother', 'bar')
         actual = set(self.redis.scan_iter(match='key:*'))
-        self.assertEqual(actual, set(all_keys))
+        assert actual == set(all_keys)
 
     def test_scan_multiple_pages_with_count_arg(self):
         all_keys = key_val_dict(size=100)
-        self.assertTrue(
-            all(self.redis.set(k, v) for k, v in all_keys.items()))
-        self.assertEqual(
-            set(self.redis.scan_iter(count=1000)),
-            set(all_keys))
+        assert all(self.redis.set(k, v) for k, v in all_keys.items())
+        assert set(self.redis.scan_iter(count=1000)) == set(all_keys)
 
     def test_scan_all_in_single_call(self):
         all_keys = key_val_dict(size=100)
-        self.assertTrue(
-            all(self.redis.set(k, v) for k, v in all_keys.items()))
+        assert all(self.redis.set(k, v) for k, v in all_keys.items())
         # Specify way more than the 100 keys we've added.
         actual = self.redis.scan(count=1000)
-        self.assertEqual(set(actual[1]), set(all_keys))
-        self.assertEqual(actual[0], 0)
+        assert set(actual[1]) == set(all_keys)
+        assert actual[0] == 0
 
     @pytest.mark.slow
     def test_scan_expired_key(self):
         self.redis.set('expiringkey', 'value')
         self.redis.pexpire('expiringkey', 1)
         sleep(1)
-        self.assertEqual(self.redis.scan()[1], [])
+        assert self.redis.scan()[1] == []
 
     def test_scard(self):
         self.redis.sadd('foo', 'member1')
         self.redis.sadd('foo', 'member2')
         self.redis.sadd('foo', 'member2')
-        self.assertEqual(self.redis.scard('foo'), 2)
+        assert self.redis.scard('foo') == 2
 
     def test_scard_wrong_type(self):
         self.zadd('foo', {'member': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.scard('foo')
 
     def test_sdiff(self):
@@ -1509,28 +1434,25 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.sadd('foo', 'member2')
         self.redis.sadd('bar', 'member2')
         self.redis.sadd('bar', 'member3')
-        self.assertEqual(self.redis.sdiff('foo', 'bar'), {b'member1'})
+        assert self.redis.sdiff('foo', 'bar') == {b'member1'}
         # Original sets shouldn't be modified.
-        self.assertEqual(self.redis.smembers('foo'),
-                         {b'member1', b'member2'})
-        self.assertEqual(self.redis.smembers('bar'),
-                         {b'member2', b'member3'})
+        assert self.redis.smembers('foo') == {b'member1', b'member2'}
+        assert self.redis.smembers('bar') == {b'member2', b'member3'}
 
     def test_sdiff_one_key(self):
         self.redis.sadd('foo', 'member1')
         self.redis.sadd('foo', 'member2')
-        self.assertEqual(self.redis.sdiff('foo'),
-                         {b'member1', b'member2'})
+        assert self.redis.sdiff('foo') == {b'member1', b'member2'}
 
     def test_sdiff_empty(self):
-        self.assertEqual(self.redis.sdiff('foo'), set())
+        assert self.redis.sdiff('foo') == set()
 
     def test_sdiff_wrong_type(self):
         self.zadd('foo', {'member': 1})
         self.redis.sadd('bar', 'member')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.sdiff('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.sdiff('bar', 'foo')
 
     def test_sdiffstore(self):
@@ -1538,38 +1460,37 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.sadd('foo', 'member2')
         self.redis.sadd('bar', 'member2')
         self.redis.sadd('bar', 'member3')
-        self.assertEqual(self.redis.sdiffstore('baz', 'foo', 'bar'), 1)
+        assert self.redis.sdiffstore('baz', 'foo', 'bar') == 1
 
         # Catch instances where we store bytes and strings inconsistently
         # and thus baz = {'member1', b'member1'}
         self.redis.sadd('baz', 'member1')
-        self.assertEqual(self.redis.scard('baz'), 1)
+        assert self.redis.scard('baz') == 1
 
     def test_setrange(self):
         self.redis.set('foo', 'test')
-        self.assertEqual(self.redis.setrange('foo', 1, 'aste'), 5)
-        self.assertEqual(self.redis.get('foo'), b'taste')
+        assert self.redis.setrange('foo', 1, 'aste') == 5
+        assert self.redis.get('foo') == b'taste'
 
         self.redis.set('foo', 'test')
-        self.assertEqual(self.redis.setrange('foo', 1, 'a'), 4)
-        self.assertEqual(self.redis.get('foo'), b'tast')
+        assert self.redis.setrange('foo', 1, 'a') == 4
+        assert self.redis.get('foo') == b'tast'
 
-        self.assertEqual(self.redis.setrange('bar', 2, 'test'), 6)
-        self.assertEqual(self.redis.get('bar'), b'\x00\x00test')
+        assert self.redis.setrange('bar', 2, 'test') == 6
+        assert self.redis.get('bar') == b'\x00\x00test'
 
     def test_setrange_expiry(self):
         self.redis.set('foo', 'test', ex=10)
         self.redis.setrange('foo', 1, 'aste')
-        self.assertGreater(self.redis.ttl('foo'), 0)
+        assert self.redis.ttl('foo') > 0
 
     def test_sinter(self):
         self.redis.sadd('foo', 'member1')
         self.redis.sadd('foo', 'member2')
         self.redis.sadd('bar', 'member2')
         self.redis.sadd('bar', 'member3')
-        self.assertEqual(self.redis.sinter('foo', 'bar'), {b'member2'})
-        self.assertEqual(self.redis.sinter('foo'),
-                         {b'member1', b'member2'})
+        assert self.redis.sinter('foo', 'bar') == {b'member2'}
+        assert self.redis.sinter('foo') == {b'member1', b'member2'}
 
     def test_sinter_bytes_keys(self):
         foo = os.urandom(10)
@@ -1578,15 +1499,15 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.sadd(foo, 'member2')
         self.redis.sadd(bar, 'member2')
         self.redis.sadd(bar, 'member3')
-        self.assertEqual(self.redis.sinter(foo, bar), {b'member2'})
-        self.assertEqual(self.redis.sinter(foo), {b'member1', b'member2'})
+        assert self.redis.sinter(foo, bar) == {b'member2'}
+        assert self.redis.sinter(foo) == {b'member1', b'member2'}
 
     def test_sinter_wrong_type(self):
         self.zadd('foo', {'member': 1})
         self.redis.sadd('bar', 'member')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.sinter('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.sinter('bar', 'foo')
 
     def test_sinterstore(self):
@@ -1594,35 +1515,35 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.sadd('foo', 'member2')
         self.redis.sadd('bar', 'member2')
         self.redis.sadd('bar', 'member3')
-        self.assertEqual(self.redis.sinterstore('baz', 'foo', 'bar'), 1)
+        assert self.redis.sinterstore('baz', 'foo', 'bar') == 1
 
         # Catch instances where we store bytes and strings inconsistently
         # and thus baz = {'member2', b'member2'}
         self.redis.sadd('baz', 'member2')
-        self.assertEqual(self.redis.scard('baz'), 1)
+        assert self.redis.scard('baz') == 1
 
     def test_sismember(self):
-        self.assertEqual(self.redis.sismember('foo', 'member1'), False)
+        assert self.redis.sismember('foo', 'member1') == False
         self.redis.sadd('foo', 'member1')
-        self.assertEqual(self.redis.sismember('foo', 'member1'), True)
+        assert self.redis.sismember('foo', 'member1') == True
 
     def test_sismember_wrong_type(self):
         self.zadd('foo', {'member': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.sismember('foo', 'member')
 
     def test_smembers(self):
-        self.assertEqual(self.redis.smembers('foo'), set())
+        assert self.redis.smembers('foo') == set()
 
     def test_smembers_copy(self):
         self.redis.sadd('foo', 'member1')
         set = self.redis.smembers('foo')
         self.redis.sadd('foo', 'member2')
-        self.assertNotEqual(set, self.redis.smembers('foo'))
+        assert self.redis.smembers('foo') != set
 
     def test_smembers_wrong_type(self):
         self.zadd('foo', {'member': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.smembers('foo')
 
     def test_smembers_runtime_error(self):
@@ -1633,50 +1554,49 @@ class TestFakeStrictRedis(unittest.TestCase):
     def test_smove(self):
         self.redis.sadd('foo', 'member1')
         self.redis.sadd('foo', 'member2')
-        self.assertEqual(self.redis.smove('foo', 'bar', 'member1'), True)
-        self.assertEqual(self.redis.smembers('bar'), {b'member1'})
+        assert self.redis.smove('foo', 'bar', 'member1') == True
+        assert self.redis.smembers('bar') == {b'member1'}
 
     def test_smove_non_existent_key(self):
-        self.assertEqual(self.redis.smove('foo', 'bar', 'member1'), False)
+        assert self.redis.smove('foo', 'bar', 'member1') == False
 
     def test_smove_wrong_type(self):
         self.zadd('foo', {'member': 1})
         self.redis.sadd('bar', 'member')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.smove('bar', 'foo', 'member')
         # Must raise the error before removing member from bar
-        self.assertEqual(self.redis.smembers('bar'), {b'member'})
-        with self.assertRaises(redis.ResponseError):
+        assert self.redis.smembers('bar') == {b'member'}
+        with pytest.raises(redis.ResponseError):
             self.redis.smove('foo', 'bar', 'member')
 
     def test_spop(self):
         # This is tricky because it pops a random element.
         self.redis.sadd('foo', 'member1')
-        self.assertEqual(self.redis.spop('foo'), b'member1')
-        self.assertEqual(self.redis.spop('foo'), None)
+        assert self.redis.spop('foo') == b'member1'
+        assert self.redis.spop('foo') is None
 
     def test_spop_wrong_type(self):
         self.zadd('foo', {'member': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.spop('foo')
 
     def test_srandmember(self):
         self.redis.sadd('foo', 'member1')
-        self.assertEqual(self.redis.srandmember('foo'), b'member1')
+        assert self.redis.srandmember('foo') == b'member1'
         # Shouldn't be removed from the set.
-        self.assertEqual(self.redis.srandmember('foo'), b'member1')
+        assert self.redis.srandmember('foo') == b'member1'
 
     def test_srandmember_number(self):
         """srandmember works with the number argument."""
-        self.assertEqual(self.redis.srandmember('foo', 2), [])
+        assert self.redis.srandmember('foo', 2) == []
         self.redis.sadd('foo', b'member1')
-        self.assertEqual(self.redis.srandmember('foo', 2), [b'member1'])
+        assert self.redis.srandmember('foo', 2) == [b'member1']
         self.redis.sadd('foo', b'member2')
-        self.assertEqual(set(self.redis.srandmember('foo', 2)),
-                         {b'member1', b'member2'})
+        assert set(self.redis.srandmember('foo', 2)) == {b'member1', b'member2'}
         self.redis.sadd('foo', b'member3')
         res = self.redis.srandmember('foo', 2)
-        self.assertEqual(len(res), 2)
+        assert len(res) == 2
 
         if self.decode_responses:
             superset = {'member1', 'member2', 'member3'}
@@ -1684,31 +1604,29 @@ class TestFakeStrictRedis(unittest.TestCase):
             superset = {b'member1', b'member2', b'member3'}
 
         for e in res:
-            self.assertIn(e, superset)
+            assert e in superset
 
     def test_srandmember_wrong_type(self):
         self.zadd('foo', {'member': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.srandmember('foo')
 
     def test_srem(self):
         self.redis.sadd('foo', 'member1', 'member2', 'member3', 'member4')
-        self.assertEqual(self.redis.smembers('foo'),
-                         {b'member1', b'member2', b'member3', b'member4'})
-        self.assertEqual(self.redis.srem('foo', 'member1'), True)
-        self.assertEqual(self.redis.smembers('foo'),
-                         {b'member2', b'member3', b'member4'})
-        self.assertEqual(self.redis.srem('foo', 'member1'), False)
+        assert self.redis.smembers('foo') == {b'member1', b'member2', b'member3', b'member4'}
+        assert self.redis.srem('foo', 'member1') == True
+        assert self.redis.smembers('foo') == {b'member2', b'member3', b'member4'}
+        assert self.redis.srem('foo', 'member1') == False
         # Since redis>=2.7.6 returns number of deleted items.
-        self.assertEqual(self.redis.srem('foo', 'member2', 'member3'), 2)
-        self.assertEqual(self.redis.smembers('foo'), {b'member4'})
-        self.assertEqual(self.redis.srem('foo', 'member3', 'member4'), True)
-        self.assertEqual(self.redis.smembers('foo'), set())
-        self.assertEqual(self.redis.srem('foo', 'member3', 'member4'), False)
+        assert self.redis.srem('foo', 'member2', 'member3') == 2
+        assert self.redis.smembers('foo') == {b'member4'}
+        assert self.redis.srem('foo', 'member3', 'member4') == True
+        assert self.redis.smembers('foo') == set()
+        assert self.redis.srem('foo', 'member3', 'member4') == False
 
     def test_srem_wrong_type(self):
         self.zadd('foo', {'member': 1})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.srem('foo', 'member')
 
     def test_sunion(self):
@@ -1716,15 +1634,14 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.sadd('foo', 'member2')
         self.redis.sadd('bar', 'member2')
         self.redis.sadd('bar', 'member3')
-        self.assertEqual(self.redis.sunion('foo', 'bar'),
-                         {b'member1', b'member2', b'member3'})
+        assert self.redis.sunion('foo', 'bar') == {b'member1', b'member2', b'member3'}
 
     def test_sunion_wrong_type(self):
         self.zadd('foo', {'member': 1})
         self.redis.sadd('bar', 'member')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.sunion('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.sunion('bar', 'foo')
 
     def test_sunionstore(self):
@@ -1732,69 +1649,67 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.sadd('foo', 'member2')
         self.redis.sadd('bar', 'member2')
         self.redis.sadd('bar', 'member3')
-        self.assertEqual(self.redis.sunionstore('baz', 'foo', 'bar'), 3)
-        self.assertEqual(self.redis.smembers('baz'),
-                         {b'member1', b'member2', b'member3'})
+        assert self.redis.sunionstore('baz', 'foo', 'bar') == 3
+        assert self.redis.smembers('baz') == {b'member1', b'member2', b'member3'}
 
         # Catch instances where we store bytes and strings inconsistently
         # and thus baz = {b'member1', b'member2', b'member3', 'member3'}
         self.redis.sadd('baz', 'member3')
-        self.assertEqual(self.redis.scard('baz'), 3)
+        assert self.redis.scard('baz') == 3
 
     def test_empty_set(self):
         self.redis.sadd('foo', 'bar')
         self.redis.srem('foo', 'bar')
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     def test_zadd(self):
         self.zadd('foo', {'four': 4})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.zadd('foo', {'two': 2, 'one': 1, 'zero': 0}), 3)
-        self.assertEqual(self.redis.zrange('foo', 0, -1),
-                         [b'zero', b'one', b'two', b'three', b'four'])
-        self.assertEqual(self.zadd('foo', {'zero': 7, 'one': 1, 'five': 5}), 1)
-        self.assertEqual(self.redis.zrange('foo', 0, -1),
-                         [b'one', b'two', b'three', b'four', b'five', b'zero'])
+        assert self.zadd('foo', {'two': 2, 'one': 1, 'zero': 0}) == 3
+        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'one', b'two', b'three', b'four']
+        assert self.zadd('foo', {'zero': 7, 'one': 1, 'five': 5}) == 1
+        assert (
+            self.redis.zrange('foo', 0, -1)
+            == [b'one', b'two', b'three', b'four', b'five', b'zero']
+        )
 
     @redis2_only
     def test_zadd_uses_str(self):
         self.redis.zadd('foo', 12345, (1, 2, 3))
-        self.assertEqual(self.redis.zrange('foo', 0, 0), [b'(1, 2, 3)'])
+        assert self.redis.zrange('foo', 0, 0) == [b'(1, 2, 3)']
 
     @redis2_only
     def test_zadd_errors(self):
         # The args are backwards, it should be 2, "two", so we
         # expect an exception to be raised.
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zadd('foo', 'two', 2)
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zadd('foo', two='two')
         # It's expected an equal number of values and scores
-        with self.assertRaises(redis.RedisError):
+        with pytest.raises(redis.RedisError):
             self.redis.zadd('foo', 'two')
 
     def test_zadd_empty(self):
         # Have to add at least one key/value pair
-        with self.assertRaises(redis.RedisError):
+        with pytest.raises(redis.RedisError):
             self.zadd('foo', {})
 
     def test_zadd_minus_zero(self):
         # Changing -0 to +0 is ignored
         self.zadd('foo', {'a': -0.0})
         self.zadd('foo', {'a': 0.0})
-        self.assertEqual(self.raw_command('zscore', 'foo', 'a'), b'-0')
+        assert self.raw_command('zscore', 'foo', 'a') == b'-0'
 
     def test_zadd_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.zadd('foo', {'two': 2})
 
     def test_zadd_multiple(self):
         self.zadd('foo', {'one': 1, 'two': 2})
-        self.assertEqual(self.redis.zrange('foo', 0, 0),
-                         [b'one'])
-        self.assertEqual(self.redis.zrange('foo', 1, 1),
-                         [b'two'])
+        assert self.redis.zrange('foo', 0, 0) == [b'one']
+        assert self.redis.zrange('foo', 1, 1) == [b'two']
 
     @redis3_only
     def test_zadd_with_nx(self):
@@ -1816,8 +1731,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         ]
 
         for update in updates:
-            self.assertEqual(self.zadd('foo', update.input, nx=True), update.expected_return_value)
-            self.assertItemsEqual(self.redis.zrange('foo', 0, -1, withscores=True), update.expected_state)
+            assert self.zadd('foo', update.input, nx=True) == update.expected_return_value
+            assert (
+                sorted(self.redis.zrange('foo', 0, -1, withscores=True))
+                == sorted(update.expected_state)
+            )
 
     @redis3_only
     def test_zadd_with_ch(self):
@@ -1839,8 +1757,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         ]
 
         for update in updates:
-            self.assertEqual(self.zadd('foo', update.input, ch=True), update.expected_return_value)
-            self.assertItemsEqual(self.redis.zrange('foo', 0, -1, withscores=True), update.expected_state)
+            assert self.zadd('foo', update.input, ch=True) == update.expected_return_value
+            assert (
+                sorted(self.redis.zrange('foo', 0, -1, withscores=True))
+                == sorted(update.expected_state)
+            )
 
     @redis3_only
     def test_zadd_with_xx(self):
@@ -1862,15 +1783,18 @@ class TestFakeStrictRedis(unittest.TestCase):
         ]
 
         for update in updates:
-            self.assertEqual(self.zadd('foo', update.input, xx=True), update.expected_return_value)
-            self.assertItemsEqual(self.redis.zrange('foo', 0, -1, withscores=True), update.expected_state)
+            assert self.zadd('foo', update.input, xx=True) == update.expected_return_value
+            assert (
+                sorted(self.redis.zrange('foo', 0, -1, withscores=True))
+                == sorted(update.expected_state)
+            )
 
     @redis3_only
     def test_zadd_with_nx_and_xx(self):
         self.zadd('foo', {'four': 4.0, 'three': 3.0})
-        with self.assertRaises(redis.DataError):
+        with pytest.raises(redis.DataError):
             self.zadd('foo', {'four': -4.0, 'three': -3.0}, nx=True, xx=True)
-        with self.assertRaises(redis.DataError):
+        with pytest.raises(redis.DataError):
             self.zadd('foo', {'four': -4.0, 'three': -3.0}, nx=True, xx=True, ch=True)
 
     @redis3_only
@@ -1893,8 +1817,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         ]
 
         for update in updates:
-            self.assertEqual(self.zadd('foo', update.input, nx=True, ch=True), update.expected_return_value)
-            self.assertItemsEqual(self.redis.zrange('foo', 0, -1, withscores=True), update.expected_state)
+            assert self.zadd('foo', update.input, nx=True, ch=True) == update.expected_return_value
+            assert (
+                sorted(self.redis.zrange('foo', 0, -1, withscores=True))
+                == sorted(update.expected_state)
+            )
 
     @redis3_only
     def test_zadd_with_xx_and_ch(self):
@@ -1916,8 +1843,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         ]
 
         for update in updates:
-            self.assertEqual(self.zadd('foo', update.input, xx=True, ch=True), update.expected_return_value)
-            self.assertItemsEqual(self.redis.zrange('foo', 0, -1, withscores=True), update.expected_state)
+            assert self.zadd('foo', update.input, xx=True, ch=True) == update.expected_return_value
+            assert (
+                sorted(self.redis.zrange('foo', 0, -1, withscores=True))
+                == sorted(update.expected_state)
+            )
 
     def test_zrange_same_score(self):
         self.zadd('foo', {'two_a': 2})
@@ -1925,85 +1855,83 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two_c': 2})
         self.zadd('foo', {'two_d': 2})
         self.zadd('foo', {'two_e': 2})
-        self.assertEqual(self.redis.zrange('foo', 2, 3),
-                         [b'two_c', b'two_d'])
+        assert self.redis.zrange('foo', 2, 3) == [b'two_c', b'two_d']
 
     def test_zcard(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
-        self.assertEqual(self.redis.zcard('foo'), 2)
+        assert self.redis.zcard('foo') == 2
 
     def test_zcard_non_existent_key(self):
-        self.assertEqual(self.redis.zcard('foo'), 0)
+        assert self.redis.zcard('foo') == 0
 
     def test_zcard_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zcard('foo')
 
     def test_zcount(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'three': 2})
         self.zadd('foo', {'five': 5})
-        self.assertEqual(self.redis.zcount('foo', 2, 4), 1)
-        self.assertEqual(self.redis.zcount('foo', 1, 4), 2)
-        self.assertEqual(self.redis.zcount('foo', 0, 5), 3)
-        self.assertEqual(self.redis.zcount('foo', 4, '+inf'), 1)
-        self.assertEqual(self.redis.zcount('foo', '-inf', 4), 2)
-        self.assertEqual(self.redis.zcount('foo', '-inf', '+inf'), 3)
+        assert self.redis.zcount('foo', 2, 4) == 1
+        assert self.redis.zcount('foo', 1, 4) == 2
+        assert self.redis.zcount('foo', 0, 5) == 3
+        assert self.redis.zcount('foo', 4, '+inf') == 1
+        assert self.redis.zcount('foo', '-inf', 4) == 2
+        assert self.redis.zcount('foo', '-inf', '+inf') == 3
 
     def test_zcount_exclusive(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'three': 2})
         self.zadd('foo', {'five': 5})
-        self.assertEqual(self.redis.zcount('foo', '-inf', '(2'), 1)
-        self.assertEqual(self.redis.zcount('foo', '-inf', 2), 2)
-        self.assertEqual(self.redis.zcount('foo', '(5', '+inf'), 0)
-        self.assertEqual(self.redis.zcount('foo', '(1', 5), 2)
-        self.assertEqual(self.redis.zcount('foo', '(2', '(5'), 0)
-        self.assertEqual(self.redis.zcount('foo', '(1', '(5'), 1)
-        self.assertEqual(self.redis.zcount('foo', 2, '(5'), 1)
+        assert self.redis.zcount('foo', '-inf', '(2') == 1
+        assert self.redis.zcount('foo', '-inf', 2) == 2
+        assert self.redis.zcount('foo', '(5', '+inf') == 0
+        assert self.redis.zcount('foo', '(1', 5) == 2
+        assert self.redis.zcount('foo', '(2', '(5') == 0
+        assert self.redis.zcount('foo', '(1', '(5') == 1
+        assert self.redis.zcount('foo', 2, '(5') == 1
 
     def test_zcount_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zcount('foo', '-inf', '+inf')
 
     def test_zincrby(self):
         self.zadd('foo', {'one': 1})
-        self.assertEqual(self.zincrby('foo', 10, 'one'), 11)
-        self.assertEqual(self.redis.zrange('foo', 0, -1, withscores=True),
-                         [(b'one', 11)])
+        assert self.zincrby('foo', 10, 'one') == 11
+        assert self.redis.zrange('foo', 0, -1, withscores=True) == [(b'one', 11)]
 
     def test_zincrby_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.zincrby('foo', 10, 'one')
 
     def test_zrange_descending(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zrange('foo', 0, -1, desc=True),
-                         [b'three', b'two', b'one'])
+        assert self.redis.zrange('foo', 0, -1, desc=True) == [b'three', b'two', b'one']
 
     def test_zrange_descending_with_scores(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zrange('foo', 0, -1, desc=True,
-                                           withscores=True),
-                         [(b'three', 3), (b'two', 2), (b'one', 1)])
+        assert (
+            self.redis.zrange('foo', 0, -1, desc=True, withscores=True)
+            == [(b'three', 3), (b'two', 2), (b'one', 1)]
+        )
 
     def test_zrange_with_positive_indices(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zrange('foo', 0, 1), [b'one', b'two'])
+        assert self.redis.zrange('foo', 0, 1) == [b'one', b'two']
 
     def test_zrange_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrange('foo', 0, -1)
 
     def test_zrange_score_cast(self):
@@ -2012,26 +1940,26 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         expected_without_cast_round = [(b'one', 1.2), (b'two', 2.2)]
         expected_with_cast_round = [(b'one', 1.0), (b'two', 2.0)]
-        self.assertEqual(self.redis.zrange('foo', 0, 2, withscores=True),
-                         expected_without_cast_round)
-        self.assertEqual(self.redis.zrange('foo', 0, 2, withscores=True,
-                                           score_cast_func=self._round_str),
-                         expected_with_cast_round)
+        assert self.redis.zrange('foo', 0, 2, withscores=True) == expected_without_cast_round
+        assert (
+            self.redis.zrange('foo', 0, 2, withscores=True, score_cast_func=self._round_str)
+            == expected_with_cast_round
+        )
 
     def test_zrank(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zrank('foo', 'one'), 0)
-        self.assertEqual(self.redis.zrank('foo', 'two'), 1)
-        self.assertEqual(self.redis.zrank('foo', 'three'), 2)
+        assert self.redis.zrank('foo', 'one') == 0
+        assert self.redis.zrank('foo', 'two') == 1
+        assert self.redis.zrank('foo', 'three') == 2
 
     def test_zrank_non_existent_member(self):
-        self.assertEqual(self.redis.zrank('foo', 'one'), None)
+        assert self.redis.zrank('foo', 'one') is None
 
     def test_zrank_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrank('foo', 'one')
 
     def test_zrem(self):
@@ -2039,78 +1967,74 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
         self.zadd('foo', {'four': 4})
-        self.assertEqual(self.redis.zrem('foo', 'one'), True)
-        self.assertEqual(self.redis.zrange('foo', 0, -1),
-                         [b'two', b'three', b'four'])
+        assert self.redis.zrem('foo', 'one') == True
+        assert self.redis.zrange('foo', 0, -1) == [b'two', b'three', b'four']
         # Since redis>=2.7.6 returns number of deleted items.
-        self.assertEqual(self.redis.zrem('foo', 'two', 'three'), 2)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'four'])
-        self.assertEqual(self.redis.zrem('foo', 'three', 'four'), True)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [])
-        self.assertEqual(self.redis.zrem('foo', 'three', 'four'), False)
+        assert self.redis.zrem('foo', 'two', 'three') == 2
+        assert self.redis.zrange('foo', 0, -1) == [b'four']
+        assert self.redis.zrem('foo', 'three', 'four') == True
+        assert self.redis.zrange('foo', 0, -1) == []
+        assert self.redis.zrem('foo', 'three', 'four') == False
 
     def test_zrem_non_existent_member(self):
-        self.assertFalse(self.redis.zrem('foo', 'one'))
+        assert not self.redis.zrem('foo', 'one')
 
     def test_zrem_numeric_member(self):
         self.zadd('foo', {'128': 13.0, '129': 12.0})
-        self.assertEqual(self.redis.zrem('foo', 128), True)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'129'])
+        assert self.redis.zrem('foo', 128) == True
+        assert self.redis.zrange('foo', 0, -1) == [b'129']
 
     def test_zrem_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrem('foo', 'bar')
 
     def test_zscore(self):
         self.zadd('foo', {'one': 54})
-        self.assertEqual(self.redis.zscore('foo', 'one'), 54)
+        assert self.redis.zscore('foo', 'one') == 54
 
     def test_zscore_non_existent_member(self):
-        self.assertIsNone(self.redis.zscore('foo', 'one'))
+        assert self.redis.zscore('foo', 'one') is None
 
     def test_zscore_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zscore('foo', 'one')
 
     def test_zrevrank(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zrevrank('foo', 'one'), 2)
-        self.assertEqual(self.redis.zrevrank('foo', 'two'), 1)
-        self.assertEqual(self.redis.zrevrank('foo', 'three'), 0)
+        assert self.redis.zrevrank('foo', 'one') == 2
+        assert self.redis.zrevrank('foo', 'two') == 1
+        assert self.redis.zrevrank('foo', 'three') == 0
 
     def test_zrevrank_non_existent_member(self):
-        self.assertEqual(self.redis.zrevrank('foo', 'one'), None)
+        assert self.redis.zrevrank('foo', 'one') is None
 
     def test_zrevrank_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrank('foo', 'one')
 
     def test_zrevrange(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zrevrange('foo', 0, 1), [b'three', b'two'])
-        self.assertEqual(self.redis.zrevrange('foo', 0, -1),
-                         [b'three', b'two', b'one'])
+        assert self.redis.zrevrange('foo', 0, 1) == [b'three', b'two']
+        assert self.redis.zrevrange('foo', 0, -1) == [b'three', b'two', b'one']
 
     def test_zrevrange_sorted_keys(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'two_b': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zrevrange('foo', 0, 2),
-                         [b'three', b'two_b', b'two'])
-        self.assertEqual(self.redis.zrevrange('foo', 0, -1),
-                         [b'three', b'two_b', b'two', b'one'])
+        assert self.redis.zrevrange('foo', 0, 2) == [b'three', b'two_b', b'two']
+        assert self.redis.zrevrange('foo', 0, -1) == [b'three', b'two_b', b'two', b'one']
 
     def test_zrevrange_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrange('foo', 0, 2)
 
     def test_zrevrange_score_cast(self):
@@ -2119,11 +2043,11 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         expected_without_cast_round = [(b'two', 2.2), (b'one', 1.2)]
         expected_with_cast_round = [(b'two', 2.0), (b'one', 1.0)]
-        self.assertEqual(self.redis.zrevrange('foo', 0, 2, withscores=True),
-                         expected_without_cast_round)
-        self.assertEqual(self.redis.zrevrange('foo', 0, 2, withscores=True,
-                                              score_cast_func=self._round_str),
-                         expected_with_cast_round)
+        assert self.redis.zrevrange('foo', 0, 2, withscores=True) == expected_without_cast_round
+        assert (
+            self.redis.zrevrange('foo', 0, 2, withscores=True, score_cast_func=self._round_str)
+            == expected_with_cast_round
+        )
 
     def test_zrangebyscore(self):
         self.zadd('foo', {'zero': 0})
@@ -2131,49 +2055,47 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two_a_also': 2})
         self.zadd('foo', {'two_b_also': 2})
         self.zadd('foo', {'four': 4})
-        self.assertEqual(self.redis.zrangebyscore('foo', 1, 3),
-                         [b'two', b'two_a_also', b'two_b_also'])
-        self.assertEqual(self.redis.zrangebyscore('foo', 2, 3),
-                         [b'two', b'two_a_also', b'two_b_also'])
-        self.assertEqual(self.redis.zrangebyscore('foo', 0, 4),
-                         [b'zero', b'two', b'two_a_also', b'two_b_also',
-                          b'four'])
-        self.assertEqual(self.redis.zrangebyscore('foo', '-inf', 1),
-                         [b'zero'])
-        self.assertEqual(self.redis.zrangebyscore('foo', 2, '+inf'),
-                         [b'two', b'two_a_also', b'two_b_also', b'four'])
-        self.assertEqual(self.redis.zrangebyscore('foo', '-inf', '+inf'),
-                         [b'zero', b'two', b'two_a_also', b'two_b_also',
-                          b'four'])
+        assert self.redis.zrangebyscore('foo', 1, 3) == [b'two', b'two_a_also', b'two_b_also']
+        assert self.redis.zrangebyscore('foo', 2, 3) == [b'two', b'two_a_also', b'two_b_also']
+        assert (
+            self.redis.zrangebyscore('foo', 0, 4)
+            == [b'zero', b'two', b'two_a_also', b'two_b_also', b'four']
+        )
+        assert self.redis.zrangebyscore('foo', '-inf', 1) == [b'zero']
+        assert (
+            self.redis.zrangebyscore('foo', 2, '+inf')
+            == [b'two', b'two_a_also', b'two_b_also', b'four']
+        )
+        assert (
+            self.redis.zrangebyscore('foo', '-inf', '+inf')
+            == [b'zero', b'two', b'two_a_also', b'two_b_also', b'four']
+        )
 
     def test_zrangebysore_exclusive(self):
         self.zadd('foo', {'zero': 0})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'four': 4})
         self.zadd('foo', {'five': 5})
-        self.assertEqual(self.redis.zrangebyscore('foo', '(0', 6),
-                         [b'two', b'four', b'five'])
-        self.assertEqual(self.redis.zrangebyscore('foo', '(2', '(5'),
-                         [b'four'])
-        self.assertEqual(self.redis.zrangebyscore('foo', 0, '(4'),
-                         [b'zero', b'two'])
+        assert self.redis.zrangebyscore('foo', '(0', 6) == [b'two', b'four', b'five']
+        assert self.redis.zrangebyscore('foo', '(2', '(5') == [b'four']
+        assert self.redis.zrangebyscore('foo', 0, '(4') == [b'zero', b'two']
 
     def test_zrangebyscore_raises_error(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrangebyscore('foo', 'one', 2)
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrangebyscore('foo', 2, 'three')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrangebyscore('foo', 2, '3)')
-        with self.assertRaises(redis.RedisError):
+        with pytest.raises(redis.RedisError):
             self.redis.zrangebyscore('foo', 2, '3)', 0, None)
 
     def test_zrangebyscore_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrangebyscore('foo', '(1', '(2')
 
     def test_zrangebyscore_slice(self):
@@ -2181,17 +2103,14 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two_b': 2})
         self.zadd('foo', {'two_c': 2})
         self.zadd('foo', {'two_d': 2})
-        self.assertEqual(self.redis.zrangebyscore('foo', 0, 4, 0, 2),
-                         [b'two_a', b'two_b'])
-        self.assertEqual(self.redis.zrangebyscore('foo', 0, 4, 1, 3),
-                         [b'two_b', b'two_c', b'two_d'])
+        assert self.redis.zrangebyscore('foo', 0, 4, 0, 2) == [b'two_a', b'two_b']
+        assert self.redis.zrangebyscore('foo', 0, 4, 1, 3) == [b'two_b', b'two_c', b'two_d']
 
     def test_zrangebyscore_withscores(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zrangebyscore('foo', 1, 3, 0, 2, True),
-                         [(b'one', 1), (b'two', 2)])
+        assert self.redis.zrangebyscore('foo', 1, 3, 0, 2, True) == [(b'one', 1), (b'two', 2)]
 
     def test_zrangebyscore_cast_scores(self):
         self.zadd('foo', {'two': 2})
@@ -2199,62 +2118,52 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         expected_without_cast_round = [(b'two', 2.0), (b'two_a_also', 2.2)]
         expected_with_cast_round = [(b'two', 2.0), (b'two_a_also', 2.0)]
-        self.assertItemsEqual(
-            self.redis.zrangebyscore('foo', 2, 3, withscores=True),
-            expected_without_cast_round
+        assert (
+            sorted(self.redis.zrangebyscore('foo', 2, 3, withscores=True))
+            == sorted(expected_without_cast_round)
         )
-        self.assertItemsEqual(
-            self.redis.zrangebyscore('foo', 2, 3, withscores=True,
-                                     score_cast_func=self._round_str),
-            expected_with_cast_round
+        assert (
+            sorted(self.redis.zrangebyscore('foo', 2, 3, withscores=True,
+                                            score_cast_func=self._round_str))
+            == sorted(expected_with_cast_round)
         )
 
     def test_zrevrangebyscore(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zrevrangebyscore('foo', 3, 1),
-                         [b'three', b'two', b'one'])
-        self.assertEqual(self.redis.zrevrangebyscore('foo', 3, 2),
-                         [b'three', b'two'])
-        self.assertEqual(self.redis.zrevrangebyscore('foo', 3, 1, 0, 1),
-                         [b'three'])
-        self.assertEqual(self.redis.zrevrangebyscore('foo', 3, 1, 1, 2),
-                         [b'two', b'one'])
+        assert self.redis.zrevrangebyscore('foo', 3, 1) == [b'three', b'two', b'one']
+        assert self.redis.zrevrangebyscore('foo', 3, 2) == [b'three', b'two']
+        assert self.redis.zrevrangebyscore('foo', 3, 1, 0, 1) == [b'three']
+        assert self.redis.zrevrangebyscore('foo', 3, 1, 1, 2) == [b'two', b'one']
 
     def test_zrevrangebyscore_exclusive(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zrevrangebyscore('foo', '(3', 1),
-                         [b'two', b'one'])
-        self.assertEqual(self.redis.zrevrangebyscore('foo', 3, '(2'),
-                         [b'three'])
-        self.assertEqual(self.redis.zrevrangebyscore('foo', '(3', '(1'),
-                         [b'two'])
-        self.assertEqual(self.redis.zrevrangebyscore('foo', '(2', 1, 0, 1),
-                         [b'one'])
-        self.assertEqual(self.redis.zrevrangebyscore('foo', '(2', '(1', 0, 1),
-                         [])
-        self.assertEqual(self.redis.zrevrangebyscore('foo', '(3', '(0', 1, 2),
-                         [b'one'])
+        assert self.redis.zrevrangebyscore('foo', '(3', 1) == [b'two', b'one']
+        assert self.redis.zrevrangebyscore('foo', 3, '(2') == [b'three']
+        assert self.redis.zrevrangebyscore('foo', '(3', '(1') == [b'two']
+        assert self.redis.zrevrangebyscore('foo', '(2', 1, 0, 1) == [b'one']
+        assert self.redis.zrevrangebyscore('foo', '(2', '(1', 0, 1) == []
+        assert self.redis.zrevrangebyscore('foo', '(3', '(0', 1, 2) == [b'one']
 
     def test_zrevrangebyscore_raises_error(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebyscore('foo', 'three', 1)
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebyscore('foo', 3, 'one')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebyscore('foo', 3, '1)')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebyscore('foo', '((3', '1)')
 
     def test_zrevrangebyscore_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebyscore('foo', '(3', '(1')
 
     def test_zrevrangebyscore_cast_scores(self):
@@ -2263,14 +2172,14 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         expected_without_cast_round = [(b'two_a_also', 2.2), (b'two', 2.0)]
         expected_with_cast_round = [(b'two_a_also', 2.0), (b'two', 2.0)]
-        self.assertEqual(
-            self.redis.zrevrangebyscore('foo', 3, 2, withscores=True),
-            expected_without_cast_round
+        assert (
+            self.redis.zrevrangebyscore('foo', 3, 2, withscores=True)
+             == expected_without_cast_round
         )
-        self.assertEqual(
+        assert (
             self.redis.zrevrangebyscore('foo', 3, 2, withscores=True,
-                                        score_cast_func=self._round_str),
-            expected_with_cast_round
+                                        score_cast_func=self._round_str)
+            == expected_with_cast_round
         )
 
     def test_zrangebylex(self):
@@ -2278,38 +2187,25 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two_a': 0})
         self.zadd('foo', {'two_b': 0})
         self.zadd('foo', {'three_a': 0})
-        self.assertEqual(self.redis.zrangebylex('foo', b'(t', b'+'),
-                         [b'three_a', b'two_a', b'two_b'])
-
-        self.assertEqual(self.redis.zrangebylex('foo', b'(t', b'[two_b'),
-                         [b'three_a', b'two_a', b'two_b'])
-
-        self.assertEqual(self.redis.zrangebylex('foo', b'(t', b'(two_b'),
-                         [b'three_a', b'two_a'])
-
-        self.assertEqual(self.redis.zrangebylex('foo', b'[three_a', b'[two_b'),
-                         [b'three_a', b'two_a', b'two_b'])
-
-        self.assertEqual(self.redis.zrangebylex('foo', b'(three_a', b'[two_b'),
-                         [b'two_a', b'two_b'])
-
-        self.assertEqual(self.redis.zrangebylex('foo', b'-', b'(two_b'),
-                         [b'one_a', b'three_a', b'two_a'])
-
-        self.assertEqual(self.redis.zrangebylex('foo', b'[two_b', b'(two_b'),
-                         [])
+        assert self.redis.zrangebylex('foo', b'(t', b'+') == [b'three_a', b'two_a', b'two_b']
+        assert self.redis.zrangebylex('foo', b'(t', b'[two_b') == [b'three_a', b'two_a', b'two_b']
+        assert self.redis.zrangebylex('foo', b'(t', b'(two_b') == [b'three_a', b'two_a']
+        assert (
+            self.redis.zrangebylex('foo', b'[three_a', b'[two_b')
+            == [b'three_a', b'two_a', b'two_b']
+        )
+        assert self.redis.zrangebylex('foo', b'(three_a', b'[two_b') == [b'two_a', b'two_b']
+        assert self.redis.zrangebylex('foo', b'-', b'(two_b') == [b'one_a', b'three_a', b'two_a']
+        assert self.redis.zrangebylex('foo', b'[two_b', b'(two_b') == []
         # reversed max + and min - boundaries
         # these will be always empty, but allowed by redis
-        self.assertEqual(self.redis.zrangebylex('foo', b'+', b'-'),
-                         [])
-        self.assertEqual(self.redis.zrangebylex('foo', b'+', b'[three_a'),
-                         [])
-        self.assertEqual(self.redis.zrangebylex('foo', b'[o', b'-'),
-                         [])
+        assert self.redis.zrangebylex('foo', b'+', b'-') == []
+        assert self.redis.zrangebylex('foo', b'+', b'[three_a') == []
+        assert self.redis.zrangebylex('foo', b'[o', b'-') == []
 
     def test_zrangebylex_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrangebylex('foo', b'-', b'+')
 
     def test_zlexcount(self):
@@ -2317,37 +2213,22 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two_a': 0})
         self.zadd('foo', {'two_b': 0})
         self.zadd('foo', {'three_a': 0})
-        self.assertEqual(self.redis.zlexcount('foo', b'(t', b'+'),
-                         3)
-
-        self.assertEqual(self.redis.zlexcount('foo', b'(t', b'[two_b'),
-                         3)
-
-        self.assertEqual(self.redis.zlexcount('foo', b'(t', b'(two_b'),
-                         2)
-
-        self.assertEqual(self.redis.zlexcount('foo', b'[three_a', b'[two_b'),
-                         3)
-        self.assertEqual(self.redis.zlexcount('foo', b'(three_a', b'[two_b'),
-                         2)
-
-        self.assertEqual(self.redis.zlexcount('foo', b'-', b'(two_b'),
-                         3)
-
-        self.assertEqual(self.redis.zlexcount('foo', b'[two_b', b'(two_b'),
-                         0)
+        assert self.redis.zlexcount('foo', b'(t', b'+') == 3
+        assert self.redis.zlexcount('foo', b'(t', b'[two_b') == 3
+        assert self.redis.zlexcount('foo', b'(t', b'(two_b') == 2
+        assert self.redis.zlexcount('foo', b'[three_a', b'[two_b') == 3
+        assert self.redis.zlexcount('foo', b'(three_a', b'[two_b') == 2
+        assert self.redis.zlexcount('foo', b'-', b'(two_b') == 3
+        assert self.redis.zlexcount('foo', b'[two_b', b'(two_b') == 0
         # reversed max + and min - boundaries
         # these will be always empty, but allowed by redis
-        self.assertEqual(self.redis.zlexcount('foo', b'+', b'-'),
-                         0)
-        self.assertEqual(self.redis.zlexcount('foo', b'+', b'[three_a'),
-                         0)
-        self.assertEqual(self.redis.zlexcount('foo', b'[o', b'-'),
-                         0)
+        assert self.redis.zlexcount('foo', b'+', b'-') == 0
+        assert self.redis.zlexcount('foo', b'+', b'[three_a') == 0
+        assert self.redis.zlexcount('foo', b'[o', b'-') == 0
 
     def test_zlexcount_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zlexcount('foo', b'-', b'+')
 
     def test_zrangebylex_with_limit(self):
@@ -2355,22 +2236,18 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two_a': 0})
         self.zadd('foo', {'two_b': 0})
         self.zadd('foo', {'three_a': 0})
-        self.assertEqual(self.redis.zrangebylex('foo', b'-', b'+', 1, 2),
-                         [b'three_a', b'two_a'])
+        assert self.redis.zrangebylex('foo', b'-', b'+', 1, 2) == [b'three_a', b'two_a']
 
         # negative offset no results
-        self.assertEqual(self.redis.zrangebylex('foo', b'-', b'+', -1, 3),
-                         [])
+        assert self.redis.zrangebylex('foo', b'-', b'+', -1, 3) == []
 
         # negative limit ignored
-        self.assertEqual(self.redis.zrangebylex('foo', b'-', b'+', 0, -2),
-                         [b'one_a', b'three_a', b'two_a', b'two_b'])
-
-        self.assertEqual(self.redis.zrangebylex('foo', b'-', b'+', 1, -2),
-                         [b'three_a', b'two_a', b'two_b'])
-
-        self.assertEqual(self.redis.zrangebylex('foo', b'+', b'-', 1, 1),
-                         [])
+        assert (
+            self.redis.zrangebylex('foo', b'-', b'+', 0, -2)
+            == [b'one_a', b'three_a', b'two_a', b'two_b']
+        )
+        assert self.redis.zrangebylex('foo', b'-', b'+', 1, -2) == [b'three_a', b'two_a', b'two_b']
+        assert self.redis.zrangebylex('foo', b'+', b'-', 1, 1) == []
 
     def test_zrangebylex_raises_error(self):
         self.zadd('foo', {'one_a': 0})
@@ -2378,22 +2255,22 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two_b': 0})
         self.zadd('foo', {'three_a': 0})
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrangebylex('foo', b'', b'[two_b')
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrangebylex('foo', b'-', b'two_b')
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrangebylex('foo', b'(t', b'two_b')
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrangebylex('foo', b't', b'+')
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrangebylex('foo', b'[two_a', b'')
 
-        with self.assertRaises(redis.RedisError):
+        with pytest.raises(redis.RedisError):
             self.redis.zrangebylex('foo', b'(two_a', b'[two_b', 1)
 
     def test_zrevrangebylex(self):
@@ -2401,42 +2278,31 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two_a': 0})
         self.zadd('foo', {'two_b': 0})
         self.zadd('foo', {'three_a': 0})
-        self.assertEqual(self.redis.zrevrangebylex('foo', b'+', b'(t'),
-                         [b'two_b', b'two_a', b'three_a'])
-
-        self.assertEqual(self.redis.zrevrangebylex('foo', b'[two_b', b'(t'),
-                         [b'two_b', b'two_a', b'three_a'])
-
-        self.assertEqual(self.redis.zrevrangebylex('foo', b'(two_b', b'(t'),
-                         [b'two_a', b'three_a'])
-
-        self.assertEqual(self.redis.zrevrangebylex('foo', b'[two_b', b'[three_a'),
-                         [b'two_b', b'two_a', b'three_a'])
-
-        self.assertEqual(self.redis.zrevrangebylex('foo', b'[two_b', b'(three_a'),
-                         [b'two_b', b'two_a'])
-
-        self.assertEqual(self.redis.zrevrangebylex('foo', b'(two_b', b'-'),
-                         [b'two_a', b'three_a', b'one_a'])
-
-        self.assertEqual(self.redis.zrangebylex('foo', b'(two_b', b'[two_b'),
-                         [])
+        assert self.redis.zrevrangebylex('foo', b'+', b'(t') == [b'two_b', b'two_a', b'three_a']
+        assert (
+            self.redis.zrevrangebylex('foo', b'[two_b', b'(t')
+            == [b'two_b', b'two_a', b'three_a']
+        )
+        assert self.redis.zrevrangebylex('foo', b'(two_b', b'(t') == [b'two_a', b'three_a']
+        assert (
+            self.redis.zrevrangebylex('foo', b'[two_b', b'[three_a')
+            == [b'two_b', b'two_a', b'three_a']
+        )
+        assert self.redis.zrevrangebylex('foo', b'[two_b', b'(three_a') == [b'two_b', b'two_a']
+        assert self.redis.zrevrangebylex('foo', b'(two_b', b'-') == [b'two_a', b'three_a', b'one_a']
+        assert self.redis.zrangebylex('foo', b'(two_b', b'[two_b') == []
         # reversed max + and min - boundaries
         # these will be always empty, but allowed by redis
-        self.assertEqual(self.redis.zrevrangebylex('foo', b'-', b'+'),
-                         [])
-        self.assertEqual(self.redis.zrevrangebylex('foo', b'[three_a', b'+'),
-                         [])
-        self.assertEqual(self.redis.zrevrangebylex('foo', b'-', b'[o'),
-                         [])
+        assert self.redis.zrevrangebylex('foo', b'-', b'+') == []
+        assert self.redis.zrevrangebylex('foo', b'[three_a', b'+') == []
+        assert self.redis.zrevrangebylex('foo', b'-', b'[o') == []
 
     def test_zrevrangebylex_with_limit(self):
         self.zadd('foo', {'one_a': 0})
         self.zadd('foo', {'two_a': 0})
         self.zadd('foo', {'two_b': 0})
         self.zadd('foo', {'three_a': 0})
-        self.assertEqual(self.redis.zrevrangebylex('foo', b'+', b'-', 1, 2),
-                         [b'two_a', b'three_a'])
+        assert self.redis.zrevrangebylex('foo', b'+', b'-', 1, 2) == [b'two_a', b'three_a']
 
     def test_zrevrangebylex_raises_error(self):
         self.zadd('foo', {'one_a': 0})
@@ -2444,50 +2310,50 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two_b': 0})
         self.zadd('foo', {'three_a': 0})
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebylex('foo', b'[two_b', b'')
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebylex('foo', b'two_b', b'-')
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebylex('foo', b'two_b', b'(t')
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebylex('foo', b'+', b't')
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebylex('foo', b'', b'[two_a')
 
-        with self.assertRaises(redis.RedisError):
+        with pytest.raises(redis.RedisError):
             self.redis.zrevrangebylex('foo', b'[two_a', b'(two_b', 1)
 
     def test_zrevrangebylex_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zrevrangebylex('foo', b'+', b'-')
 
     def test_zremrangebyrank(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zremrangebyrank('foo', 0, 1), 2)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'three'])
+        assert self.redis.zremrangebyrank('foo', 0, 1) == 2
+        assert self.redis.zrange('foo', 0, -1) == [b'three']
 
     def test_zremrangebyrank_negative_indices(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'three': 3})
-        self.assertEqual(self.redis.zremrangebyrank('foo', -2, -1), 2)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'one'])
+        assert self.redis.zremrangebyrank('foo', -2, -1) == 2
+        assert self.redis.zrange('foo', 0, -1) == [b'one']
 
     def test_zremrangebyrank_out_of_bounds(self):
         self.zadd('foo', {'one': 1})
-        self.assertEqual(self.redis.zremrangebyrank('foo', 1, 3), 0)
+        assert self.redis.zremrangebyrank('foo', 1, 3) == 0
 
     def test_zremrangebyrank_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zremrangebyrank('foo', 1, 3)
 
     def test_zremrangebyscore(self):
@@ -2495,53 +2361,50 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'four': 4})
         # Outside of range.
-        self.assertEqual(self.redis.zremrangebyscore('foo', 5, 10), 0)
-        self.assertEqual(self.redis.zrange('foo', 0, -1),
-                         [b'zero', b'two', b'four'])
+        assert self.redis.zremrangebyscore('foo', 5, 10) == 0
+        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'two', b'four']
         # Middle of range.
-        self.assertEqual(self.redis.zremrangebyscore('foo', 1, 3), 1)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'zero', b'four'])
-        self.assertEqual(self.redis.zremrangebyscore('foo', 1, 3), 0)
+        assert self.redis.zremrangebyscore('foo', 1, 3) == 1
+        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'four']
+        assert self.redis.zremrangebyscore('foo', 1, 3) == 0
         # Entire range.
-        self.assertEqual(self.redis.zremrangebyscore('foo', 0, 4), 2)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [])
+        assert self.redis.zremrangebyscore('foo', 0, 4) == 2
+        assert self.redis.zrange('foo', 0, -1) == []
 
     def test_zremrangebyscore_exclusive(self):
         self.zadd('foo', {'zero': 0})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'four': 4})
-        self.assertEqual(self.redis.zremrangebyscore('foo', '(0', 1), 0)
-        self.assertEqual(self.redis.zrange('foo', 0, -1),
-                         [b'zero', b'two', b'four'])
-        self.assertEqual(self.redis.zremrangebyscore('foo', '-inf', '(0'), 0)
-        self.assertEqual(self.redis.zrange('foo', 0, -1),
-                         [b'zero', b'two', b'four'])
-        self.assertEqual(self.redis.zremrangebyscore('foo', '(2', 5), 1)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'zero', b'two'])
-        self.assertEqual(self.redis.zremrangebyscore('foo', 0, '(2'), 1)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'two'])
-        self.assertEqual(self.redis.zremrangebyscore('foo', '(1', '(3'), 1)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [])
+        assert self.redis.zremrangebyscore('foo', '(0', 1) == 0
+        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'two', b'four']
+        assert self.redis.zremrangebyscore('foo', '-inf', '(0') == 0
+        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'two', b'four']
+        assert self.redis.zremrangebyscore('foo', '(2', 5) == 1
+        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'two']
+        assert self.redis.zremrangebyscore('foo', 0, '(2') == 1
+        assert self.redis.zrange('foo', 0, -1) == [b'two']
+        assert self.redis.zremrangebyscore('foo', '(1', '(3') == 1
+        assert self.redis.zrange('foo', 0, -1) == []
 
     def test_zremrangebyscore_raises_error(self):
         self.zadd('foo', {'zero': 0})
         self.zadd('foo', {'two': 2})
         self.zadd('foo', {'four': 4})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zremrangebyscore('foo', 'three', 1)
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zremrangebyscore('foo', 3, 'one')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zremrangebyscore('foo', 3, '1)')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zremrangebyscore('foo', '((3', '1)')
 
     def test_zremrangebyscore_badkey(self):
-        self.assertEqual(self.redis.zremrangebyscore('foo', 0, 2), 0)
+        assert self.redis.zremrangebyscore('foo', 0, 2) == 0
 
     def test_zremrangebyscore_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zremrangebyscore('foo', 0, 2)
 
     def test_zremrangebylex(self):
@@ -2549,34 +2412,34 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('foo', {'two_b': 0})
         self.zadd('foo', {'one_a': 0})
         self.zadd('foo', {'three_a': 0})
-        self.assertEqual(self.redis.zremrangebylex('foo', b'(three_a', b'[two_b'), 2)
-        self.assertEqual(self.redis.zremrangebylex('foo', b'(three_a', b'[two_b'), 0)
-        self.assertEqual(self.redis.zremrangebylex('foo', b'-', b'(o'), 0)
-        self.assertEqual(self.redis.zremrangebylex('foo', b'-', b'[one_a'), 1)
-        self.assertEqual(self.redis.zremrangebylex('foo', b'[tw', b'+'), 0)
-        self.assertEqual(self.redis.zremrangebylex('foo', b'[t', b'+'), 1)
-        self.assertEqual(self.redis.zremrangebylex('foo', b'[t', b'+'), 0)
+        assert self.redis.zremrangebylex('foo', b'(three_a', b'[two_b') == 2
+        assert self.redis.zremrangebylex('foo', b'(three_a', b'[two_b') == 0
+        assert self.redis.zremrangebylex('foo', b'-', b'(o') == 0
+        assert self.redis.zremrangebylex('foo', b'-', b'[one_a') == 1
+        assert self.redis.zremrangebylex('foo', b'[tw', b'+') == 0
+        assert self.redis.zremrangebylex('foo', b'[t', b'+') == 1
+        assert self.redis.zremrangebylex('foo', b'[t', b'+') == 0
 
     def test_zremrangebylex_error(self):
         self.zadd('foo', {'two_a': 0})
         self.zadd('foo', {'two_b': 0})
         self.zadd('foo', {'one_a': 0})
         self.zadd('foo', {'three_a': 0})
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zremrangebylex('foo', b'(t', b'two_b')
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zremrangebylex('foo', b't', b'+')
 
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zremrangebylex('foo', b'[two_a', b'')
 
     def test_zremrangebylex_badkey(self):
-        self.assertEqual(self.redis.zremrangebylex('foo', b'(three_a', b'[two_b'), 0)
+        assert self.redis.zremrangebylex('foo', b'(three_a', b'[two_b') == 0
 
     def test_zremrangebylex_wrong_type(self):
         self.redis.sadd('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zremrangebylex('foo', b'bar', b'baz')
 
     def test_zunionstore(self):
@@ -2586,8 +2449,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('bar', {'two': 2})
         self.zadd('bar', {'three': 3})
         self.redis.zunionstore('baz', ['foo', 'bar'])
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 2), (b'three', 3), (b'two', 4)])
+        assert (
+            self.redis.zrange('baz', 0, -1, withscores=True)
+            == [(b'one', 2), (b'three', 3), (b'two', 4)]
+        )
 
     def test_zunionstore_sum(self):
         self.zadd('foo', {'one': 1})
@@ -2596,8 +2461,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('bar', {'two': 2})
         self.zadd('bar', {'three': 3})
         self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='SUM')
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 2), (b'three', 3), (b'two', 4)])
+        assert (
+            self.redis.zrange('baz', 0, -1, withscores=True)
+            == [(b'one', 2), (b'three', 3), (b'two', 4)]
+        )
 
     def test_zunionstore_max(self):
         self.zadd('foo', {'one': 0})
@@ -2606,8 +2473,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('bar', {'two': 2})
         self.zadd('bar', {'three': 3})
         self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='MAX')
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 1), (b'two', 2), (b'three', 3)])
+        assert (
+            self.redis.zrange('baz', 0, -1, withscores=True)
+            == [(b'one', 1), (b'two', 2), (b'three', 3)]
+        )
 
     def test_zunionstore_min(self):
         self.zadd('foo', {'one': 1})
@@ -2616,8 +2485,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('bar', {'two': 0})
         self.zadd('bar', {'three': 3})
         self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='MIN')
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 0), (b'two', 0), (b'three', 3)])
+        assert (
+            self.redis.zrange('baz', 0, -1, withscores=True)
+            == [(b'one', 0), (b'two', 0), (b'three', 3)]
+        )
 
     def test_zunionstore_weights(self):
         self.zadd('foo', {'one': 1})
@@ -2626,8 +2497,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('bar', {'two': 2})
         self.zadd('bar', {'four': 4})
         self.redis.zunionstore('baz', {'foo': 1, 'bar': 2}, aggregate='SUM')
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 3), (b'two', 6), (b'four', 8)])
+        assert (
+            self.redis.zrange('baz', 0, -1, withscores=True)
+            == [(b'one', 3), (b'two', 6), (b'four', 8)]
+        )
 
     def test_zunionstore_nan_to_zero(self):
         self.zadd('foo', {'x': math.inf})
@@ -2635,24 +2508,22 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.zunionstore('bar', OrderedDict([('foo', 1.0), ('foo2', 0.0)]))
         # This is different to test_zinterstore_nan_to_zero because of a quirk
         # in redis. See https://github.com/antirez/redis/issues/3954.
-        self.assertEqual(self.redis.zscore('bar', 'x'), math.inf)
+        assert self.redis.zscore('bar', 'x') == math.inf
 
     def test_zunionstore_nan_to_zero2(self):
         self.zadd('foo', {'zero': 0})
         self.zadd('foo2', {'one': 1})
         self.zadd('foo3', {'one': 1})
         self.redis.zunionstore('bar', {'foo': math.inf}, aggregate='SUM')
-        self.assertEqual(self.redis.zrange('bar', 0, -1, withscores=True),
-                         [(b'zero', 0)])
+        assert self.redis.zrange('bar', 0, -1, withscores=True) == [(b'zero', 0)]
         self.redis.zunionstore('bar', OrderedDict([('foo2', math.inf), ('foo3', -math.inf)]))
-        self.assertEqual(self.redis.zrange('bar', 0, -1, withscores=True),
-                         [(b'one', 0)])
+        assert self.redis.zrange('bar', 0, -1, withscores=True) == [(b'one', 0)]
 
     def test_zunionstore_nan_to_zero_ordering(self):
         self.zadd('foo', {'e1': math.inf})
         self.zadd('bar', {'e1': -math.inf, 'e2': 0.0})
         self.redis.zunionstore('baz', ['foo', 'bar', 'foo'])
-        self.assertEqual(self.redis.zscore('baz', 'e1'), 0.0)
+        assert self.redis.zscore('baz', 'e1') == 0.0
 
     def test_zunionstore_mixed_set_types(self):
         # No score, redis will use 1.0.
@@ -2662,22 +2533,22 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('bar', {'two': 2})
         self.zadd('bar', {'three': 3})
         self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='SUM')
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 2), (b'three', 3), (b'two', 3)])
+        assert (
+            self.redis.zrange('baz', 0, -1, withscores=True)
+            == [(b'one', 2), (b'three', 3), (b'two', 3)]
+        )
 
     def test_zunionstore_badkey(self):
         self.zadd('foo', {'one': 1})
         self.zadd('foo', {'two': 2})
         self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='SUM')
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 1), (b'two', 2)])
+        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 1), (b'two', 2)]
         self.redis.zunionstore('baz', {'foo': 1, 'bar': 2}, aggregate='SUM')
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 1), (b'two', 2)])
+        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 1), (b'two', 2)]
 
     def test_zunionstore_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zunionstore('baz', ['foo', 'bar'])
 
     def test_zinterstore(self):
@@ -2687,8 +2558,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('bar', {'two': 2})
         self.zadd('bar', {'three': 3})
         self.redis.zinterstore('baz', ['foo', 'bar'])
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 2), (b'two', 4)])
+        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 2), (b'two', 4)]
 
     def test_zinterstore_mixed_set_types(self):
         self.redis.sadd('foo', 'one')
@@ -2697,8 +2567,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('bar', {'two': 2})
         self.zadd('bar', {'three': 3})
         self.redis.zinterstore('baz', ['foo', 'bar'], aggregate='SUM')
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 2), (b'two', 3)])
+        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 2), (b'two', 3)]
 
     def test_zinterstore_max(self):
         self.zadd('foo', {'one': 0})
@@ -2707,38 +2576,36 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd('bar', {'two': 2})
         self.zadd('bar', {'three': 3})
         self.redis.zinterstore('baz', ['foo', 'bar'], aggregate='MAX')
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 1), (b'two', 2)])
+        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 1), (b'two', 2)]
 
     def test_zinterstore_onekey(self):
         self.zadd('foo', {'one': 1})
         self.redis.zinterstore('baz', ['foo'], aggregate='MAX')
-        self.assertEqual(self.redis.zrange('baz', 0, -1, withscores=True),
-                         [(b'one', 1)])
+        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 1)]
 
     def test_zinterstore_nokey(self):
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zinterstore('baz', [], aggregate='MAX')
 
     def test_zinterstore_nan_to_zero(self):
         self.zadd('foo', {'x': math.inf})
         self.zadd('foo2', {'x': math.inf})
         self.redis.zinterstore('bar', OrderedDict([('foo', 1.0), ('foo2', 0.0)]))
-        self.assertEqual(self.redis.zscore('bar', 'x'), 0.0)
+        assert self.redis.zscore('bar', 'x') == 0.0
 
     def test_zunionstore_nokey(self):
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zunionstore('baz', [], aggregate='MAX')
 
     def test_zinterstore_wrong_type(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.zinterstore('baz', ['foo', 'bar'])
 
     def test_empty_zset(self):
         self.zadd('foo', {'one': 1})
         self.redis.zrem('foo', 'one')
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     def test_multidb(self):
         r1 = self.create_redis(db=0)
@@ -2747,26 +2614,26 @@ class TestFakeStrictRedis(unittest.TestCase):
         r1['r1'] = 'r1'
         r2['r2'] = 'r2'
 
-        self.assertTrue('r2' not in r1)
-        self.assertTrue('r1' not in r2)
+        assert 'r2' not in r1
+        assert 'r1' not in r2
 
-        self.assertEqual(r1['r1'], b'r1')
-        self.assertEqual(r2['r2'], b'r2')
+        assert r1['r1'] == b'r1'
+        assert r2['r2'] == b'r2'
 
-        self.assertEqual(r1.flushall(), True)
+        assert r1.flushall() == True
 
-        self.assertTrue('r1' not in r1)
-        self.assertTrue('r2' not in r2)
+        assert 'r1' not in r1
+        assert 'r2' not in r2
 
     def test_basic_sort(self):
         self.redis.rpush('foo', '2')
         self.redis.rpush('foo', '1')
         self.redis.rpush('foo', '3')
 
-        self.assertEqual(self.redis.sort('foo'), [b'1', b'2', b'3'])
+        assert self.redis.sort('foo') == [b'1', b'2', b'3']
 
     def test_empty_sort(self):
-        self.assertEqual(self.redis.sort('foo'), [])
+        assert self.redis.sort('foo') == []
 
     def test_sort_range_offset_range(self):
         self.redis.rpush('foo', '2')
@@ -2774,7 +2641,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.rpush('foo', '4')
         self.redis.rpush('foo', '3')
 
-        self.assertEqual(self.redis.sort('foo', start=0, num=2), [b'1', b'2'])
+        assert self.redis.sort('foo', start=0, num=2) == [b'1', b'2']
 
     def test_sort_range_offset_range_and_desc(self):
         self.redis.rpush('foo', '2')
@@ -2782,11 +2649,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.rpush('foo', '4')
         self.redis.rpush('foo', '3')
 
-        self.assertEqual(self.redis.sort("foo", start=0, num=1, desc=True),
-                         [b"4"])
+        assert self.redis.sort("foo", start=0, num=1, desc=True) == [b"4"]
 
     def test_sort_range_offset_norange(self):
-        with self.assertRaises(redis.RedisError):
+        with pytest.raises(redis.RedisError):
             self.redis.sort('foo', start=1)
 
     def test_sort_range_with_large_range(self):
@@ -2795,14 +2661,13 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.rpush('foo', '4')
         self.redis.rpush('foo', '3')
         # num=20 even though len(foo) is 4.
-        self.assertEqual(self.redis.sort('foo', start=1, num=20),
-                         [b'2', b'3', b'4'])
+        assert self.redis.sort('foo', start=1, num=20) == [b'2', b'3', b'4']
 
     def test_sort_descending(self):
         self.redis.rpush('foo', '1')
         self.redis.rpush('foo', '2')
         self.redis.rpush('foo', '3')
-        self.assertEqual(self.redis.sort('foo', desc=True), [b'3', b'2', b'1'])
+        assert self.redis.sort('foo', desc=True) == [b'3', b'2', b'1']
 
     def test_sort_alpha(self):
         self.redis.rpush('foo', '2a')
@@ -2810,12 +2675,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.rpush('foo', '2b')
         self.redis.rpush('foo', '1a')
 
-        self.assertEqual(self.redis.sort('foo', alpha=True),
-                         [b'1a', b'1b', b'2a', b'2b'])
+        assert self.redis.sort('foo', alpha=True) == [b'1a', b'1b', b'2a', b'2b']
 
     def test_sort_wrong_type(self):
         self.redis.set('string', '3')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.sort('string')
 
     def test_foo(self):
@@ -2823,7 +2687,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.rpush('foo', '1b')
         self.redis.rpush('foo', '2b')
         self.redis.rpush('foo', '1a')
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.sort('foo', alpha=False)
 
     def test_sort_with_store_option(self):
@@ -2832,9 +2696,8 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.rpush('foo', '4')
         self.redis.rpush('foo', '3')
 
-        self.assertEqual(self.redis.sort('foo', store='bar'), 4)
-        self.assertEqual(self.redis.lrange('bar', 0, -1),
-                         [b'1', b'2', b'3', b'4'])
+        assert self.redis.sort('foo', store='bar') == 4
+        assert self.redis.lrange('bar', 0, -1) == [b'1', b'2', b'3', b'4']
 
     def test_sort_with_by_and_get_option(self):
         self.redis.rpush('foo', '2')
@@ -2852,15 +2715,16 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis['data_3'] = 'three'
         self.redis['data_4'] = 'four'
 
-        self.assertEqual(self.redis.sort('foo', by='weight_*', get='data_*'),
-                         [b'four', b'three', b'two', b'one'])
-        self.assertEqual(self.redis.sort('foo', by='weight_*', get='#'),
-                         [b'4', b'3', b'2', b'1'])
-        self.assertEqual(
-            self.redis.sort('foo', by='weight_*', get=('data_*', '#')),
-            [b'four', b'4', b'three', b'3', b'two', b'2', b'one', b'1'])
-        self.assertEqual(self.redis.sort('foo', by='weight_*', get='data_1'),
-                         [None, None, None, None])
+        assert (
+            self.redis.sort('foo', by='weight_*', get='data_*')
+            == [b'four', b'three', b'two', b'one']
+        )
+        assert self.redis.sort('foo', by='weight_*', get='#') == [b'4', b'3', b'2', b'1']
+        assert (
+            self.redis.sort('foo', by='weight_*', get=('data_*', '#'))
+            == [b'four', b'4', b'three', b'3', b'two', b'2', b'one', b'1']
+        )
+        assert self.redis.sort('foo', by='weight_*', get='data_1') == [None, None, None, None]
 
     def test_sort_with_hash(self):
         self.redis.rpush('foo', 'middle')
@@ -2875,17 +2739,17 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.hset('record_eldest', 'age', 20)
         self.redis.hset('record_eldest', 'name', 'adult')
 
-        self.assertEqual(self.redis.sort('foo', by='record_*->age'),
-                         [b'youngest', b'middle', b'eldest'])
-        self.assertEqual(
-            self.redis.sort('foo', by='record_*->age', get='record_*->name'),
-            [b'baby', b'teen', b'adult'])
+        assert self.redis.sort('foo', by='record_*->age') == [b'youngest', b'middle', b'eldest']
+        assert (
+            self.redis.sort('foo', by='record_*->age', get='record_*->name')
+            == [b'baby', b'teen', b'adult']
+        )
 
     def test_sort_with_set(self):
         self.redis.sadd('foo', '3')
         self.redis.sadd('foo', '1')
         self.redis.sadd('foo', '2')
-        self.assertEqual(self.redis.sort('foo'), [b'1', b'2', b'3'])
+        assert self.redis.sort('foo') == [b'1', b'2', b'3']
 
     def test_pipeline(self):
         # The pipeline method returns an object for
@@ -2899,31 +2763,31 @@ class TestFakeStrictRedis(unittest.TestCase):
         res = p.execute()
 
         # Check return values returned as list.
-        self.assertEqual(res, [True, b'bar', 1, 2, [b'quux2', b'quux']])
+        assert res == [True, b'bar', 1, 2, [b'quux2', b'quux']]
 
         # Check side effects happened as expected.
-        self.assertEqual(self.redis.lrange('baz', 0, -1), [b'quux2', b'quux'])
+        assert self.redis.lrange('baz', 0, -1) == [b'quux2', b'quux']
 
         # Check that the command buffer has been emptied.
-        self.assertEqual(p.execute(), [])
+        assert p.execute() == []
 
     def test_pipeline_ignore_errors(self):
         """Test the pipeline ignoring errors when asked."""
         with self.redis.pipeline() as p:
             p.set('foo', 'bar')
             p.rename('baz', 'bats')
-            with self.assertRaises(redis.exceptions.ResponseError):
+            with pytest.raises(redis.exceptions.ResponseError):
                 p.execute()
-            self.assertEqual([], p.execute())
+            assert [] == p.execute()
         with self.redis.pipeline() as p:
             p.set('foo', 'bar')
             p.rename('baz', 'bats')
             res = p.execute(raise_on_error=False)
 
-            self.assertEqual([], p.execute())
+            assert [] == p.execute()
 
-            self.assertEqual(len(res), 2)
-            self.assertIsInstance(res[1], redis.exceptions.ResponseError)
+            assert len(res) == 2
+            assert isinstance(res[1], redis.exceptions.ResponseError)
 
     def test_multiple_successful_watch_calls(self):
         p = self.redis.pipeline()
@@ -2939,7 +2803,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.set('bam', 'boo')
         p.multi()
         p.set('foo', 'bats')
-        self.assertEqual(p.execute(), [True])
+        assert p.execute() == [True]
 
     def test_pipeline_non_transactional(self):
         # For our simple-minded model I don't think
@@ -2947,7 +2811,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         p = self.redis.pipeline(transaction=False)
         res = p.set('baz', 'quux').get('baz').execute()
 
-        self.assertEqual(res, [True, b'quux'])
+        assert res == [True, b'quux']
 
     def test_pipeline_raises_when_watched_key_changed(self):
         self.redis.set('foo', 'bar')
@@ -2963,7 +2827,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         p.multi()
         p.set('foo', nextf)
 
-        with self.assertRaises(redis.WatchError):
+        with pytest.raises(redis.WatchError):
             p.execute()
 
     def test_pipeline_succeeds_despite_unwatched_key_changed(self):
@@ -2982,7 +2846,7 @@ class TestFakeStrictRedis(unittest.TestCase):
             p.execute()
 
             # Check the commands were executed.
-            self.assertEqual(self.redis.get('foo'), b'barbaz')
+            assert self.redis.get('foo') == b'barbaz'
         finally:
             p.reset()
 
@@ -3001,7 +2865,7 @@ class TestFakeStrictRedis(unittest.TestCase):
             p.execute()
 
             # Check the commands were executed.
-            self.assertEqual(self.redis.get('foo'), b'barbaz')
+            assert self.redis.get('foo') == b'barbaz'
         finally:
             p.reset()
 
@@ -3016,7 +2880,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.set('foo', 'three')
         p.multi()
         p.set('foo', 'three')
-        with self.assertRaises(redis.WatchError):
+        with pytest.raises(redis.WatchError):
             p.execute()
 
         # Now watch another key.  It should be ok to change
@@ -3025,7 +2889,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.set('foo', 'four')
         p.multi()
         p.set('bar', 'five')
-        self.assertEqual(p.execute(), [True])
+        assert p.execute() == [True]
 
     def test_pipeline_transaction_shortcut(self):
         # This example taken pretty much from the redis-py documentation.
@@ -3046,9 +2910,9 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         res = self.redis.transaction(client_side_incr, 'OUR-SEQUENCE-KEY')
 
-        self.assertEqual([True], res)
-        self.assertEqual(16, int(self.redis.get('OUR-SEQUENCE-KEY')))
-        self.assertEqual(3, len(calls))
+        assert res == [True]
+        assert int(self.redis.get('OUR-SEQUENCE-KEY')) == 16
+        assert len(calls) == 3
 
     def test_pipeline_transaction_value_from_callable(self):
         def callback(pipe):
@@ -3057,17 +2921,16 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         res = self.redis.transaction(callback, 'OUR-SEQUENCE-KEY',
                                      value_from_callable=True)
-
-        self.assertEqual('OUR-RETURN-VALUE', res)
+        assert res == 'OUR-RETURN-VALUE'
 
     def test_pipeline_empty(self):
         p = self.redis.pipeline()
-        self.assertEqual(0, len(p))
+        assert len(p) == 0
 
     def test_pipeline_length(self):
         p = self.redis.pipeline()
         p.set('baz', 'quux').get('baz')
-        self.assertEqual(2, len(p))
+        assert len(p) == 2
 
     def test_pipeline_no_commands(self):
         # Prior to 3.4, redis-py's execute is a nop if there are no commands
@@ -3077,10 +2940,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         p.watch('foo')
         self.redis.set('foo', '2')
         if REDIS_VERSION >= '3.4':
-            with self.assertRaises(redis.WatchError):
+            with pytest.raises(redis.WatchError):
                 p.execute()
         else:
-            self.assertEqual(p.execute(), [])
+            assert p.execute() == []
 
     def test_pipeline_failed_transaction(self):
         p = self.redis.pipeline()
@@ -3090,9 +2953,9 @@ class TestFakeStrictRedis(unittest.TestCase):
         p.execute_command('set')
         # It should be an ExecAbortError, but redis-py tries to DISCARD after the
         # failed EXEC, which raises a ResponseError.
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             p.execute()
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
 
     def test_pipeline_srem_no_change(self):
         # A regression test for a case picked up by hypothesis tests
@@ -3102,21 +2965,18 @@ class TestFakeStrictRedis(unittest.TestCase):
         p.multi()
         p.set('foo', 'baz')
         p.execute()
-        self.assertEqual(self.redis.get('foo'), b'baz')
+        assert self.redis.get('foo') == b'baz'
 
     def test_key_patterns(self):
         self.redis.mset({'one': 1, 'two': 2, 'three': 3, 'four': 4})
-        self.assertItemsEqual(self.redis.keys('*o*'),
-                              [b'four', b'one', b'two'])
-        self.assertItemsEqual(self.redis.keys('t??'), [b'two'])
-        self.assertItemsEqual(self.redis.keys('*'),
-                              [b'four', b'one', b'two', b'three'])
-        self.assertItemsEqual(self.redis.keys(),
-                              [b'four', b'one', b'two', b'three'])
+        assert sorted(self.redis.keys('*o*')) == [b'four', b'one', b'two']
+        assert self.redis.keys('t??') == [b'two']
+        assert sorted(self.redis.keys('*')) == [b'four', b'one', b'three', b'two']
+        assert sorted(self.redis.keys()) == [b'four', b'one', b'three', b'two']
 
     def test_ping(self):
-        self.assertTrue(self.redis.ping())
-        self.assertEqual(self.raw_command('ping', 'test'), b'test')
+        assert self.redis.ping()
+        assert self.raw_command('ping', 'test') == b'test'
 
     @redis3_only
     def test_ping_pubsub(self):
@@ -3124,9 +2984,9 @@ class TestFakeStrictRedis(unittest.TestCase):
         p.subscribe('channel')
         p.parse_response()    # Consume the subscribe reply
         p.ping()
-        self.assertEqual(p.parse_response(), [b'pong', b''])
+        assert p.parse_response() == [b'pong', b'']
         p.ping('test')
-        self.assertEqual(p.parse_response(), [b'pong', b'test'])
+        assert p.parse_response() == [b'pong', b'test']
 
     @redis3_only
     def test_swapdb(self):
@@ -3135,43 +2995,43 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.set('bar', 'xyz')
         r1.set('foo', 'foo')
         r1.set('baz', 'baz')
-        self.assertTrue(self.redis.swapdb(0, 1))
-        self.assertEqual(self.redis.get('foo'), b'foo')
-        self.assertEqual(self.redis.get('bar'), None)
-        self.assertEqual(self.redis.get('baz'), b'baz')
-        self.assertEqual(r1.get('foo'), b'abc')
-        self.assertEqual(r1.get('bar'), b'xyz')
-        self.assertEqual(r1.get('baz'), None)
+        assert self.redis.swapdb(0, 1)
+        assert self.redis.get('foo') == b'foo'
+        assert self.redis.get('bar') is None
+        assert self.redis.get('baz') == b'baz'
+        assert r1.get('foo') == b'abc'
+        assert r1.get('bar') == b'xyz'
+        assert r1.get('baz') is None
 
     @redis3_only
     def test_swapdb_same_db(self):
-        self.assertTrue(self.redis.swapdb(1, 1))
+        assert self.redis.swapdb(1, 1)
 
     def test_bgsave(self):
-        self.assertTrue(self.redis.bgsave())
+        assert self.redis.bgsave()
 
     def test_save(self):
-        self.assertTrue(self.redis.save())
+        assert self.redis.save()
 
     def test_lastsave(self):
-        self.assertTrue(isinstance(self.redis.lastsave(), datetime))
+        assert isinstance(self.redis.lastsave(), datetime)
 
     @pytest.mark.slow
     def test_bgsave_timestamp_update(self):
         early_timestamp = self.redis.lastsave()
         sleep(1)
-        self.assertTrue(self.redis.bgsave())
+        assert self.redis.bgsave()
         sleep(1)
         late_timestamp = self.redis.lastsave()
-        self.assertLess(early_timestamp, late_timestamp)
+        assert early_timestamp <late_timestamp
 
     @pytest.mark.slow
     def test_save_timestamp_update(self):
         early_timestamp = self.redis.lastsave()
         sleep(1)
-        self.assertTrue(self.redis.save())
+        assert self.redis.save()
         late_timestamp = self.redis.lastsave()
-        self.assertLess(early_timestamp, late_timestamp)
+        assert early_timestamp < late_timestamp
 
     def test_type(self):
         self.redis.set('string_key', "value")
@@ -3180,12 +3040,12 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.zadd("zset_key", {"value": 1})
         self.redis.hset('hset_key', 'key', 'value')
 
-        self.assertEqual(self.redis.type('string_key'), b'string')
-        self.assertEqual(self.redis.type('list_key'), b'list')
-        self.assertEqual(self.redis.type('set_key'), b'set')
-        self.assertEqual(self.redis.type('zset_key'), b'zset')
-        self.assertEqual(self.redis.type('hset_key'), b'hash')
-        self.assertEqual(self.redis.type('none_key'), b'none')
+        assert self.redis.type('string_key') == b'string'
+        assert self.redis.type('list_key') == b'list'
+        assert self.redis.type('set_key') == b'set'
+        assert self.redis.type('zset_key') == b'zset'
+        assert self.redis.type('hset_key') == b'hash'
+        assert self.redis.type('none_key') == b'none'
 
     @pytest.mark.slow
     def test_pubsub_subscribe(self):
@@ -3202,9 +3062,9 @@ class TestFakeStrictRedis(unittest.TestCase):
             key = (key if type(key) == bytes
                    else bytes(key, encoding='utf-8'))
 
-        self.assertEqual(len(keys), 1)
-        self.assertEqual(key, b'channel')
-        self.assertEqual(message, expected_message)
+        assert len(keys) == 1
+        assert key == b'channel'
+        assert message == expected_message
 
     @pytest.mark.slow
     def test_pubsub_psubscribe(self):
@@ -3216,8 +3076,8 @@ class TestFakeStrictRedis(unittest.TestCase):
 
         message = pubsub.get_message()
         keys = list(pubsub.patterns.keys())
-        self.assertEqual(len(keys), 1)
-        self.assertEqual(message, expected_message)
+        assert len(keys) == 1
+        assert message == expected_message
 
     @pytest.mark.slow
     def test_pubsub_unsubscribe(self):
@@ -3235,8 +3095,8 @@ class TestFakeStrictRedis(unittest.TestCase):
         sleep(1)
         message = pubsub.get_message()
         keys = list(pubsub.channels.keys())
-        self.assertEqual(message, expected_message)
-        self.assertEqual(len(keys), 2)
+        assert message == expected_message
+        assert len(keys) == 2
 
         # unsubscribe from multiple
         pubsub.unsubscribe()
@@ -3244,8 +3104,8 @@ class TestFakeStrictRedis(unittest.TestCase):
         pubsub.get_message()
         pubsub.get_message()
         keys = list(pubsub.channels.keys())
-        self.assertEqual(message, expected_message)
-        self.assertEqual(len(keys), 0)
+        assert message == expected_message
+        assert len(keys) == 0
 
     @pytest.mark.slow
     def test_pubsub_punsubscribe(self):
@@ -3263,8 +3123,8 @@ class TestFakeStrictRedis(unittest.TestCase):
         sleep(1)
         message = pubsub.get_message()
         keys = list(pubsub.patterns.keys())
-        self.assertEqual(message, expected_message)
-        self.assertEqual(len(keys), 2)
+        assert message == expected_message
+        assert len(keys) == 2
 
         # unsubscribe from multiple
         pubsub.punsubscribe()
@@ -3272,7 +3132,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         pubsub.get_message()
         pubsub.get_message()
         keys = list(pubsub.patterns.keys())
-        self.assertEqual(len(keys), 0)
+        assert len(keys) == 0
 
     @pytest.mark.slow
     def test_pubsub_listen(self):
@@ -3294,10 +3154,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         msg2 = pubsub.get_message()
         msg3 = pubsub.get_message()
         msg4 = pubsub.get_message()
-        self.assertEqual(msg1['type'], 'subscribe')
-        self.assertEqual(msg2['type'], 'psubscribe')
-        self.assertEqual(msg3['type'], 'psubscribe')
-        self.assertEqual(msg4['type'], 'psubscribe')
+        assert msg1['type'] == 'subscribe'
+        assert msg2['type'] == 'psubscribe'
+        assert msg3['type'] == 'psubscribe'
+        assert msg4['type'] == 'psubscribe'
 
         q = Queue()
         t = threading.Thread(target=_listen, args=(pubsub, q))
@@ -3317,14 +3177,14 @@ class TestFakeStrictRedis(unittest.TestCase):
             bpatterns = [pattern.encode() for pattern in patterns]
             bpatterns.append(channel.encode())
         msg = msg.encode()
-        self.assertEqual(msg1['data'], msg)
-        self.assertIn(msg1['channel'], bpatterns)
-        self.assertEqual(msg2['data'], msg)
-        self.assertIn(msg2['channel'], bpatterns)
-        self.assertEqual(msg3['data'], msg)
-        self.assertIn(msg3['channel'], bpatterns)
-        self.assertEqual(msg4['data'], msg)
-        self.assertIn(msg4['channel'], bpatterns)
+        assert msg1['data'] == msg
+        assert msg1['channel'] in bpatterns
+        assert msg2['data'] == msg
+        assert msg2['channel'] in bpatterns
+        assert msg3['data'] == msg
+        assert msg3['channel'] in bpatterns
+        assert msg4['data'] == msg
+        assert msg4['channel'] in bpatterns
 
     @pytest.mark.slow
     def test_pubsub_listen_handler(self):
@@ -3341,20 +3201,20 @@ class TestFakeStrictRedis(unittest.TestCase):
         sleep(1)
         msg1 = pubsub.get_message()
         msg2 = pubsub.get_message()
-        self.assertEqual(msg1['type'], 'subscribe')
-        self.assertEqual(msg2['type'], 'psubscribe')
+        assert msg1['type'] == 'subscribe'
+        assert msg2['type'] == 'psubscribe'
         msg = 'hello world'
         self.redis.publish(channel, msg)
         sleep(1)
         for i in range(2):
             msg = pubsub.get_message()
-            self.assertIsNone(msg)   # get_message returns None when handler is used
+            assert msg is None   # get_message returns None when handler is used
         pubsub.close()
         calls.sort(key=lambda call: call['type'])
-        self.assertEqual(calls, [
+        assert calls == [
             {'pattern': None, 'channel': b'ch1', 'data': b'hello world', 'type': 'message'},
             {'pattern': b'ch?', 'channel': b'ch1', 'data': b'hello world', 'type': 'pmessage'}
-        ])
+        ]
 
     @pytest.mark.slow
     def test_pubsub_ignore_sub_messages_listen(self):
@@ -3391,14 +3251,14 @@ class TestFakeStrictRedis(unittest.TestCase):
             bpatterns = [pattern.encode() for pattern in patterns]
             bpatterns.append(channel.encode())
         msg = msg.encode()
-        self.assertEqual(msg1['data'], msg)
-        self.assertIn(msg1['channel'], bpatterns)
-        self.assertEqual(msg2['data'], msg)
-        self.assertIn(msg2['channel'], bpatterns)
-        self.assertEqual(msg3['data'], msg)
-        self.assertIn(msg3['channel'], bpatterns)
-        self.assertEqual(msg4['data'], msg)
-        self.assertIn(msg4['channel'], bpatterns)
+        assert msg1['data'] == msg
+        assert msg1['channel'] in bpatterns
+        assert msg2['data'] == msg
+        assert msg2['channel'] in bpatterns
+        assert msg3['data'] == msg
+        assert msg3['channel'] in bpatterns
+        assert msg4['data'] == msg
+        assert msg4['channel'] in bpatterns
 
     @pytest.mark.slow
     def test_pubsub_binary(self):
@@ -3424,7 +3284,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         t.join()
 
         received = q.get()
-        self.assertEqual(received['data'], msg)
+        assert received['data'] == msg
 
     @pytest.mark.slow
     def test_pubsub_run_in_thread(self):
@@ -3438,7 +3298,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.publish("channel", msg)
 
         retrieved = q.get()
-        self.assertEqual(retrieved["data"], msg)
+        assert retrieved["data"] == msg
 
         pubsub_thread.stop()
         # Newer versions of redis wait for an unsubscribe message, which sometimes comes early
@@ -3446,16 +3306,16 @@ class TestFakeStrictRedis(unittest.TestCase):
         if pubsub.channels:
             pubsub.channels = {}
         pubsub_thread.join()
-        self.assertTrue(not pubsub_thread.is_alive())
+        assert not pubsub_thread.is_alive()
 
         pubsub.subscribe(channel=None)
-        with self.assertRaises(redis.exceptions.PubSubError):
+        with pytest.raises(redis.exceptions.PubSubError):
             pubsub_thread = pubsub.run_in_thread()
 
         pubsub.unsubscribe("channel")
 
         pubsub.psubscribe(channel=None)
-        with self.assertRaises(redis.exceptions.PubSubError):
+        with pytest.raises(redis.exceptions.PubSubError):
             pubsub_thread = pubsub.run_in_thread()
 
     @pytest.mark.slow
@@ -3470,42 +3330,43 @@ class TestFakeStrictRedis(unittest.TestCase):
         publish_thread = threading.Thread(target=publish)
         publish_thread.start()
         message = p.get_message(timeout=1)
-        self.assertEqual(message, {'type': 'message', 'pattern': None,
-                                   'channel': b'channel', 'data': b'hello'})
+        assert message == {
+            'type': 'message', 'pattern': None,
+            'channel': b'channel', 'data': b'hello'
+        }
         publish_thread.join()
         message = p.get_message(timeout=0.5)
-        self.assertIsNone(message)
+        assert message is None
 
     def test_pfadd(self):
         key = "hll-pfadd"
-        self.assertEqual(
-            1, self.redis.pfadd(key, "a", "b", "c", "d", "e", "f", "g"))
-        self.assertEqual(7, self.redis.pfcount(key))
+        assert self.redis.pfadd(key, "a", "b", "c", "d", "e", "f", "g") == 1
+        assert self.redis.pfcount(key) == 7
 
     def test_pfcount(self):
         key1 = "hll-pfcount01"
         key2 = "hll-pfcount02"
         key3 = "hll-pfcount03"
-        self.assertEqual(1, self.redis.pfadd(key1, "foo", "bar", "zap"))
-        self.assertEqual(0, self.redis.pfadd(key1, "zap", "zap", "zap"))
-        self.assertEqual(0, self.redis.pfadd(key1, "foo", "bar"))
-        self.assertEqual(3, self.redis.pfcount(key1))
-        self.assertEqual(1, self.redis.pfadd(key2, "1", "2", "3"))
-        self.assertEqual(3, self.redis.pfcount(key2))
-        self.assertEqual(6, self.redis.pfcount(key1, key2))
-        self.assertEqual(1, self.redis.pfadd(key3, "foo", "bar", "zip"))
-        self.assertEqual(3, self.redis.pfcount(key3))
-        self.assertEqual(4, self.redis.pfcount(key1, key3))
-        self.assertEqual(7, self.redis.pfcount(key1, key2, key3))
+        assert self.redis.pfadd(key1, "foo", "bar", "zap") == 1
+        assert self.redis.pfadd(key1, "zap", "zap", "zap") == 0
+        assert self.redis.pfadd(key1, "foo", "bar") == 0
+        assert self.redis.pfcount(key1) == 3
+        assert self.redis.pfadd(key2, "1", "2", "3") == 1
+        assert self.redis.pfcount(key2) == 3
+        assert self.redis.pfcount(key1, key2) == 6
+        assert self.redis.pfadd(key3, "foo", "bar", "zip") == 1
+        assert self.redis.pfcount(key3) == 3
+        assert self.redis.pfcount(key1, key3) == 4
+        assert self.redis.pfcount(key1, key2, key3) == 7
 
     def test_pfmerge(self):
         key1 = "hll-pfmerge01"
         key2 = "hll-pfmerge02"
         key3 = "hll-pfmerge03"
-        self.assertEqual(1, self.redis.pfadd(key1, "foo", "bar", "zap", "a"))
-        self.assertEqual(1, self.redis.pfadd(key2, "a", "b", "c", "foo"))
-        self.assertTrue(self.redis.pfmerge(key3, key1, key2))
-        self.assertEqual(6, self.redis.pfcount(key3))
+        assert self.redis.pfadd(key1, "foo", "bar", "zap", "a") == 1
+        assert self.redis.pfadd(key2, "a", "b", "c", "foo") == 1
+        assert self.redis.pfmerge(key3, key1, key2)
+        assert self.redis.pfcount(key3) == 6
 
     def test_scan(self):
         # Setup the data
@@ -3514,7 +3375,7 @@ class TestFakeStrictRedis(unittest.TestCase):
             v = 'result:%s' % ix
             self.redis.set(k, v)
         expected = self.redis.keys()
-        self.assertEqual(20, len(expected))  # Ensure we know what we're testing
+        assert len(expected) == 20  # Ensure we know what we're testing
 
         # Test that we page through the results and get everything out
         results = []
@@ -3522,7 +3383,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         while cursor != 0:
             cursor, data = self.redis.scan(cursor, count=6)
             results.extend(data)
-        self.assertSetEqual(set(expected), set(results))
+        assert set(expected) == set(results)
 
         # Now test that the MATCH functionality works
         results = []
@@ -3530,15 +3391,15 @@ class TestFakeStrictRedis(unittest.TestCase):
         while cursor != 0:
             cursor, data = self.redis.scan(cursor, match='*7', count=100)
             results.extend(data)
-        self.assertIn(b'scan-test:7', results)
-        self.assertIn(b'scan-test:17', results)
-        self.assertEqual(2, len(results))
+        assert b'scan-test:7' in results
+        assert b'scan-test:17' in results
+        assert len(results) == 2
 
         # Test the match on iterator
         results = [r for r in self.redis.scan_iter(match='*7')]
-        self.assertIn(b'scan-test:7', results)
-        self.assertIn(b'scan-test:17', results)
-        self.assertEqual(2, len(results))
+        assert b'scan-test:7' in results
+        assert b'scan-test:17' in results
+        assert len(results) == 2
 
     def test_sscan(self):
         # Setup the data
@@ -3547,7 +3408,7 @@ class TestFakeStrictRedis(unittest.TestCase):
             k = 'sscan-test:%s' % ix
             self.redis.sadd(name, k)
         expected = self.redis.smembers(name)
-        self.assertEqual(20, len(expected))  # Ensure we know what we're testing
+        assert len(expected) == 20  # Ensure we know what we're testing
 
         # Test that we page through the results and get everything out
         results = []
@@ -3555,11 +3416,11 @@ class TestFakeStrictRedis(unittest.TestCase):
         while cursor != 0:
             cursor, data = self.redis.sscan(name, cursor, count=6)
             results.extend(data)
-        self.assertSetEqual(set(expected), set(results))
+        assert set(expected) == set(results)
 
         # Test the iterator version
         results = [r for r in self.redis.sscan_iter(name, count=6)]
-        self.assertSetEqual(set(expected), set(results))
+        assert set(expected) == set(results)
 
         # Now test that the MATCH functionality works
         results = []
@@ -3567,15 +3428,15 @@ class TestFakeStrictRedis(unittest.TestCase):
         while cursor != 0:
             cursor, data = self.redis.sscan(name, cursor, match='*7', count=100)
             results.extend(data)
-        self.assertIn(b'sscan-test:7', results)
-        self.assertIn(b'sscan-test:17', results)
-        self.assertEqual(2, len(results))
+        assert b'sscan-test:7' in results
+        assert b'sscan-test:17' in results
+        assert len(results) == 2
 
         # Test the match on iterator
         results = [r for r in self.redis.sscan_iter(name, match='*7')]
-        self.assertIn(b'sscan-test:7', results)
-        self.assertIn(b'sscan-test:17', results)
-        self.assertEqual(2, len(results))
+        assert b'sscan-test:7' in results
+        assert b'sscan-test:17' in results
+        assert len(results) == 2
 
     def test_hscan(self):
         # Setup the data
@@ -3585,7 +3446,7 @@ class TestFakeStrictRedis(unittest.TestCase):
             v = 'result:%s' % ix
             self.redis.hset(name, k, v)
         expected = self.redis.hgetall(name)
-        self.assertEqual(20, len(expected))  # Ensure we know what we're testing
+        assert len(expected) == 20  # Ensure we know what we're testing
 
         # Test that we page through the results and get everything out
         results = {}
@@ -3593,13 +3454,13 @@ class TestFakeStrictRedis(unittest.TestCase):
         while cursor != 0:
             cursor, data = self.redis.hscan(name, cursor, count=6)
             results.update(data)
-        self.assertDictEqual(expected, results)
+        assert expected == results
 
         # Test the iterator version
         results = {}
         for key, val in self.redis.hscan_iter(name, count=6):
             results[key] = val
-        self.assertDictEqual(expected, results)
+        assert expected == results
 
         # Now test that the MATCH functionality works
         results = {}
@@ -3607,17 +3468,17 @@ class TestFakeStrictRedis(unittest.TestCase):
         while cursor != 0:
             cursor, data = self.redis.hscan(name, cursor, match='*7', count=100)
             results.update(data)
-        self.assertIn(b'key:7', results)
-        self.assertIn(b'key:17', results)
-        self.assertEqual(2, len(results))
+        assert b'key:7' in results
+        assert b'key:17' in results
+        assert len(results) == 2
 
         # Test the match on iterator
         results = {}
         for key, val in self.redis.hscan_iter(name, match='*7'):
             results[key] = val
-        self.assertIn(b'key:7', results)
-        self.assertIn(b'key:17', results)
-        self.assertEqual(2, len(results))
+        assert b'key:7' in results
+        assert b'key:17' in results
+        assert len(results) == 2
 
     def test_zscan(self):
         # Setup the data
@@ -3630,7 +3491,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         results = {}
         for key, val in self.redis.zscan_iter(name, count=6):
             results[key] = val
-        self.assertEqual(expected, results)
+        assert results == expected
 
         # Now test that the MATCH functionality works
         results = {}
@@ -3638,160 +3499,151 @@ class TestFakeStrictRedis(unittest.TestCase):
         while cursor != 0:
             cursor, data = self.redis.zscan(name, cursor, match='*7', count=6)
             results.update(data)
-        self.assertEqual(results, {b'key:7': 7.0, b'key:17': 17.0})
+        assert results == {b'key:7': 7.0, b'key:17': 17.0}
 
     @pytest.mark.slow
     def test_set_ex_should_expire_value(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         self.redis.set('foo', 'bar', ex=1)
         sleep(2)
-        self.assertEqual(self.redis.get('foo'), None)
+        assert self.redis.get('foo') is None
 
     @pytest.mark.slow
     def test_set_px_should_expire_value(self):
         self.redis.set('foo', 'bar', px=500)
         sleep(1.5)
-        self.assertEqual(self.redis.get('foo'), None)
+        assert self.redis.get('foo') is None
 
     @pytest.mark.slow
     def test_psetex_expire_value(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.psetex('foo', 0, 'bar')
         self.redis.psetex('foo', 500, 'bar')
         sleep(1.5)
-        self.assertEqual(self.redis.get('foo'), None)
+        assert self.redis.get('foo') is None
 
     @pytest.mark.slow
     def test_psetex_expire_value_using_timedelta(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.psetex('foo', timedelta(seconds=0), 'bar')
         self.redis.psetex('foo', timedelta(seconds=0.5), 'bar')
         sleep(1.5)
-        self.assertEqual(self.redis.get('foo'), None)
+        assert self.redis.get('foo') is None
 
     @pytest.mark.slow
     def test_expire_should_expire_key(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         self.redis.expire('foo', 1)
         sleep(1.5)
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.expire('bar', 1), False)
+        assert self.redis.get('foo') is None
+        assert self.redis.expire('bar', 1) == False
 
     def test_expire_should_return_true_for_existing_key(self):
         self.redis.set('foo', 'bar')
-        rv = self.redis.expire('foo', 1)
-        self.assertIs(rv, True)
+        assert self.redis.expire('foo', 1) is True
 
     def test_expire_should_return_false_for_missing_key(self):
-        rv = self.redis.expire('missing', 1)
-        self.assertIs(rv, False)
+        assert self.redis.expire('missing', 1) is False
 
     @pytest.mark.slow
     def test_expire_should_expire_key_using_timedelta(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         self.redis.expire('foo', timedelta(seconds=1))
         sleep(1.5)
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.expire('bar', 1), False)
+        assert self.redis.get('foo') is None
+        assert self.redis.expire('bar', 1) == False
 
     @pytest.mark.slow
     def test_expire_should_expire_immediately_with_millisecond_timedelta(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         self.redis.expire('foo', timedelta(milliseconds=750))
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.expire('bar', 1), False)
+        assert self.redis.get('foo') is None
+        assert self.redis.expire('bar', 1) == False
 
     @pytest.mark.slow
     def test_pexpire_should_expire_key(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         self.redis.pexpire('foo', 150)
         sleep(0.2)
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.pexpire('bar', 1), False)
+        assert self.redis.get('foo') is None
+        assert self.redis.pexpire('bar', 1) == False
 
     def test_pexpire_should_return_truthy_for_existing_key(self):
         self.redis.set('foo', 'bar')
-        rv = self.redis.pexpire('foo', 1)
-        self.assertIs(bool(rv), True)
+        assert self.redis.pexpire('foo', 1)
 
     def test_pexpire_should_return_falsey_for_missing_key(self):
-        rv = self.redis.pexpire('missing', 1)
-        self.assertIs(bool(rv), False)
+        assert not self.redis.pexpire('missing', 1)
 
     @pytest.mark.slow
     def test_pexpire_should_expire_key_using_timedelta(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         self.redis.pexpire('foo', timedelta(milliseconds=750))
         sleep(0.5)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         sleep(0.5)
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.pexpire('bar', 1), False)
+        assert self.redis.get('foo') is None
+        assert self.redis.pexpire('bar', 1) == False
 
     @pytest.mark.slow
     def test_expireat_should_expire_key_by_datetime(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         self.redis.expireat('foo', datetime.now() + timedelta(seconds=1))
         sleep(1.5)
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.expireat('bar', datetime.now()), False)
+        assert self.redis.get('foo') is None
+        assert self.redis.expireat('bar', datetime.now()) == False
 
     @pytest.mark.slow
     def test_expireat_should_expire_key_by_timestamp(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         self.redis.expireat('foo', int(time() + 1))
         sleep(1.5)
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.expire('bar', 1), False)
+        assert self.redis.get('foo') is None
+        assert self.redis.expire('bar', 1) == False
 
     def test_expireat_should_return_true_for_existing_key(self):
         self.redis.set('foo', 'bar')
-        rv = self.redis.expireat('foo', int(time() + 1))
-        self.assertIs(rv, True)
+        assert self.redis.expireat('foo', int(time() + 1)) is True
 
     def test_expireat_should_return_false_for_missing_key(self):
-        rv = self.redis.expireat('missing', int(time() + 1))
-        self.assertIs(rv, False)
+        assert self.redis.expireat('missing', int(time() + 1)) is False
 
     @pytest.mark.slow
     def test_pexpireat_should_expire_key_by_datetime(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         self.redis.pexpireat('foo', datetime.now() + timedelta(milliseconds=150))
         sleep(0.2)
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.pexpireat('bar', datetime.now()), False)
+        assert self.redis.get('foo') is None
+        assert self.redis.pexpireat('bar', datetime.now()) == False
 
     @pytest.mark.slow
     def test_pexpireat_should_expire_key_by_timestamp(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.get('foo') == b'bar'
         self.redis.pexpireat('foo', int(time() * 1000 + 150))
         sleep(0.2)
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.expire('bar', 1), False)
+        assert self.redis.get('foo') is None
+        assert self.redis.expire('bar', 1) == False
 
     def test_pexpireat_should_return_true_for_existing_key(self):
         self.redis.set('foo', 'bar')
-        rv = self.redis.pexpireat('foo', int(time() * 1000 + 150))
-        self.assertIs(bool(rv), True)
+        assert self.redis.pexpireat('foo', int(time() * 1000 + 150))
 
     def test_pexpireat_should_return_false_for_missing_key(self):
-        rv = self.redis.pexpireat('missing', int(time() * 1000 + 150))
-        self.assertIs(bool(rv), False)
+        assert not self.redis.pexpireat('missing', int(time() * 1000 + 150))
 
     def test_expire_should_not_handle_floating_point_values(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaisesRegex(
-                redis.ResponseError, 'value is not an integer or out of range'):
+        with pytest.raises(redis.ResponseError, match='value is not an integer or out of range'):
             self.redis.expire('something_new', 1.2)
             self.redis.pexpire('something_new', 1000.2)
             self.redis.expire('some_unused_key', 1.2)
@@ -3799,37 +3651,37 @@ class TestFakeStrictRedis(unittest.TestCase):
 
     def test_ttl_should_return_minus_one_for_non_expiring_key(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
-        self.assertEqual(self.redis.ttl('foo'), -1)
+        assert self.redis.get('foo') == b'bar'
+        assert self.redis.ttl('foo') == -1
 
     def test_ttl_should_return_minus_two_for_non_existent_key(self):
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.ttl('foo'), -2)
+        assert self.redis.get('foo') is None
+        assert self.redis.ttl('foo') == -2
 
     def test_pttl_should_return_minus_one_for_non_expiring_key(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
-        self.assertEqual(self.redis.pttl('foo'), -1)
+        assert self.redis.get('foo') == b'bar'
+        assert self.redis.pttl('foo') == -1
 
     def test_pttl_should_return_minus_two_for_non_existent_key(self):
-        self.assertEqual(self.redis.get('foo'), None)
-        self.assertEqual(self.redis.pttl('foo'), -2)
+        assert self.redis.get('foo') is None
+        assert self.redis.pttl('foo') == -2
 
     def test_persist(self):
         self.redis.set('foo', 'bar', ex=20)
-        self.assertEqual(self.redis.persist('foo'), 1)
-        self.assertEqual(self.redis.ttl('foo'), -1)
-        self.assertEqual(self.redis.persist('foo'), 0)
+        assert self.redis.persist('foo') == 1
+        assert self.redis.ttl('foo') == -1
+        assert self.redis.persist('foo') == 0
 
     def test_set_existing_key_persists(self):
         self.redis.set('foo', 'bar', ex=20)
         self.redis.set('foo', 'foo')
-        self.assertEqual(self.redis.ttl('foo'), -1)
+        assert self.redis.ttl('foo') == -1
 
     def test_eval_set_value_to_arg(self):
         self.redis.eval('redis.call("SET", KEYS[1], ARGV[1])', 1, 'foo', 'bar')
         val = self.redis.get('foo')
-        self.assertEqual(val, b'bar')
+        assert val == b'bar'
 
     def test_eval_conditional(self):
         lua = """
@@ -3842,10 +3694,10 @@ class TestFakeStrictRedis(unittest.TestCase):
         """
         self.redis.eval(lua, 1, 'foo', 'bar', 'baz')
         val = self.redis.get('foo')
-        self.assertEqual(val, b'bar')
+        assert val == b'bar'
         self.redis.eval(lua, 1, 'foo', 'bar', 'baz')
         val = self.redis.get('foo')
-        self.assertEqual(val, b'baz')
+        assert val == b'baz'
 
     def test_eval_table(self):
         lua = """
@@ -3856,7 +3708,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         return a
         """
         val = self.redis.eval(lua, 0)
-        self.assertEqual(val, [b'foo', b'bar'])
+        assert val == [b'foo', b'bar']
 
     def test_eval_table_with_nil(self):
         lua = """
@@ -3867,7 +3719,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         return a
         """
         val = self.redis.eval(lua, 0)
-        self.assertEqual(val, [b'foo'])
+        assert val == [b'foo']
 
     def test_eval_table_with_numbers(self):
         lua = """
@@ -3876,7 +3728,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         return a
         """
         val = self.redis.eval(lua, 0)
-        self.assertEqual(val, [42])
+        assert val == [42]
 
     def test_eval_nested_table(self):
         lua = """
@@ -3886,7 +3738,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         return a
         """
         val = self.redis.eval(lua, 0)
-        self.assertEqual(val, [[b'foo']])
+        assert val == [[b'foo']]
 
     def test_eval_iterate_over_argv(self):
         lua = """
@@ -3895,7 +3747,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         return ARGV
         """
         val = self.redis.eval(lua, 0, "a", "b", "c")
-        self.assertEqual(val, [b"a", b"b", b"c"])
+        assert val == [b"a", b"b", b"c"]
 
     def test_eval_iterate_over_keys(self):
         lua = """
@@ -3904,34 +3756,31 @@ class TestFakeStrictRedis(unittest.TestCase):
         return KEYS
         """
         val = self.redis.eval(lua, 2, "a", "b", "c")
-        self.assertEqual(val, [b"a", b"b"])
+        assert val == [b"a", b"b"]
 
     def test_eval_mget(self):
         self.redis.set('foo1', 'bar1')
         self.redis.set('foo2', 'bar2')
         val = self.redis.eval('return redis.call("mget", "foo1", "foo2")', 2, 'foo1', 'foo2')
-        self.assertEqual(val, [b'bar1', b'bar2'])
+        assert val == [b'bar1', b'bar2']
 
     @redis2_only
     def test_eval_mget_none(self):
         self.redis.set('foo1', None)
         self.redis.set('foo2', None)
         val = self.redis.eval('return redis.call("mget", "foo1", "foo2")', 2, 'foo1', 'foo2')
-        self.assertEqual(val, [b'None', b'None'])
+        assert val == [b'None', b'None']
 
     def test_eval_mget_not_set(self):
         val = self.redis.eval('return redis.call("mget", "foo1", "foo2")', 2, 'foo1', 'foo2')
-        self.assertEqual(val, [None, None])
+        assert val == [None, None]
 
     def test_eval_hgetall(self):
         self.redis.hset('foo', 'k1', 'bar')
         self.redis.hset('foo', 'k2', 'baz')
         val = self.redis.eval('return redis.call("hgetall", "foo")', 1, 'foo')
         sorted_val = sorted([val[:2], val[2:]])
-        self.assertEqual(
-            sorted_val,
-            [[b'k1', b'bar'], [b'k2', b'baz']]
-        )
+        assert sorted_val == [[b'k1', b'bar'], [b'k2', b'baz']]
 
     def test_eval_hgetall_iterate(self):
         self.redis.hset('foo', 'k1', 'bar')
@@ -3944,10 +3793,7 @@ class TestFakeStrictRedis(unittest.TestCase):
         """
         val = self.redis.eval(lua, 1, 'foo')
         sorted_val = sorted([val[:2], val[2:]])
-        self.assertEqual(
-            sorted_val,
-            [[b'k1', b'bar'], [b'k2', b'baz']]
-        )
+        assert sorted_val == [[b'k1', b'bar'], [b'k2', b'baz']]
 
     @redis2_only
     def test_eval_list_with_nil(self):
@@ -3955,51 +3801,51 @@ class TestFakeStrictRedis(unittest.TestCase):
         self.redis.lpush('foo', None)
         self.redis.lpush('foo', 'baz')
         val = self.redis.eval('return redis.call("lrange", KEYS[1], 0, 2)', 1, 'foo')
-        self.assertEqual(val, [b'baz', b'None', b'bar'])
+        assert val == [b'baz', b'None', b'bar']
 
     def test_eval_invalid_command(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.eval(
                 'return redis.call("FOO")',
                 0
             )
 
     def test_eval_syntax_error(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.eval('return "', 0)
 
     def test_eval_runtime_error(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.eval('error("CRASH")', 0)
 
     def test_eval_more_keys_than_args(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.eval('return 1', 42)
 
     def test_eval_numkeys_float_string(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.eval('return KEYS[1]', '0.7', 'foo')
 
     def test_eval_numkeys_integer_string(self):
         val = self.redis.eval('return KEYS[1]', "1", "foo")
-        self.assertEqual(val, b'foo')
+        assert val == b'foo'
 
     def test_eval_numkeys_negative(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.eval('return KEYS[1]', -1, "foo")
 
     def test_eval_numkeys_float(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.eval('return KEYS[1]', 0.7, "foo")
 
     def test_eval_global_variable(self):
         # Redis doesn't allow script to define global variables
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.eval('a=10', 0)
 
     def test_eval_global_and_return_ok(self):
         # Redis doesn't allow script to define global variables
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.eval(
                 '''
                 a=10
@@ -4011,52 +3857,48 @@ class TestFakeStrictRedis(unittest.TestCase):
     def test_eval_convert_number(self):
         # Redis forces all Lua numbers to integer
         val = self.redis.eval('return 3.2', 0)
-        self.assertEqual(val, 3)
+        assert val == 3
         val = self.redis.eval('return 3.8', 0)
-        self.assertEqual(val, 3)
+        assert val == 3
         val = self.redis.eval('return -3.8', 0)
-        self.assertEqual(val, -3)
+        assert val == -3
 
     def test_eval_convert_bool(self):
         # Redis converts true to 1 and false to nil (which redis-py converts to None)
-        val = self.redis.eval('return false', 0)
-        self.assertIsNone(val)
+        assert self.redis.eval('return false', 0) is None
         val = self.redis.eval('return true', 0)
-        self.assertEqual(val, 1)
-        self.assertNotIsInstance(val, bool)
+        assert val == 1
+        assert not isinstance(val, bool)
 
     def test_eval_call_bool(self):
         # Redis doesn't allow Lua bools to be passed to [p]call
-        with self.assertRaises(redis.ResponseError) as cm:
+        with pytest.raises(redis.ResponseError,
+                           match=r'Lua redis\(\) command arguments must be strings or integers'):
             self.redis.eval('return redis.call("SET", KEYS[1], true)', 1, "testkey")
-        self.assertIn('Lua redis() command arguments must be strings or integers',
-                      str(cm.exception))
 
     @redis2_only
     def test_eval_none_arg(self):
         val = self.redis.eval('return ARGV[1] == "None"', 0, None)
-        self.assertTrue(val)
+        assert val
 
     def test_eval_return_error(self):
-        with self.assertRaises(redis.ResponseError) as cm:
+        with pytest.raises(redis.ResponseError, match='Testing') as exc_info:
             self.redis.eval('return {err="Testing"}', 0)
-        self.assertIsInstance(cm.exception.args[0], str)
-        self.assertIn('Testing', str(cm.exception))
-        with self.assertRaises(redis.ResponseError) as cm:
+        assert isinstance(exc_info.value.args[0], str)
+        with pytest.raises(redis.ResponseError, match='Testing') as exc_info:
             self.redis.eval('return redis.error_reply("Testing")', 0)
-        self.assertIsInstance(cm.exception.args[0], str)
-        self.assertIn('Testing', str(cm.exception))
+        assert isinstance(exc_info.value.args[0], str)
 
     def test_eval_return_redis_error(self):
-        with self.assertRaises(redis.ResponseError) as cm:
+        with pytest.raises(redis.ResponseError) as exc_info:
             self.redis.eval('return redis.pcall("BADCOMMAND")', 0)
-        self.assertIsInstance(cm.exception.args[0], str)
+        assert isinstance(exc_info.value.args[0], str)
 
     def test_eval_return_ok(self):
         val = self.redis.eval('return {ok="Testing"}', 0)
-        self.assertEqual(val, b'Testing')
+        assert val == b'Testing'
         val = self.redis.eval('return redis.status_reply("Testing")', 0)
-        self.assertEqual(val, b'Testing')
+        assert val == b'Testing'
 
     def test_eval_return_ok_nested(self):
         val = self.redis.eval(
@@ -4067,10 +3909,10 @@ class TestFakeStrictRedis(unittest.TestCase):
             ''',
             0
         )
-        self.assertEqual(val, [b'Testing'])
+        assert val == [b'Testing']
 
     def test_eval_return_ok_wrong_type(self):
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             self.redis.eval('return redis.status_reply(123)', 0)
 
     def test_eval_pcall(self):
@@ -4082,24 +3924,24 @@ class TestFakeStrictRedis(unittest.TestCase):
             ''',
             0
         )
-        self.assertIsInstance(val, list)
-        self.assertEqual(len(val), 1)
-        self.assertIsInstance(val[0], ResponseError)
+        assert isinstance(val, list)
+        assert len(val) == 1
+        assert isinstance(val[0], ResponseError)
 
     def test_eval_pcall_return_value(self):
-        with self.assertRaises(ResponseError):
+        with pytest.raises(ResponseError):
             self.redis.eval('return redis.pcall("foo")', 0)
 
     def test_eval_delete(self):
         self.redis.set('foo', 'bar')
         val = self.redis.get('foo')
-        self.assertEqual(val, b'bar')
+        assert val == b'bar'
         val = self.redis.eval('redis.call("DEL", KEYS[1])', 1, 'foo')
-        self.assertIsNone(val)
+        assert val is None
 
     def test_eval_exists(self):
         val = self.redis.eval('return redis.call("exists", KEYS[1]) == 0', 1, 'foo')
-        self.assertEqual(val, 1)
+        assert val == 1
 
     def test_eval_flushdb(self):
         self.redis.set('foo', 'bar')
@@ -4109,7 +3951,7 @@ class TestFakeStrictRedis(unittest.TestCase):
             return type(value) == "table" and value.ok == "OK";
             ''', 0
         )
-        self.assertEqual(val, 1)
+        assert val == 1
 
     def test_eval_flushall(self):
         r1 = self.create_redis(db=0)
@@ -4125,9 +3967,9 @@ class TestFakeStrictRedis(unittest.TestCase):
             ''', 0
         )
 
-        self.assertEqual(val, 1)
-        self.assertNotIn('r1', r1)
-        self.assertNotIn('r2', r2)
+        assert val == 1
+        assert 'r1' not in r1
+        assert 'r2' not in r2
 
     def test_eval_incrbyfloat(self):
         self.redis.set('foo', 0.5)
@@ -4137,7 +3979,7 @@ class TestFakeStrictRedis(unittest.TestCase):
             return type(value) == "string" and tonumber(value) == 2.5;
             ''', 1, 'foo'
         )
-        self.assertEqual(val, 1)
+        assert val == 1
 
     def test_eval_lrange(self):
         self.redis.rpush('foo', 'a', 'b')
@@ -4147,7 +3989,7 @@ class TestFakeStrictRedis(unittest.TestCase):
             return type(value) == "table" and value[1] == "a" and value[2] == "b";
             ''', 1, 'foo'
         )
-        self.assertEqual(val, 1)
+        assert val == 1
 
     def test_eval_ltrim(self):
         self.redis.rpush('foo', 'a', 'b', 'c', 'd')
@@ -4157,8 +3999,8 @@ class TestFakeStrictRedis(unittest.TestCase):
             return type(value) == "table" and value.ok == "OK";
             ''', 1, 'foo'
         )
-        self.assertEqual(val, 1)
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [b'b', b'c'])
+        assert val == 1
+        assert self.redis.lrange('foo', 0, -1) == [b'b', b'c']
 
     def test_eval_lset(self):
         self.redis.rpush('foo', 'a', 'b')
@@ -4168,8 +4010,8 @@ class TestFakeStrictRedis(unittest.TestCase):
             return type(value) == "table" and value.ok == "OK";
             ''', 1, 'foo'
         )
-        self.assertEqual(val, 1)
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [b'z', b'b'])
+        assert val == 1
+        assert self.redis.lrange('foo', 0, -1) == [b'z', b'b']
 
     def test_eval_sdiff(self):
         self.redis.sadd('foo', 'a', 'b', 'c', 'f', 'e', 'd')
@@ -4187,12 +4029,12 @@ class TestFakeStrictRedis(unittest.TestCase):
         # actually part of the redis contract (see
         # https://github.com/antirez/redis/issues/5538), and for Redis 5 we
         # need to sort val to pass the test.
-        self.assertEqual(sorted(val), [b'a', b'c', b'd', b'e', b'f'])
+        assert sorted(val) == [b'a', b'c', b'd', b'e', b'f']
 
     def test_script(self):
         script = self.redis.register_script('return ARGV[1]')
         result = script(args=[42])
-        self.assertEqual(result, b'42')
+        assert result == b'42'
 
     @fake_only("requires access to redis log file")
     def test_lua_log(self):
@@ -4206,15 +4048,17 @@ class TestFakeStrictRedis(unittest.TestCase):
         script = self.redis.register_script(script)
         with self.assertLogs(logger, 'DEBUG') as cm:
             script()
-            self.assertEqual(cm.output, ['DEBUG:%s:debug' % logger.name,
-                                         'INFO:%s:verbose' % logger.name,
-                                         'INFO:%s:notice' % logger.name,
-                                         'WARNING:%s:warning' % logger.name])
+            assert cm.output == [
+                'DEBUG:%s:debug' % logger.name,
+                'INFO:%s:verbose' % logger.name,
+                'INFO:%s:notice' % logger.name,
+                'WARNING:%s:warning' % logger.name
+            ]
 
     def test_lua_log_no_message(self):
         script = "redis.log(redis.LOG_DEBUG)"
         script = self.redis.register_script(script)
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             script()
 
     @fake_only("requires access to redis log file")
@@ -4224,12 +4068,12 @@ class TestFakeStrictRedis(unittest.TestCase):
         script = self.redis.register_script(script)
         with self.assertLogs(logger, 'DEBUG') as cm:
             script()
-        self.assertEqual(cm.output, ['DEBUG:%s:string 1 3.14 string' % logger.name])
+        assert cm.output == ['DEBUG:%s:string 1 3.14 string' % logger.name]
 
     def test_lua_log_wrong_level(self):
         script = "redis.log(10, 'string')"
         script = self.redis.register_script(script)
-        with self.assertRaises(redis.ResponseError):
+        with pytest.raises(redis.ResponseError):
             script()
 
     @fake_only("requires access to redis log file")
@@ -4242,13 +4086,13 @@ class TestFakeStrictRedis(unittest.TestCase):
         script = self.redis.register_script(script)
         with self.assertLogs(logger, 'DEBUG') as cm:
             script()
-        self.assertEqual(cm.output, ['DEBUG:%s:string' % logger.name])
+        assert cm.output == ['DEBUG:%s:string' % logger.name]
 
     @redis3_only
     def test_unlink(self):
         self.redis.set('foo', 'bar')
         self.redis.unlink('foo')
-        self.assertIsNone(self.redis.get('foo'))
+        assert self.redis.get('foo') is None
 
 
 @redis2_only
@@ -4263,28 +4107,23 @@ class TestFakeRedis(unittest.TestCase):
         self.redis.flushall()
         del self.redis
 
-    def assertInRange(self, value, start, end, msg=None):
-        self.assertGreaterEqual(value, start, msg)
-        self.assertLessEqual(value, end, msg)
-
     def create_redis(self, db=0):
         return fakeredis.FakeRedis(db=db, server=self.server)
 
     def test_setex(self):
-        self.assertEqual(self.redis.setex('foo', 'bar', 100), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.setex('foo', 'bar', 100) == True
+        assert self.redis.get('foo') == b'bar'
 
     def test_setex_using_timedelta(self):
-        self.assertEqual(
-            self.redis.setex('foo', 'bar', timedelta(seconds=100)), True)
-        self.assertEqual(self.redis.get('foo'), b'bar')
+        assert self.redis.setex('foo', 'bar', timedelta(seconds=100)) == True
+        assert self.redis.get('foo') == b'bar'
 
     def test_lrem_positive_count(self):
         self.redis.lpush('foo', 'same')
         self.redis.lpush('foo', 'same')
         self.redis.lpush('foo', 'different')
         self.redis.lrem('foo', 'same', 2)
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [b'different'])
+        assert self.redis.lrange('foo', 0, -1) == [b'different']
 
     def test_lrem_negative_count(self):
         self.redis.lpush('foo', 'removeme')
@@ -4295,22 +4134,21 @@ class TestFakeRedis(unittest.TestCase):
         self.redis.lrem('foo', 'removeme', -1)
         # Should remove it from the end of the list,
         # leaving the 'removeme' from the front of the list alone.
-        self.assertEqual(self.redis.lrange('foo', 0, -1),
-                         [b'removeme', b'one', b'two', b'three'])
+        assert self.redis.lrange('foo', 0, -1) == [b'removeme', b'one', b'two', b'three']
 
     def test_lrem_zero_count(self):
         self.redis.lpush('foo', 'one')
         self.redis.lpush('foo', 'one')
         self.redis.lpush('foo', 'one')
         self.redis.lrem('foo', 'one')
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [])
+        assert self.redis.lrange('foo', 0, -1) == []
 
     def test_lrem_default_value(self):
         self.redis.lpush('foo', 'one')
         self.redis.lpush('foo', 'one')
         self.redis.lpush('foo', 'one')
         self.redis.lrem('foo', 'one')
-        self.assertEqual(self.redis.lrange('foo', 0, -1), [])
+        assert self.redis.lrange('foo', 0, -1) == []
 
     def test_lrem_does_not_exist(self):
         self.redis.lpush('foo', 'one')
@@ -4322,78 +4160,75 @@ class TestFakeRedis(unittest.TestCase):
     def test_lrem_return_value(self):
         self.redis.lpush('foo', 'one')
         count = self.redis.lrem('foo', 'one', 0)
-        self.assertEqual(count, 1)
-        self.assertEqual(self.redis.lrem('foo', 'one'), 0)
+        assert count == 1
+        assert self.redis.lrem('foo', 'one') == 0
 
     def test_zadd_deprecated(self):
         result = self.redis.zadd('foo', 'one', 1)
-        self.assertEqual(result, 1)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'one'])
+        assert result == 1
+        assert self.redis.zrange('foo', 0, -1) == [b'one']
 
     def test_zadd_missing_required_params(self):
-        with self.assertRaises(redis.RedisError):
+        with pytest.raises(redis.RedisError):
             # Missing the 'score' param.
             self.redis.zadd('foo', 'one')
-        with self.assertRaises(redis.RedisError):
+        with pytest.raises(redis.RedisError):
             # Missing the 'value' param.
             self.redis.zadd('foo', None, score=1)
-        with self.assertRaises(redis.RedisError):
+        with pytest.raises(redis.RedisError):
             self.redis.zadd('foo')
 
     def test_zadd_with_single_keypair(self):
         result = self.redis.zadd('foo', bar=1)
-        self.assertEqual(result, 1)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'bar'])
+        assert result == 1
+        assert self.redis.zrange('foo', 0, -1) == [b'bar']
 
     def test_zadd_with_multiple_keypairs(self):
         result = self.redis.zadd('foo', bar=1, baz=9)
-        self.assertEqual(result, 2)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'bar', b'baz'])
+        assert result == 2
+        assert self.redis.zrange('foo', 0, -1) == [b'bar', b'baz']
 
     def test_zadd_with_name_is_non_string(self):
         result = self.redis.zadd('foo', 1, 9)
-        self.assertEqual(result, 1)
-        self.assertEqual(self.redis.zrange('foo', 0, -1), [b'1'])
+        assert result == 1
+        assert self.redis.zrange('foo', 0, -1) == [b'1']
 
     def test_ttl_should_return_none_for_non_expiring_key(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
-        self.assertEqual(self.redis.ttl('foo'), None)
+        assert self.redis.get('foo') == b'bar'
+        assert self.redis.ttl('foo') is None
 
     def test_ttl_should_return_value_for_expiring_key(self):
         self.redis.set('foo', 'bar')
         self.redis.expire('foo', 1)
-        self.assertEqual(self.redis.ttl('foo'), 1)
+        assert self.redis.ttl('foo') == 1
         self.redis.expire('foo', 2)
-        self.assertEqual(self.redis.ttl('foo'), 2)
+        assert self.redis.ttl('foo') == 2
         # See https://github.com/antirez/redis/blob/unstable/src/db.c#L632
         ttl = 1000000000
         self.redis.expire('foo', ttl)
-        self.assertEqual(self.redis.ttl('foo'), ttl)
+        assert self.redis.ttl('foo') == ttl
 
     def test_pttl_should_return_none_for_non_expiring_key(self):
         self.redis.set('foo', 'bar')
-        self.assertEqual(self.redis.get('foo'), b'bar')
-        self.assertEqual(self.redis.pttl('foo'), None)
+        assert self.redis.get('foo') == b'bar'
+        assert self.redis.pttl('foo') is None
 
     def test_pttl_should_return_value_for_expiring_key(self):
         d = 100
         self.redis.set('foo', 'bar')
         self.redis.expire('foo', 1)
-        self.assertInRange(self.redis.pttl('foo'), 1000 - d, 1000)
+        assert 1000 - d <= self.redis.pttl('foo') <= 1000
         self.redis.expire('foo', 2)
-        self.assertInRange(self.redis.pttl('foo'), 2000 - d, 2000)
+        assert 2000 - d <= self.redis.pttl('foo') <= 2000
         ttl = 1000000000
         # See https://github.com/antirez/redis/blob/unstable/src/db.c#L632
         self.redis.expire('foo', ttl)
-        self.assertInRange(self.redis.pttl('foo'),
-                           ttl * 1000 - d,
-                           ttl * 1000)
+        assert ttl * 1000 - d <= self.redis.pttl('foo') <= ttl * 1000
 
     def test_expire_should_not_handle_floating_point_values(self):
         self.redis.set('foo', 'bar')
-        with self.assertRaisesRegex(
-                redis.ResponseError, 'value is not an integer or out of range'):
+        with pytest.raises(redis.ResponseError, match='value is not an integer or out of range'):
             self.redis.expire('something_new', 1.2)
             self.redis.pexpire('something_new', 1000.2)
             self.redis.expire('some_unused_key', 1.2)
@@ -4401,75 +4236,74 @@ class TestFakeRedis(unittest.TestCase):
 
     def test_lock(self):
         lock = self.redis.lock('foo')
-        self.assertTrue(lock.acquire())
-        self.assertTrue(self.redis.exists('foo'))
+        assert lock.acquire()
+        assert self.redis.exists('foo')
         lock.release()
-        self.assertFalse(self.redis.exists('foo'))
+        assert not self.redis.exists('foo')
         with self.redis.lock('bar'):
-            self.assertTrue(self.redis.exists('bar'))
-        self.assertFalse(self.redis.exists('bar'))
+            assert self.redis.exists('bar')
+        assert not self.redis.exists('bar')
 
     def test_unlock_without_lock(self):
         lock = self.redis.lock('foo')
-        with self.assertRaises(redis.exceptions.LockError):
+        with pytest.raises(redis.exceptions.LockError):
             lock.release()
 
     @pytest.mark.slow
     def test_unlock_expired(self):
         lock = self.redis.lock('foo', timeout=0.01, sleep=0.001)
-        self.assertTrue(lock.acquire())
+        assert lock.acquire()
         sleep(0.1)
-        with self.assertRaises(redis.exceptions.LockError):
+        with pytest.raises(redis.exceptions.LockError):
             lock.release()
 
     @pytest.mark.slow
     def test_lock_blocking_timeout(self):
         lock = self.redis.lock('foo')
-        self.assertTrue(lock.acquire())
+        assert lock.acquire()
         lock2 = self.redis.lock('foo')
-        self.assertFalse(lock2.acquire(blocking_timeout=1))
+        assert not lock2.acquire(blocking_timeout=1)
 
     def test_lock_nonblocking(self):
         lock = self.redis.lock('foo')
-        self.assertTrue(lock.acquire())
+        assert lock.acquire()
         lock2 = self.redis.lock('foo')
-        self.assertFalse(lock2.acquire(blocking=False))
+        assert not lock2.acquire(blocking=False)
 
     def test_lock_twice(self):
         lock = self.redis.lock('foo')
-        self.assertTrue(lock.acquire(blocking=False))
-        self.assertFalse(lock.acquire(blocking=False))
+        assert lock.acquire(blocking=False)
+        assert not lock.acquire(blocking=False)
 
     def test_acquiring_lock_different_lock_release(self):
         lock1 = self.redis.lock('foo')
         lock2 = self.redis.lock('foo')
-        self.assertTrue(lock1.acquire(blocking=False))
-        self.assertFalse(lock2.acquire(blocking=False))
+        assert lock1.acquire(blocking=False)
+        assert not lock2.acquire(blocking=False)
 
         # Test only releasing lock1 actually releases the lock
-        with self.assertRaises(redis.exceptions.LockError):
+        with pytest.raises(redis.exceptions.LockError):
             lock2.release()
-        self.assertFalse(lock2.acquire(blocking=False))
+        assert not lock2.acquire(blocking=False)
         lock1.release()
         # Locking with lock2 now has the lock
-        self.assertTrue(lock2.acquire(blocking=False))
-        self.assertFalse(lock1.acquire(blocking=False))
+        assert lock2.acquire(blocking=False)
+        assert not lock1.acquire(blocking=False)
 
     def test_lock_extend(self):
         lock = self.redis.lock('foo', timeout=2)
         lock.acquire()
         lock.extend(3)
         ttl = int(self.redis.pttl('foo'))
-        self.assertGreater(ttl, 4000)
-        self.assertLessEqual(ttl, 5000)
+        assert 4000 < ttl <= 5000
 
     def test_lock_extend_exceptions(self):
         lock1 = self.redis.lock('foo', timeout=2)
-        with self.assertRaises(redis.exceptions.LockError):
+        with pytest.raises(redis.exceptions.LockError):
             lock1.extend(3)
         lock2 = self.redis.lock('foo')
         lock2.acquire()
-        with self.assertRaises(redis.exceptions.LockError):
+        with pytest.raises(redis.exceptions.LockError):
             lock2.extend(3)  # Cannot extend a lock with no timeout
 
     @pytest.mark.slow
@@ -4477,7 +4311,7 @@ class TestFakeRedis(unittest.TestCase):
         lock = self.redis.lock('foo', timeout=0.01, sleep=0.001)
         lock.acquire()
         sleep(0.1)
-        with self.assertRaises(redis.exceptions.LockError):
+        with pytest.raises(redis.exceptions.LockError):
             lock.extend(3)
 
 
@@ -4485,7 +4319,7 @@ class DecodeMixin:
     decode_responses = True
 
     def _round_str(self, x):
-        self.assertIsInstance(x, str)
+        assert isinstance(x, str)
         return round(float(x))
 
     @classmethod
@@ -4509,8 +4343,8 @@ class DecodeMixin:
     def assertIn(self, member, container, msg=None):
         super().assertIn(self._decode(member), container)
 
-    def assertItemsEqual(self, a, b):
-        super().assertItemsEqual(a, self._decode(b))
+    def assertCountEqual(self, a, b):
+        super().assertCountEqual(a, self._decode(b))
 
 
 class TestFakeStrictRedisDecodeResponses(DecodeMixin, TestFakeStrictRedis):
@@ -4558,19 +4392,19 @@ class TestInitArgs(unittest.TestCase):
         r1.set('foo', 'bar')
         r3.set('bar', 'baz')
 
-        self.assertIn('foo', r1)
-        self.assertNotIn('foo', r2)
-        self.assertNotIn('foo', r3)
+        assert 'foo' in r1
+        assert 'foo' not in r2
+        assert 'foo' not in r3
 
-        self.assertIn('bar', r3)
-        self.assertIn('bar', r4)
-        self.assertNotIn('bar', r1)
+        assert 'bar' in r3
+        assert 'bar' in r4
+        assert 'bar' not in r1
 
     def test_from_url(self):
         db = fakeredis.FakeStrictRedis.from_url(
             'redis://localhost:6379/0')
         db.set('foo', 'bar')
-        self.assertEqual(db.get('foo'), b'bar')
+        assert db.get('foo') == b'bar'
 
     def test_from_url_with_db_arg(self):
         db = fakeredis.FakeStrictRedis.from_url(
@@ -4583,22 +4417,22 @@ class TestInitArgs(unittest.TestCase):
         db.set('foo', 'foo0')
         db1.set('foo', 'foo1')
         db2.set('foo', 'foo2')
-        self.assertEqual(db.get('foo'), b'foo0')
-        self.assertEqual(db1.get('foo'), b'foo1')
-        self.assertEqual(db2.get('foo'), b'foo2')
+        assert db.get('foo') == b'foo0'
+        assert db1.get('foo') == b'foo1'
+        assert db2.get('foo') == b'foo2'
 
     def test_from_url_db_value_error(self):
         # In ValueError, should default to 0
         db = fakeredis.FakeStrictRedis.from_url(
             'redis://localhost:6379/a')
-        self.assertEqual(db.connection_pool.connection_kwargs['db'], 0)
+        assert db.connection_pool.connection_kwargs['db'] == 0
 
     def test_can_pass_through_extra_args(self):
         db = fakeredis.FakeStrictRedis.from_url(
             'redis://localhost:6379/0',
             decode_responses=True)
         db.set('foo', 'bar')
-        self.assertEqual(db.get('foo'), 'bar')
+        assert db.get('foo') == 'bar'
 
     def test_can_allow_extra_args(self):
         db = fakeredis.FakeStrictRedis.from_url(
@@ -4608,12 +4442,12 @@ class TestInitArgs(unittest.TestCase):
             retry_on_timeout=True,
         )
         fake_conn = db.connection_pool.make_connection()
-        self.assertEqual(fake_conn.socket_connect_timeout, 11)
-        self.assertEqual(fake_conn.socket_timeout, 12)
-        self.assertEqual(fake_conn.socket_keepalive, True)
-        self.assertEqual(fake_conn.socket_keepalive_options, {60: 30})
-        self.assertEqual(fake_conn.socket_type, 1)
-        self.assertEqual(fake_conn.retry_on_timeout, True)
+        assert fake_conn.socket_connect_timeout == 11
+        assert fake_conn.socket_timeout == 12
+        assert fake_conn.socket_keepalive == True
+        assert fake_conn.socket_keepalive_options == {60: 30}
+        assert fake_conn.socket_type == 1
+        assert fake_conn.retry_on_timeout == True
 
         # Make fallback logic match redis-py
         db = fakeredis.FakeStrictRedis.from_url(
@@ -4621,17 +4455,15 @@ class TestInitArgs(unittest.TestCase):
             socket_connect_timeout=None, socket_timeout=30
         )
         fake_conn = db.connection_pool.make_connection()
-        self.assertEqual(
-            fake_conn.socket_connect_timeout, fake_conn.socket_timeout
-        )
-        self.assertEqual(fake_conn.socket_keepalive_options, {})
+        assert fake_conn.socket_connect_timeout == fake_conn.socket_timeout
+        assert fake_conn.socket_keepalive_options == {}
 
     def test_repr(self):
         # repr is human-readable, so we only test that it doesn't crash,
         # and that it contains the db number.
         db = fakeredis.FakeStrictRedis.from_url('redis://localhost:6379/11')
         rep = repr(db)
-        self.assertIn('db=11', rep)
+        assert 'db=11' in rep
 
 
 class TestFakeStrictRedisConnectionErrors(unittest.TestCase):
@@ -4652,83 +4484,83 @@ class TestFakeStrictRedisConnectionErrors(unittest.TestCase):
         del self.redis
 
     def test_flushdb(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.flushdb()
 
     def test_flushall(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.flushall()
 
     def test_append(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.append('key', 'value')
 
     def test_bitcount(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.bitcount('key', 0, 20)
 
     def test_decr(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.decr('key', 2)
 
     def test_exists(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.exists('key')
 
     def test_expire(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.expire('key', 20)
 
     def test_pexpire(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.pexpire('key', 20)
 
     def test_echo(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.echo('value')
 
     def test_get(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.get('key')
 
     def test_getbit(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.getbit('key', 2)
 
     def test_getset(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.getset('key', 'value')
 
     def test_incr(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.incr('key')
 
     def test_incrby(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.incrby('key')
 
     def test_ncrbyfloat(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.incrbyfloat('key')
 
     def test_keys(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.keys()
 
     def test_mget(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.mget(['key1', 'key2'])
 
     def test_mset(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.mset({'key': 'value'})
 
     def test_msetnx(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.msetnx({'key': 'value'})
 
     def test_persist(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.persist('key')
 
     def test_rename(self):
@@ -4736,317 +4568,317 @@ class TestFakeStrictRedisConnectionErrors(unittest.TestCase):
         server.connected = True
         self.redis.set('key1', 'value')
         server.connected = False
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.rename('key1', 'key2')
         server.connected = True
-        self.assertTrue(self.redis.exists('key1'))
+        assert self.redis.exists('key1')
 
     def test_eval(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.eval('', 0)
 
     def test_lpush(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.lpush('name', 1, 2)
 
     def test_lrange(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.lrange('name', 1, 5)
 
     def test_llen(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.llen('name')
 
     def test_lrem(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.lrem('name', 2, 2)
 
     def test_rpush(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.rpush('name', 1)
 
     def test_lpop(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.lpop('name')
 
     def test_lset(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.lset('name', 1, 4)
 
     def test_rpushx(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.rpushx('name', 1)
 
     def test_ltrim(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.ltrim('name', 1, 4)
 
     def test_lindex(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.lindex('name', 1)
 
     def test_lpushx(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.lpushx('name', 1)
 
     def test_rpop(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.rpop('name')
 
     def test_linsert(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.linsert('name', 'where', 'refvalue', 'value')
 
     def test_rpoplpush(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.rpoplpush('src', 'dst')
 
     def test_blpop(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.blpop('keys')
 
     def test_brpop(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.brpop('keys')
 
     def test_brpoplpush(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.brpoplpush('src', 'dst')
 
     def test_hdel(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hdel('name')
 
     def test_hexists(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hexists('name', 'key')
 
     def test_hget(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hget('name', 'key')
 
     def test_hgetall(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hgetall('name')
 
     def test_hincrby(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hincrby('name', 'key')
 
     def test_hincrbyfloat(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hincrbyfloat('name', 'key')
 
     def test_hkeys(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hkeys('name')
 
     def test_hlen(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hlen('name')
 
     def test_hset(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hset('name', 'key', 1)
 
     def test_hsetnx(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hsetnx('name', 'key', 2)
 
     def test_hmset(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hmset('name', {'key': 1})
 
     def test_hmget(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hmget('name', ['a', 'b'])
 
     def test_hvals(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hvals('name')
 
     def test_sadd(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.sadd('name', 1, 2)
 
     def test_scard(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.scard('name')
 
     def test_sdiff(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.sdiff(['a', 'b'])
 
     def test_sdiffstore(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.sdiffstore('dest', ['a', 'b'])
 
     def test_sinter(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.sinter(['a', 'b'])
 
     def test_sinterstore(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.sinterstore('dest', ['a', 'b'])
 
     def test_sismember(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.sismember('name', 20)
 
     def test_smembers(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.smembers('name')
 
     def test_smove(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.smove('src', 'dest', 20)
 
     def test_spop(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.spop('name')
 
     def test_srandmember(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.srandmember('name')
 
     def test_srem(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.srem('name')
 
     def test_sunion(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.sunion(['a', 'b'])
 
     def test_sunionstore(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.sunionstore('dest', ['a', 'b'])
 
     def test_zadd(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.zadd('name', {'key': 'value'})
 
     def test_zcard(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zcard('name')
 
     def test_zcount(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zcount('name', 1, 5)
 
     def test_zincrby(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zincrby('name', 1, 1)
 
     def test_zinterstore(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zinterstore('dest', ['a', 'b'])
 
     def test_zrange(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zrange('name', 1, 5)
 
     def test_zrangebyscore(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zrangebyscore('name', 1, 5)
 
     def test_rangebylex(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zrangebylex('name', 1, 4)
 
     def test_zrem(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zrem('name', 'value')
 
     def test_zremrangebyrank(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zremrangebyrank('name', 1, 5)
 
     def test_zremrangebyscore(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zremrangebyscore('name', 1, 5)
 
     def test_zremrangebylex(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zremrangebylex('name', 1, 5)
 
     def test_zlexcount(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zlexcount('name', 1, 5)
 
     def test_zrevrange(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zrevrange('name', 1, 5, 1)
 
     def test_zrevrangebyscore(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zrevrangebyscore('name', 5, 1)
 
     def test_zrevrangebylex(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zrevrangebylex('name', 5, 1)
 
     def test_zrevran(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zrevrank('name', 2)
 
     def test_zscore(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zscore('name', 2)
 
     def test_zunionstor(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.zunionstore('dest', ['1', '2'])
 
     def test_pipeline(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.pipeline().watch('key')
 
     def test_transaction(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             def func(a):
                 return a * a
 
             self.redis.transaction(func, 3)
 
     def test_lock(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             with self.redis.lock('name'):
                 pass
 
     def test_pubsub(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.pubsub().subscribe('channel')
 
     def test_pfadd(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.pfadd('name', 1)
 
     def test_pfmerge(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.pfmerge('dest', 'a', 'b')
 
     def test_scan(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             list(self.redis.scan())
 
     def test_sscan(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.sscan('name')
 
     def test_hscan(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.redis.hscan('name')
 
     def test_scan_iter(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             list(self.redis.scan_iter())
 
     def test_sscan_iter(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             list(self.redis.sscan_iter('name'))
 
     def test_hscan_iter(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             list(self.redis.hscan_iter('name'))
 
 
@@ -5058,7 +4890,7 @@ class TestPubSubConnected(unittest.TestCase):
         self.pubsub = self.redis.pubsub()
 
     def test_basic_subscribe(self):
-        with self.assertRaises(redis.ConnectionError):
+        with pytest.raises(redis.ConnectionError):
             self.pubsub.subscribe('logs')
 
     def test_subscription_conn_lost(self):
@@ -5073,6 +4905,6 @@ class TestPubSubConnected(unittest.TestCase):
             'channel': b'logs',
             'data': 1
         }
-        self.assertEqual(msg, check, 'Message was not published to channel')
-        with self.assertRaises(redis.ConnectionError):
+        assert msg == check, 'Message was not published to channel'
+        with pytest.raises(redis.ConnectionError):
             self.pubsub.get_message()

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -1952,30 +1952,18 @@ def test_zadd_multiple(r):
 
 
 @redis3_only
-def test_zadd_with_nx(r):
-    zadd(r, 'foo', {'four': 4.0, 'three': 3.0})
-
-    updates = [
-        UpdateCommand(
-            input={'four': 2.0, 'three': 1.0},
-            expected_return_value=0,
-            expected_state=[(b'four', 4.0), (b'three', 3.0)]),
-        UpdateCommand(
-            input={'four': 2.0, 'three': 1.0, 'zero': 0.0},
-            expected_return_value=1,
-            expected_state=[(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]),
-        UpdateCommand(
-            input={'two': 2.0, 'one': 1.0},
-            expected_return_value=2,
-            expected_state=[(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]),
+@pytest.mark.parametrize(
+    'input,return_value,state',
+    [
+        ({'four': 2.0, 'three': 1.0}, 0, [(b'three', 3.0), (b'four', 4.0)]),
+        ({'four': 2.0, 'three': 1.0, 'zero': 0.0}, 1, [(b'zero', 0.0), (b'three', 3.0), (b'four', 4.0)]),
+        ({'two': 2.0, 'one': 1.0}, 2, [(b'one', 1.0), (b'two', 2.0), (b'three', 3.0), (b'four', 4.0)])
     ]
-
-    for update in updates:
-        assert zadd(r, 'foo', update.input, nx=True) == update.expected_return_value
-        assert (
-            sorted(r.zrange('foo', 0, -1, withscores=True))
-            == sorted(update.expected_state)
-        )
+)
+def test_zadd_with_nx(r, input, return_value, state):
+    zadd(r, 'foo', {'four': 4.0, 'three': 3.0})
+    assert zadd(r, 'foo', input, nx=True) == return_value
+    assert r.zrange('foo', 0, -1, withscores=True) == state
 
 
 @redis3_only

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -1,11 +1,8 @@
 from collections import namedtuple
 from time import sleep, time
 from redis.exceptions import ResponseError
-import inspect
-from functools import wraps
 from collections import OrderedDict
 import os
-import sys
 import math
 import threading
 import logging
@@ -28,42 +25,8 @@ REDIS3 = REDIS_VERSION >= '3'
 UpdateCommand = namedtuple('UpdateCommand', 'input expected_return_value expected_state')
 
 
-def redis_must_be_running(cls):
-    # This can probably be improved.  This will determine
-    # at import time if the tests should be run, but we probably
-    # want it to be when the tests are actually run.
-    try:
-        r = redis.StrictRedis('localhost', port=6379)
-        r.ping()
-    except redis.ConnectionError:
-        redis_running = False
-    else:
-        redis_running = True
-    if not redis_running:
-        for name, attribute in inspect.getmembers(cls):
-            if name.startswith('test_'):
-                @wraps(attribute)
-                def skip_test(*args, **kwargs):
-                    pytest.skip("Redis is not running.")
-                setattr(cls, name, skip_test)
-        cls.setup = lambda x: None
-        cls.teardown = lambda x: None
-    return cls
-
-
 redis2_only = pytest.mark.skipif(REDIS3, reason="Test is only applicable to redis-py 2.x")
 redis3_only = pytest.mark.skipif(not REDIS3, reason="Test is only applicable to redis-py 3.x")
-
-
-def fake_only(reason):
-    def wrap(func):
-        @wraps(func)
-        def wrapper(self, *args, **kwargs):
-            if not isinstance(self.redis, (fakeredis.FakeRedis, fakeredis.FakeStrictRedis)):
-                pytest.skip("Works only on fakeredis: %s" % reason)
-            func(self, *args, **kwargs)
-        return wrapper
-    return wrap
 
 
 def key_val_dict(size=100):
@@ -71,4198 +34,4697 @@ def key_val_dict(size=100):
             for i in range(size)}
 
 
-class NoDecodeMixin:
-    decode_responses = False
+def round_str(x):
+    assert isinstance(x, bytes)
+    return round(float(x))
 
-    def _round_str(self, x):
-        assert isinstance(x, bytes)
-        return round(float(x))
 
-    def raw_command(self, *args):
-        """Like execute_command, but does not do command-specific response parsing"""
-        response_callbacks = self.redis.response_callbacks
-        try:
-            self.redis.response_callbacks = {}
-            return self.redis.execute_command(*args)
-        finally:
-            self.redis.response_callbacks = response_callbacks
+def raw_command(r, *args):
+    """Like execute_command, but does not do command-specific response parsing"""
+    response_callbacks = r.response_callbacks
+    try:
+        r.response_callbacks = {}
+        return r.execute_command(*args)
+    finally:
+        r.response_callbacks = response_callbacks
 
-    # Wrap some redis commands to abstract differences between redis-py 2 and 3.
-    def zadd(self, key, d, *args, **kwargs):
-        if REDIS3:
-            return self.redis.zadd(key, d, *args, **kwargs)
+
+# Wrap some redis commands to abstract differences between redis-py 2 and 3.
+def zadd(r, key, d, *args, **kwargs):
+    if REDIS3:
+        return r.zadd(key, d, *args, **kwargs)
+    else:
+        return r.zadd(key, **d)
+
+
+def zincrby(r, key, amount, value):
+    if REDIS3:
+        return r.zincrby(key, amount, value)
+    else:
+        return r.zincrby(key, value, amount)
+
+
+@pytest.fixture(scope="session")
+def is_redis_running():
+    try:
+        r = redis.StrictRedis('localhost', port=6379)
+        r.ping()
+    except redis.ConnectionError:
+        return False
+    else:
+        return True
+
+
+@pytest.fixture
+def fake_server(request):
+    server = fakeredis.FakeServer()
+    server.connected = request.node.get_closest_marker('disconnected') is None
+    return server
+
+
+@pytest.fixture(params=['StrictRedis', 'FakeStrictRedis'])
+def create_redis(request):
+    name = request.param
+    if not name.startswith('Fake') and not request.getfixturevalue('is_redis_running'):
+        pytest.skip('Redis is not running')
+    decode_responses = request.node.get_closest_marker('decode_responses') is not None
+
+    def factory(db=0):
+        if name.startswith('Fake'):
+            fake_server = request.getfixturevalue('fake_server')
+            cls = getattr(fakeredis, name)
+            return cls(db=db, decode_responses=decode_responses, server=fake_server)
         else:
-            return self.redis.zadd(key, **d)
+            cls = getattr(redis, name)
+            return cls('localhost', port=6379, db=db, decode_responses=decode_responses)
 
-    def zincrby(self, key, amount, value):
-        if REDIS3:
-            return self.redis.zincrby(key, amount, value)
-        else:
-            return self.redis.zincrby(key, value, amount)
+    return factory
 
-    def test_large_command(self):
-        self.redis.set('foo', 'bar' * 10000)
-        assert self.redis.get('foo') == b'bar' * 10000
 
-    def test_dbsize(self):
-        assert self.redis.dbsize() == 0
-        self.redis.set('foo', 'bar')
-        self.redis.set('bar', 'foo')
-        assert self.redis.dbsize() == 2
+@pytest.fixture
+def r(request, create_redis):
+    r = create_redis(db=0)
+    connected = request.node.get_closest_marker('disconnected') is None
+    if connected:
+        r.flushall()
+    yield r
+    if connected:
+        r.flushall()
+    r.close()
 
-    def test_flushdb(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.keys() == [b'foo']
-        assert self.redis.flushdb() == True
-        assert self.redis.keys() == []
 
-    def test_set_then_get(self):
-        assert self.redis.set('foo', 'bar') == True
-        assert self.redis.get('foo') == b'bar'
+def test_large_command(r):
+    r.set('foo', 'bar' * 10000)
+    assert r.get('foo') == b'bar' * 10000
 
-    @redis2_only
-    def test_set_None_value(self):
-        assert self.redis.set('foo', None) == True
-        assert self.redis.get('foo') == b'None'
 
-    def test_set_float_value(self):
-        x = 1.23456789123456789
-        self.redis.set('foo', x)
-        assert float(self.redis.get('foo')) == x
+def test_dbsize(r):
+    assert r.dbsize() == 0
+    r.set('foo', 'bar')
+    r.set('bar', 'foo')
+    assert r.dbsize() == 2
 
-    def test_saving_non_ascii_chars_as_value(self):
-        assert self.redis.set('foo', 'Ñandu') == True
-        assert self.redis.get('foo') == 'Ñandu'.encode()
 
-    def test_saving_unicode_type_as_value(self):
-        assert self.redis.set('foo', 'Ñandu') == True
-        assert self.redis.get('foo') == 'Ñandu'.encode()
+def test_flushdb(r):
+    r.set('foo', 'bar')
+    assert r.keys() == [b'foo']
+    assert r.flushdb() == True
+    assert r.keys() == []
 
-    def test_saving_non_ascii_chars_as_key(self):
-        assert self.redis.set('Ñandu', 'foo') == True
-        assert self.redis.get('Ñandu') == b'foo'
 
-    def test_saving_unicode_type_as_key(self):
-        assert self.redis.set('Ñandu', 'foo') == True
-        assert self.redis.get('Ñandu') == b'foo'
-
-    def test_future_newbytes(self):
-        bytes = pytest.importorskip('builtins', reason='future.types not available').bytes
-        self.redis.set(bytes(b'\xc3\x91andu'), 'foo')
-        assert self.redis.get('Ñandu') == b'foo'
-
-    def test_future_newstr(self):
-        str = pytest.importorskip('builtins', reason='future.types not available').str
-        self.redis.set(str('Ñandu'), 'foo')
-        assert self.redis.get('Ñandu') == b'foo'
-
-    def test_get_does_not_exist(self):
-        assert self.redis.get('foo') is None
-
-    def test_get_with_non_str_keys(self):
-        assert self.redis.set('2', 'bar') == True
-        assert self.redis.get(2) == b'bar'
-
-    def test_get_invalid_type(self):
-        assert self.redis.hset('foo', 'key', 'value') == 1
-        with pytest.raises(redis.ResponseError):
-            self.redis.get('foo')
-
-    def test_set_non_str_keys(self):
-        assert self.redis.set(2, 'bar') == True
-        assert self.redis.get(2) == b'bar'
-        assert self.redis.get('2') == b'bar'
-
-    def test_getbit(self):
-        self.redis.setbit('foo', 3, 1)
-        assert self.redis.getbit('foo', 0) == 0
-        assert self.redis.getbit('foo', 1) == 0
-        assert self.redis.getbit('foo', 2) == 0
-        assert self.redis.getbit('foo', 3) == 1
-        assert self.redis.getbit('foo', 4) == 0
-        assert self.redis.getbit('foo', 100) == 0
-
-    def test_getbit_wrong_type(self):
-        self.redis.rpush('foo', b'x')
-        with pytest.raises(redis.ResponseError):
-            self.redis.getbit('foo', 1)
-
-    def test_multiple_bits_set(self):
-        self.redis.setbit('foo', 1, 1)
-        self.redis.setbit('foo', 3, 1)
-        self.redis.setbit('foo', 5, 1)
-
-        assert self.redis.getbit('foo', 0) == 0
-        assert self.redis.getbit('foo', 1) == 1
-        assert self.redis.getbit('foo', 2) == 0
-        assert self.redis.getbit('foo', 3) == 1
-        assert self.redis.getbit('foo', 4) == 0
-        assert self.redis.getbit('foo', 5) == 1
-        assert self.redis.getbit('foo', 6) == 0
-
-    def test_unset_bits(self):
-        self.redis.setbit('foo', 1, 1)
-        self.redis.setbit('foo', 2, 0)
-        self.redis.setbit('foo', 3, 1)
-        assert self.redis.getbit('foo', 1) == 1
-        self.redis.setbit('foo', 1, 0)
-        assert self.redis.getbit('foo', 1) == 0
-        self.redis.setbit('foo', 3, 0)
-        assert self.redis.getbit('foo', 3) == 0
-
-    def test_get_set_bits(self):
-        # set bit 5
-        assert not self.redis.setbit('a', 5, True)
-        assert self.redis.getbit('a', 5)
-        # unset bit 4
-        assert not self.redis.setbit('a', 4, False)
-        assert not self.redis.getbit('a', 4)
-        # set bit 4
-        assert not self.redis.setbit('a', 4, True)
-        assert self.redis.getbit('a', 4)
-        # set bit 5 again
-        assert self.redis.setbit('a', 5, True)
-        assert self.redis.getbit('a', 5)
-
-    def test_setbits_and_getkeys(self):
-        # The bit operations and the get commands
-        # should play nicely with each other.
-        self.redis.setbit('foo', 1, 1)
-        assert self.redis.get('foo') == b'@'
-        self.redis.setbit('foo', 2, 1)
-        assert self.redis.get('foo') == b'`'
-        self.redis.setbit('foo', 3, 1)
-        assert self.redis.get('foo') == b'p'
-        self.redis.setbit('foo', 9, 1)
-        assert self.redis.get('foo') == b'p@'
-        self.redis.setbit('foo', 54, 1)
-        assert self.redis.get('foo') == b'p@\x00\x00\x00\x00\x02'
-
-    def test_setbit_wrong_type(self):
-        self.redis.rpush('foo', b'x')
-        with pytest.raises(redis.ResponseError):
-            self.redis.setbit('foo', 0, 1)
-
-    def test_setbit_expiry(self):
-        self.redis.set('foo', b'0x00', ex=10)
-        self.redis.setbit('foo', 1, 1)
-        assert self.redis.ttl('foo') > 0
-
-    def test_bitcount(self):
-        self.redis.delete('foo')
-        assert self.redis.bitcount('foo') == 0
-        self.redis.setbit('foo', 1, 1)
-        assert self.redis.bitcount('foo') == 1
-        self.redis.setbit('foo', 8, 1)
-        assert self.redis.bitcount('foo') == 2
-        assert self.redis.bitcount('foo', 1, 1) == 1
-        self.redis.setbit('foo', 57, 1)
-        assert self.redis.bitcount('foo') == 3
-        self.redis.set('foo', ' ')
-        assert self.redis.bitcount('foo') == 1
-
-    def test_bitcount_wrong_type(self):
-        self.redis.rpush('foo', b'x')
-        with pytest.raises(redis.ResponseError):
-            self.redis.bitcount('foo')
-
-    def test_getset_not_exist(self):
-        val = self.redis.getset('foo', 'bar')
-        assert val is None
-        assert self.redis.get('foo') == b'bar'
-
-    def test_getset_exists(self):
-        self.redis.set('foo', 'bar')
-        val = self.redis.getset('foo', b'baz')
-        assert val == b'bar'
-        val = self.redis.getset('foo', b'baz2')
-        assert val == b'baz'
-
-    def test_getset_wrong_type(self):
-        self.redis.rpush('foo', b'x')
-        with pytest.raises(redis.ResponseError):
-            self.redis.getset('foo', 'bar')
-
-    def test_setitem_getitem(self):
-        assert self.redis.keys() == []
-        self.redis['foo'] = 'bar'
-        assert self.redis['foo'] == b'bar'
-
-    def test_getitem_non_existent_key(self):
-        assert self.redis.keys() == []
-        with pytest.raises(KeyError):
-            self.redis['noexists']
-
-    def test_strlen(self):
-        self.redis['foo'] = 'bar'
-
-        assert self.redis.strlen('foo') == 3
-        assert self.redis.strlen('noexists') == 0
-
-    def test_strlen_wrong_type(self):
-        self.redis.rpush('foo', b'x')
-        with pytest.raises(redis.ResponseError):
-            self.redis.strlen('foo')
-
-    def test_substr(self):
-        self.redis['foo'] = 'one_two_three'
-        assert self.redis.substr('foo', 0) == b'one_two_three'
-        assert self.redis.substr('foo', 0, 2) == b'one'
-        assert self.redis.substr('foo', 4, 6) == b'two'
-        assert self.redis.substr('foo', -5) == b'three'
-        assert self.redis.substr('foo', -4, -5) == b''
-        assert self.redis.substr('foo', -5, -3) == b'thr'
-
-    def test_substr_noexist_key(self):
-        assert self.redis.substr('foo', 0) == b''
-        assert self.redis.substr('foo', 10) == b''
-        assert self.redis.substr('foo', -5, -1) == b''
-
-    def test_substr_wrong_type(self):
-        self.redis.rpush('foo', b'x')
-        with pytest.raises(redis.ResponseError):
-            self.redis.substr('foo', 0)
-
-    def test_append(self):
-        assert self.redis.set('foo', 'bar')
-        assert self.redis.append('foo', 'baz') == 6
-        assert self.redis.get('foo') == b'barbaz'
-
-    def test_append_with_no_preexisting_key(self):
-        assert self.redis.append('foo', 'bar') == 3
-        assert self.redis.get('foo') == b'bar'
-
-    def test_append_wrong_type(self):
-        self.redis.rpush('foo', b'x')
-        with pytest.raises(redis.ResponseError):
-            self.redis.append('foo', b'x')
-
-    def test_incr_with_no_preexisting_key(self):
-        assert self.redis.incr('foo') == 1
-        assert self.redis.incr('bar', 2) == 2
-
-    def test_incr_by(self):
-        assert self.redis.incrby('foo') == 1
-        assert self.redis.incrby('bar', 2) == 2
-
-    def test_incr_preexisting_key(self):
-        self.redis.set('foo', 15)
-        assert self.redis.incr('foo', 5) == 20
-        assert self.redis.get('foo') == b'20'
-
-    def test_incr_expiry(self):
-        self.redis.set('foo', 15, ex=10)
-        self.redis.incr('foo', 5)
-        assert self.redis.ttl('foo') > 0
-
-    def test_incr_bad_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.incr('foo', 15)
-        self.redis.rpush('foo2', 1)
-        with pytest.raises(redis.ResponseError):
-            self.redis.incr('foo2', 15)
-
-    def test_incr_with_float(self):
-        with pytest.raises(redis.ResponseError):
-            self.redis.incr('foo', 2.0)
-
-    def test_incr_followed_by_mget(self):
-        self.redis.set('foo', 15)
-        assert self.redis.incr('foo', 5) == 20
-        assert self.redis.get('foo') == b'20'
-
-    def test_incr_followed_by_mget_returns_strings(self):
-        self.redis.incr('foo', 1)
-        assert self.redis.mget(['foo']) == [b'1']
-
-    def test_incrbyfloat(self):
-        self.redis.set('foo', 0)
-        assert self.redis.incrbyfloat('foo', 1.0) == 1.0
-        assert self.redis.incrbyfloat('foo', 1.0) == 2.0
-
-    def test_incrbyfloat_with_noexist(self):
-        assert self.redis.incrbyfloat('foo', 1.0) == 1.0
-        assert self.redis.incrbyfloat('foo', 1.0) == 2.0
-
-    def test_incrbyfloat_expiry(self):
-        self.redis.set('foo', 1.5, ex=10)
-        self.redis.incrbyfloat('foo', 2.5)
-        assert self.redis.ttl('foo') > 0
-
-    def test_incrbyfloat_bad_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError, match='not a valid float'):
-            self.redis.incrbyfloat('foo', 1.0)
-        self.redis.rpush('foo2', 1)
-        with pytest.raises(redis.ResponseError):
-            self.redis.incrbyfloat('foo2', 1.0)
-
-    def test_incrbyfloat_precision(self):
-        x = 1.23456789123456789
-        assert self.redis.incrbyfloat('foo', x) == x
-        assert float(self.redis.get('foo')) == x
-
-    def test_decr(self):
-        self.redis.set('foo', 10)
-        assert self.redis.decr('foo') == 9
-        assert self.redis.get('foo') == b'9'
-
-    def test_decr_newkey(self):
-        self.redis.decr('foo')
-        assert self.redis.get('foo') == b'-1'
-
-    def test_decr_expiry(self):
-        self.redis.set('foo', 10, ex=10)
-        self.redis.decr('foo', 5)
-        assert self.redis.ttl('foo') > 0
-
-    def test_decr_badtype(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.decr('foo', 15)
-        self.redis.rpush('foo2', 1)
-        with pytest.raises(redis.ResponseError):
-            self.redis.decr('foo2', 15)
-
-    def test_keys(self):
-        self.redis.set('', 'empty')
-        self.redis.set('abc\n', '')
-        self.redis.set('abc\\', '')
-        self.redis.set('abcde', '')
-        self.redis.set(b'\xfe\xcd', '')
-        assert sorted(self.redis.keys()) == [b'', b'abc\n', b'abc\\', b'abcde', b'\xfe\xcd']
-        assert self.redis.keys('??') == [b'\xfe\xcd']
-        # empty pattern not the same as no pattern
-        assert self.redis.keys('') == [b'']
-        # ? must match \n
-        assert sorted(self.redis.keys('abc?')) == [b'abc\n', b'abc\\']
-        # must be anchored at both ends
-        assert self.redis.keys('abc') == []
-        assert self.redis.keys('bcd') == []
-        # wildcard test
-        assert self.redis.keys('a*de') == [b'abcde']
-        # positive groups
-        assert sorted(self.redis.keys('abc[d\n]*')) == [b'abc\n', b'abcde']
-        assert self.redis.keys('abc[c-e]?') == [b'abcde']
-        assert self.redis.keys('abc[e-c]?') == [b'abcde']
-        assert self.redis.keys('abc[e-e]?') == []
-        assert self.redis.keys('abcd[ef') == [b'abcde']
-        assert self.redis.keys('abcd[]') == []
-        # negative groups
-        assert self.redis.keys('abc[^d\\\\]*') == [b'abc\n']
-        assert self.redis.keys('abc[^]e') == [b'abcde']
-        # escaping
-        assert self.redis.keys(r'abc\?e') == []
-        assert self.redis.keys(r'abc\de') == [b'abcde']
-        assert self.redis.keys(r'abc[\d]e') == [b'abcde']
-        # some escaping cases that redis handles strangely
-        assert self.redis.keys('abc\\') == [b'abc\\']
-        assert self.redis.keys(r'abc[\c-e]e') == []
-        assert self.redis.keys(r'abc[c-\e]e') == []
-
-    def test_exists(self):
-        assert 'foo' not in self.redis
-        self.redis.set('foo', 'bar')
-        assert 'foo' in self.redis
-
-    def test_contains(self):
-        assert not self.redis.exists('foo')
-        self.redis.set('foo', 'bar')
-        assert self.redis.exists('foo')
-
-    def test_rename(self):
-        self.redis.set('foo', 'unique value')
-        assert self.redis.rename('foo', 'bar')
-        assert self.redis.get('foo') is None
-        assert self.redis.get('bar') == b'unique value'
-
-    def test_rename_nonexistent_key(self):
-        with pytest.raises(redis.ResponseError):
-            self.redis.rename('foo', 'bar')
-
-    def test_renamenx_doesnt_exist(self):
-        self.redis.set('foo', 'unique value')
-        assert self.redis.renamenx('foo', 'bar')
-        assert self.redis.get('foo') is None
-        assert self.redis.get('bar') == b'unique value'
-
-    def test_rename_does_exist(self):
-        self.redis.set('foo', 'unique value')
-        self.redis.set('bar', 'unique value2')
-        assert not self.redis.renamenx('foo', 'bar')
-        assert self.redis.get('foo') == b'unique value'
-        assert self.redis.get('bar') == b'unique value2'
-
-    def test_rename_expiry(self):
-        self.redis.set('foo', 'value1', ex=10)
-        self.redis.set('bar', 'value2')
-        self.redis.rename('foo', 'bar')
-        assert self.redis.ttl('bar') > 0
-
-    def test_mget(self):
-        self.redis.set('foo', 'one')
-        self.redis.set('bar', 'two')
-        assert self.redis.mget(['foo', 'bar']) == [b'one', b'two']
-        assert self.redis.mget(['foo', 'bar', 'baz']) == [b'one', b'two', None]
-        assert self.redis.mget('foo', 'bar') == [b'one', b'two']
-
-    @redis2_only
-    def test_mget_none(self):
-        self.redis.set('foo', 'one')
-        self.redis.set('bar', 'two')
-        assert self.redis.mget('foo', 'bar', None) == [b'one', b'two', None]
-
-    def test_mget_with_no_keys(self):
-        if REDIS3:
-            assert self.redis.mget([]) == []
-        else:
-            with pytest.raises(redis.ResponseError, match='wrong number of arguments'):
-                self.redis.mget([])
-
-    def test_mget_mixed_types(self):
-        self.redis.hset('hash', 'bar', 'baz')
-        self.zadd('zset', {'bar': 1})
-        self.redis.sadd('set', 'member')
-        self.redis.rpush('list', 'item1')
-        self.redis.set('string', 'value')
-        assert (
-            self.redis.mget(['hash', 'zset', 'set', 'string', 'absent'])
-            == [None, None, None, b'value', None]
-        )
-
-    def test_mset_with_no_keys(self):
-        with pytest.raises(redis.ResponseError):
-            self.redis.mset({})
-
-    def test_mset(self):
-        assert self.redis.mset({'foo': 'one', 'bar': 'two'}) == True
-        assert self.redis.mset({'foo': 'one', 'bar': 'two'}) == True
-        assert self.redis.mget('foo', 'bar') == [b'one', b'two']
-
-    @redis2_only
-    def test_mset_accepts_kwargs(self):
-        assert self.redis.mset(foo='one', bar='two') == True
-        assert self.redis.mset(foo='one', baz='three') == True
-        assert self.redis.mget('foo', 'bar', 'baz') == [b'one', b'two', b'three']
-
-    def test_msetnx(self):
-        assert self.redis.msetnx({'foo': 'one', 'bar': 'two'}) == True
-        assert self.redis.msetnx({'bar': 'two', 'baz': 'three'}) == False
-        assert self.redis.mget('foo', 'bar', 'baz') == [b'one', b'two', None]
-
-    def test_setex(self):
-        assert self.redis.setex('foo', 100, 'bar') == True
-        assert self.redis.get('foo') == b'bar'
-
-    def test_setex_using_timedelta(self):
-        assert self.redis.setex('foo', timedelta(seconds=100), 'bar') == True
-        assert self.redis.get('foo') == b'bar'
-
-    def test_setex_using_float(self):
-        with pytest.raises(redis.ResponseError, match='integer'):
-            self.redis.setex('foo', 1.2, 'bar')
-
-    def test_set_ex(self):
-        assert self.redis.set('foo', 'bar', ex=100) == True
-        assert self.redis.get('foo') == b'bar'
-
-    def test_set_ex_using_timedelta(self):
-        assert self.redis.set('foo', 'bar', ex=timedelta(seconds=100)) == True
-        assert self.redis.get('foo') == b'bar'
-
-    def test_set_px(self):
-        assert self.redis.set('foo', 'bar', px=100) == True
-        assert self.redis.get('foo') == b'bar'
-
-    def test_set_px_using_timedelta(self):
-        assert self.redis.set('foo', 'bar', px=timedelta(milliseconds=100)) == True
-        assert self.redis.get('foo') == b'bar'
-
-    def test_set_raises_wrong_ex(self):
-        with pytest.raises(ResponseError):
-            self.redis.set('foo', 'bar', ex=-100)
-        with pytest.raises(ResponseError):
-            self.redis.set('foo', 'bar', ex=0)
-        assert not self.redis.exists('foo')
-
-    def test_set_using_timedelta_raises_wrong_ex(self):
-        with pytest.raises(ResponseError):
-            self.redis.set('foo', 'bar', ex=timedelta(seconds=-100))
-        with pytest.raises(ResponseError):
-            self.redis.set('foo', 'bar', ex=timedelta(seconds=0))
-        assert not self.redis.exists('foo')
-
-    def test_set_raises_wrong_px(self):
-        with pytest.raises(ResponseError):
-            self.redis.set('foo', 'bar', px=-100)
-        with pytest.raises(ResponseError):
-            self.redis.set('foo', 'bar', px=0)
-        assert not self.redis.exists('foo')
-
-    def test_set_using_timedelta_raises_wrong_px(self):
-        with pytest.raises(ResponseError):
-            self.redis.set('foo', 'bar', px=timedelta(milliseconds=-100))
-        with pytest.raises(ResponseError):
-            self.redis.set('foo', 'bar', px=timedelta(milliseconds=0))
-        assert not self.redis.exists('foo')
-
-    def test_setex_raises_wrong_ex(self):
-        with pytest.raises(ResponseError):
-            self.redis.setex('foo', -100, 'bar')
-        with pytest.raises(ResponseError):
-            self.redis.setex('foo', 0, 'bar')
-        assert not self.redis.exists('foo')
-
-    def test_setex_using_timedelta_raises_wrong_ex(self):
-        with pytest.raises(ResponseError):
-            self.redis.setex('foo', timedelta(seconds=-100), 'bar')
-        with pytest.raises(ResponseError):
-            self.redis.setex('foo', timedelta(seconds=-100), 'bar')
-        assert not self.redis.exists('foo')
-
-    def test_setnx(self):
-        assert self.redis.setnx('foo', 'bar') == True
-        assert self.redis.get('foo') == b'bar'
-        assert self.redis.setnx('foo', 'baz') == False
-        assert self.redis.get('foo') == b'bar'
-
-    def test_set_nx(self):
-        assert self.redis.set('foo', 'bar', nx=True) == True
-        assert self.redis.get('foo') == b'bar'
-        assert self.redis.set('foo', 'bar', nx=True) is None
-        assert self.redis.get('foo') == b'bar'
-
-    def test_set_xx(self):
-        assert self.redis.set('foo', 'bar', xx=True) is None
-        self.redis.set('foo', 'bar')
-        assert self.redis.set('foo', 'bar', xx=True) == True
-
-    def test_del_operator(self):
-        self.redis['foo'] = 'bar'
-        del self.redis['foo']
-        assert self.redis.get('foo') is None
-
-    def test_delete(self):
-        self.redis['foo'] = 'bar'
-        assert self.redis.delete('foo') == True
-        assert self.redis.get('foo') is None
-
-    def test_echo(self):
-        assert self.redis.echo(b'hello') == b'hello'
-        assert self.redis.echo('hello') == b'hello'
-
-    @pytest.mark.slow
-    def test_delete_expire(self):
-        self.redis.set("foo", "bar", ex=1)
-        self.redis.delete("foo")
-        self.redis.set("foo", "bar")
-        sleep(2)
-        assert self.redis.get("foo") == b'bar'
-
-    def test_delete_multiple(self):
-        self.redis['one'] = 'one'
-        self.redis['two'] = 'two'
-        self.redis['three'] = 'three'
-        # Since redis>=2.7.6 returns number of deleted items.
-        assert self.redis.delete('one', 'two') == 2
-        assert self.redis.get('one') is None
-        assert self.redis.get('two') is None
-        assert self.redis.get('three') == b'three'
-        assert self.redis.delete('one', 'two') == 0
-        # If any keys are deleted, True is returned.
-        assert self.redis.delete('two', 'three', 'three') == 1
-        assert self.redis.get('three') is None
-
-    def test_delete_nonexistent_key(self):
-        assert self.redis.delete('foo') == False
-
-    # Tests for the list type.
-
-    @redis2_only
-    def test_rpush_then_lrange_with_nested_list1(self):
-        assert self.redis.rpush('foo', [12345, 6789]) == 1
-        assert self.redis.rpush('foo', [54321, 9876]) == 2
-        assert self.redis.lrange('foo', 0, -1) == [b'[12345, 6789]', b'[54321, 9876]']
-
-    @redis2_only
-    def test_rpush_then_lrange_with_nested_list2(self):
-        assert self.redis.rpush('foo', [12345, 'banana']) == 1
-        assert self.redis.rpush('foo', [54321, 'elephant']) == 2
-        assert self.redis.lrange('foo', 0, -1), [b'[12345, \'banana\']', b'[54321, \'elephant\']']
-
-    @redis2_only
-    def test_rpush_then_lrange_with_nested_list3(self):
-        assert self.redis.rpush('foo', [12345, []]) == 1
-        assert self.redis.rpush('foo', [54321, []]) == 2
-        assert self.redis.lrange('foo', 0, -1) == [b'[12345, []]', b'[54321, []]']
-
-    def test_lpush_then_lrange_all(self):
-        assert self.redis.lpush('foo', 'bar') == 1
-        assert self.redis.lpush('foo', 'baz') == 2
-        assert self.redis.lpush('foo', 'bam', 'buzz') == 4
-        assert self.redis.lrange('foo', 0, -1) == [b'buzz', b'bam', b'baz', b'bar']
-
-    def test_lpush_then_lrange_portion(self):
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'two')
-        self.redis.lpush('foo', 'three')
-        self.redis.lpush('foo', 'four')
-        assert self.redis.lrange('foo', 0, 2) == [b'four', b'three', b'two']
-        assert self.redis.lrange('foo', 0, 3) == [b'four', b'three', b'two', b'one']
-
-    def test_lrange_negative_indices(self):
-        self.redis.rpush('foo', 'a', 'b', 'c')
-        assert self.redis.lrange('foo', -1, -2) == []
-        assert self.redis.lrange('foo', -2, -1) == [b'b', b'c']
-
-    def test_lpush_key_does_not_exist(self):
-        assert self.redis.lrange('foo', 0, -1) == []
-
-    def test_lpush_with_nonstr_key(self):
-        self.redis.lpush(1, 'one')
-        self.redis.lpush(1, 'two')
-        self.redis.lpush(1, 'three')
-        assert self.redis.lrange(1, 0, 2) == [b'three', b'two', b'one']
-        assert self.redis.lrange('1', 0, 2) == [b'three', b'two', b'one']
-
-    def test_lpush_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.lpush('foo', 'element')
-
-    def test_llen(self):
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'two')
-        self.redis.lpush('foo', 'three')
-        assert self.redis.llen('foo') == 3
-
-    def test_llen_no_exist(self):
-        assert self.redis.llen('foo') == 0
-
-    def test_llen_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.llen('foo')
-
-    def test_lrem_positive_count(self):
-        self.redis.lpush('foo', 'same')
-        self.redis.lpush('foo', 'same')
-        self.redis.lpush('foo', 'different')
-        self.redis.lrem('foo', 2, 'same')
-        assert self.redis.lrange('foo', 0, -1) == [b'different']
-
-    def test_lrem_negative_count(self):
-        self.redis.lpush('foo', 'removeme')
-        self.redis.lpush('foo', 'three')
-        self.redis.lpush('foo', 'two')
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'removeme')
-        self.redis.lrem('foo', -1, 'removeme')
-        # Should remove it from the end of the list,
-        # leaving the 'removeme' from the front of the list alone.
-        assert self.redis.lrange('foo', 0, -1) == [b'removeme', b'one', b'two', b'three']
-
-    def test_lrem_zero_count(self):
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'one')
-        self.redis.lrem('foo', 0, 'one')
-        assert self.redis.lrange('foo', 0, -1) == []
-
-    def test_lrem_default_value(self):
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'one')
-        self.redis.lrem('foo', 0, 'one')
-        assert self.redis.lrange('foo', 0, -1) == []
-
-    def test_lrem_does_not_exist(self):
-        self.redis.lpush('foo', 'one')
-        self.redis.lrem('foo', 0, 'one')
-        # These should be noops.
-        self.redis.lrem('foo', -2, 'one')
-        self.redis.lrem('foo', 2, 'one')
-
-    def test_lrem_return_value(self):
-        self.redis.lpush('foo', 'one')
-        count = self.redis.lrem('foo', 0, 'one')
-        assert count == 1
-        assert self.redis.lrem('foo', 0, 'one') == 0
-
-    def test_lrem_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.lrem('foo', 0, 'element')
-
-    def test_rpush(self):
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        self.redis.rpush('foo', 'three')
-        self.redis.rpush('foo', 'four', 'five')
-        assert self.redis.lrange('foo', 0, -1) == [b'one', b'two', b'three', b'four', b'five']
-
-    def test_rpush_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.rpush('foo', 'element')
-
-    def test_lpop(self):
-        assert self.redis.rpush('foo', 'one') == 1
-        assert self.redis.rpush('foo', 'two') == 2
-        assert self.redis.rpush('foo', 'three') == 3
-        assert self.redis.lpop('foo') == b'one'
-        assert self.redis.lpop('foo') == b'two'
-        assert self.redis.lpop('foo') == b'three'
-
-    def test_lpop_empty_list(self):
-        self.redis.rpush('foo', 'one')
-        self.redis.lpop('foo')
-        assert self.redis.lpop('foo') is None
-        # Verify what happens if we try to pop from a key
-        # we've never seen before.
-        assert self.redis.lpop('noexists') is None
-
-    def test_lpop_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.lpop('foo')
-
-    def test_lset(self):
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        self.redis.rpush('foo', 'three')
-        self.redis.lset('foo', 0, 'four')
-        self.redis.lset('foo', -2, 'five')
-        assert self.redis.lrange('foo', 0, -1) == [b'four', b'five', b'three']
-
-    def test_lset_index_out_of_range(self):
-        self.redis.rpush('foo', 'one')
-        with pytest.raises(redis.ResponseError):
-            self.redis.lset('foo', 3, 'three')
-
-    def test_lset_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.lset('foo', 0, 'element')
-
-    def test_rpushx(self):
-        self.redis.rpush('foo', 'one')
-        self.redis.rpushx('foo', 'two')
-        self.redis.rpushx('bar', 'three')
-        assert self.redis.lrange('foo', 0, -1) == [b'one', b'two']
-        assert self.redis.lrange('bar', 0, -1) == []
-
-    def test_rpushx_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.rpushx('foo', 'element')
-
-    def test_ltrim(self):
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        self.redis.rpush('foo', 'three')
-        self.redis.rpush('foo', 'four')
-
-        assert self.redis.ltrim('foo', 1, 3)
-        assert self.redis.lrange('foo', 0, -1) == [b'two', b'three', b'four']
-        assert self.redis.ltrim('foo', 1, -1)
-        assert self.redis.lrange('foo', 0, -1) == [b'three', b'four']
-
-    def test_ltrim_with_non_existent_key(self):
-        assert self.redis.ltrim('foo', 0, -1)
-
-    def test_ltrim_expiry(self):
-        self.redis.rpush('foo', 'one', 'two', 'three')
-        self.redis.expire('foo', 10)
-        self.redis.ltrim('foo', 1, 2)
-        assert self.redis.ttl('foo') > 0
-
-    def test_ltrim_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.ltrim('foo', 1, -1)
-
-    def test_lindex(self):
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        assert self.redis.lindex('foo', 0) == b'one'
-        assert self.redis.lindex('foo', 4) is None
-        assert self.redis.lindex('bar', 4) is None
-
-    def test_lindex_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.lindex('foo', 0)
-
-    def test_lpushx(self):
-        self.redis.lpush('foo', 'two')
-        self.redis.lpushx('foo', 'one')
-        self.redis.lpushx('bar', 'one')
-        assert self.redis.lrange('foo', 0, -1) == [b'one', b'two']
-        assert self.redis.lrange('bar', 0, -1) == []
-
-    def test_lpushx_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.lpushx('foo', 'element')
-
-    def test_rpop(self):
-        assert self.redis.rpop('foo') is None
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        assert self.redis.rpop('foo') == b'two'
-        assert self.redis.rpop('foo') == b'one'
-        assert self.redis.rpop('foo') is None
-
-    def test_rpop_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.rpop('foo')
-
-    def test_linsert_before(self):
-        self.redis.rpush('foo', 'hello')
-        self.redis.rpush('foo', 'world')
-        assert self.redis.linsert('foo', 'before', 'world', 'there') == 3
-        assert self.redis.lrange('foo', 0, -1) == [b'hello', b'there', b'world']
-
-    def test_linsert_after(self):
-        self.redis.rpush('foo', 'hello')
-        self.redis.rpush('foo', 'world')
-        assert self.redis.linsert('foo', 'after', 'hello', 'there') == 3
-        assert self.redis.lrange('foo', 0, -1) == [b'hello', b'there', b'world']
-
-    def test_linsert_no_pivot(self):
-        self.redis.rpush('foo', 'hello')
-        self.redis.rpush('foo', 'world')
-        assert self.redis.linsert('foo', 'after', 'goodbye', 'bar') == -1
-        assert self.redis.lrange('foo', 0, -1) == [b'hello', b'world']
-
-    def test_linsert_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.linsert('foo', 'after', 'bar', 'element')
-
-    def test_rpoplpush(self):
-        assert self.redis.rpoplpush('foo', 'bar') is None
-        assert self.redis.lpop('bar') is None
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        self.redis.rpush('bar', 'one')
-
-        assert self.redis.rpoplpush('foo', 'bar') == b'two'
-        assert self.redis.lrange('foo', 0, -1) == [b'one']
-        assert self.redis.lrange('bar', 0, -1) == [b'two', b'one']
-
-        # Catch instances where we store bytes and strings inconsistently
-        # and thus bar = ['two', b'one']
-        assert self.redis.lrem('bar', -1, 'two') == 1
-
-    def test_rpoplpush_to_nonexistent_destination(self):
-        self.redis.rpush('foo', 'one')
-        assert self.redis.rpoplpush('foo', 'bar') == b'one'
-        assert self.redis.rpop('bar') == b'one'
-
-    def test_rpoplpush_expiry(self):
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('bar', 'two')
-        self.redis.expire('bar', 10)
-        self.redis.rpoplpush('foo', 'bar')
-        assert self.redis.ttl('bar') > 0
-
-    def test_rpoplpush_one_to_self(self):
-        self.redis.rpush('list', 'element')
-        assert self.redis.brpoplpush('list', 'list') == b'element'
-        assert self.redis.lrange('list', 0, -1) == [b'element']
-
-    def test_rpoplpush_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        self.redis.rpush('list', 'element')
-        with pytest.raises(redis.ResponseError):
-            self.redis.rpoplpush('foo', 'list')
-        assert self.redis.get('foo') == b'bar'
-        assert self.redis.lrange('list', 0, -1) == [b'element']
-        with pytest.raises(redis.ResponseError):
-            self.redis.rpoplpush('list', 'foo')
-        assert self.redis.get('foo') == b'bar'
-        assert self.redis.lrange('list', 0, -1) == [b'element']
-
-    def test_blpop_single_list(self):
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        self.redis.rpush('foo', 'three')
-        assert self.redis.blpop(['foo'], timeout=1) == (b'foo', b'one')
-
-    def test_blpop_test_multiple_lists(self):
-        self.redis.rpush('baz', 'zero')
-        assert self.redis.blpop(['foo', 'baz'], timeout=1) == (b'baz', b'zero')
-        assert not self.redis.exists('baz')
-
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        # bar has nothing, so the returned value should come
-        # from foo.
-        assert self.redis.blpop(['bar', 'foo'], timeout=1) == (b'foo', b'one')
-        self.redis.rpush('bar', 'three')
-        # bar now has something, so the returned value should come
-        # from bar.
-        assert self.redis.blpop(['bar', 'foo'], timeout=1) == (b'bar', b'three')
-        assert self.redis.blpop(['bar', 'foo'], timeout=1) == (b'foo', b'two')
-
-    def test_blpop_allow_single_key(self):
-        # blpop converts single key arguments to a one element list.
-        self.redis.rpush('foo', 'one')
-        assert self.redis.blpop('foo', timeout=1) == (b'foo', b'one')
-
-    @pytest.mark.slow
-    def test_blpop_block(self):
-        def push_thread():
-            sleep(0.5)
-            self.redis.rpush('foo', 'value1')
-            sleep(0.5)
-            # Will wake the condition variable
-            self.redis.set('bar', 'go back to sleep some more')
-            self.redis.rpush('foo', 'value2')
-
-        thread = threading.Thread(target=push_thread)
-        thread.start()
-        try:
-            assert self.redis.blpop('foo') == (b'foo', b'value1')
-            assert self.redis.blpop('foo', timeout=5) == (b'foo', b'value2')
-        finally:
-            thread.join()
-
-    def test_blpop_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.blpop('foo', timeout=1)
-
-    def test_blpop_transaction(self):
-        p = self.redis.pipeline()
-        p.multi()
-        p.blpop('missing', timeout=1000)
-        result = p.execute()
-        # Blocking commands behave like non-blocking versions in transactions
-        assert result == [None]
-
-    def test_eval_blpop(self):
-        self.redis.rpush('foo', 'bar')
-        with pytest.raises(redis.ResponseError, match='not allowed from scripts'):
-            self.redis.eval('return redis.pcall("BLPOP", KEYS[1], 1)', 1, 'foo')
-
-    def test_brpop_test_multiple_lists(self):
-        self.redis.rpush('baz', 'zero')
-        assert self.redis.brpop(['foo', 'baz'], timeout=1) == (b'baz', b'zero')
-        assert not self.redis.exists('baz')
-
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        assert self.redis.brpop(['bar', 'foo'], timeout=1) == (b'foo', b'two')
-
-    def test_brpop_single_key(self):
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        assert self.redis.brpop('foo', timeout=1) == (b'foo', b'two')
-
-    @pytest.mark.slow
-    def test_brpop_block(self):
-        def push_thread():
-            sleep(0.5)
-            self.redis.rpush('foo', 'value1')
-            sleep(0.5)
-            # Will wake the condition variable
-            self.redis.set('bar', 'go back to sleep some more')
-            self.redis.rpush('foo', 'value2')
-
-        thread = threading.Thread(target=push_thread)
-        thread.start()
-        try:
-            assert self.redis.brpop('foo') == (b'foo', b'value1')
-            assert self.redis.brpop('foo', timeout=5) == (b'foo', b'value2')
-        finally:
-            thread.join()
-
-    def test_brpop_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.brpop('foo', timeout=1)
-
-    def test_brpoplpush_multi_keys(self):
-        assert self.redis.lpop('bar') is None
-        self.redis.rpush('foo', 'one')
-        self.redis.rpush('foo', 'two')
-        assert self.redis.brpoplpush('foo', 'bar', timeout=1) == b'two'
-        assert self.redis.lrange('bar', 0, -1) == [b'two']
-
-        # Catch instances where we store bytes and strings inconsistently
-        # and thus bar = ['two']
-        assert self.redis.lrem('bar', -1, 'two') == 1
-
-    def test_brpoplpush_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        self.redis.rpush('list', 'element')
-        with pytest.raises(redis.ResponseError):
-            self.redis.brpoplpush('foo', 'list')
-        assert self.redis.get('foo') == b'bar'
-        assert self.redis.lrange('list', 0, -1) == [b'element']
-        with pytest.raises(redis.ResponseError):
-            self.redis.brpoplpush('list', 'foo')
-        assert self.redis.get('foo') == b'bar'
-        assert self.redis.lrange('list', 0, -1) == [b'element']
-
-    @pytest.mark.slow
-    def test_blocking_operations_when_empty(self):
-        assert self.redis.blpop(['foo'], timeout=1) is None
-        assert self.redis.blpop(['bar', 'foo'], timeout=1) is None
-        assert self.redis.brpop('foo', timeout=1) is None
-        assert self.redis.brpoplpush('foo', 'bar', timeout=1) is None
-
-    def test_empty_list(self):
-        self.redis.rpush('foo', 'bar')
-        self.redis.rpop('foo')
-        assert not self.redis.exists('foo')
-
-    # Tests for the hash type.
-
-    def test_hstrlen_missing(self):
-        assert self.redis.hstrlen('foo', 'doesnotexist') == 0
-
-        self.redis.hset('foo', 'key', 'value')
-        assert self.redis.hstrlen('foo', 'doesnotexist') == 0
-
-    def test_hstrlen(self):
-        self.redis.hset('foo', 'key', 'value')
-        assert self.redis.hstrlen('foo', 'key') == 5
-
-    def test_hset_then_hget(self):
-        assert self.redis.hset('foo', 'key', 'value') == 1
-        assert self.redis.hget('foo', 'key') == b'value'
-
-    def test_hset_update(self):
-        assert self.redis.hset('foo', 'key', 'value') == 1
-        assert self.redis.hset('foo', 'key', 'value') == 0
-
-    def test_hset_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hset('foo', 'key', 'value')
-
-    def test_hgetall(self):
-        assert self.redis.hset('foo', 'k1', 'v1') == 1
-        assert self.redis.hset('foo', 'k2', 'v2') == 1
-        assert self.redis.hset('foo', 'k3', 'v3') == 1
-        assert self.redis.hgetall('foo') == {
-            b'k1': b'v1',
-            b'k2': b'v2',
-            b'k3': b'v3'
-        }
-
-    @redis2_only
-    def test_hgetall_with_tuples(self):
-        assert self.redis.hset('foo', (1, 2), (1, 2, 3)) == 1
-        assert self.redis.hgetall('foo') == {b'(1, 2)': b'(1, 2, 3)'}
-
-    def test_hgetall_empty_key(self):
-        assert self.redis.hgetall('foo') == {}
-
-    def test_hgetall_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hgetall('foo')
-
-    def test_hexists(self):
-        self.redis.hset('foo', 'bar', 'v1')
-        assert self.redis.hexists('foo', 'bar') == 1
-        assert self.redis.hexists('foo', 'baz') == 0
-        assert self.redis.hexists('bar', 'bar') == 0
-
-    def test_hexists_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hexists('foo', 'key')
-
-    def test_hkeys(self):
-        self.redis.hset('foo', 'k1', 'v1')
-        self.redis.hset('foo', 'k2', 'v2')
-        assert set(self.redis.hkeys('foo')) == {b'k1', b'k2'}
-        assert set(self.redis.hkeys('bar')) == set()
-
-    def test_hkeys_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hkeys('foo')
-
-    def test_hlen(self):
-        self.redis.hset('foo', 'k1', 'v1')
-        self.redis.hset('foo', 'k2', 'v2')
-        assert self.redis.hlen('foo') == 2
-
-    def test_hlen_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hlen('foo')
-
-    def test_hvals(self):
-        self.redis.hset('foo', 'k1', 'v1')
-        self.redis.hset('foo', 'k2', 'v2')
-        assert set(self.redis.hvals('foo')) == {b'v1', b'v2'}
-        assert set(self.redis.hvals('bar')) == set()
-
-    def test_hvals_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hvals('foo')
-
-    def test_hmget(self):
-        self.redis.hset('foo', 'k1', 'v1')
-        self.redis.hset('foo', 'k2', 'v2')
-        self.redis.hset('foo', 'k3', 'v3')
-        # Normal case.
-        assert self.redis.hmget('foo', ['k1', 'k3']) == [b'v1', b'v3']
-        assert self.redis.hmget('foo', 'k1', 'k3') == [b'v1', b'v3']
-        # Key does not exist.
-        assert self.redis.hmget('bar', ['k1', 'k3']) == [None, None]
-        assert self.redis.hmget('bar', 'k1', 'k3') == [None, None]
-        # Some keys in the hash do not exist.
-        assert self.redis.hmget('foo', ['k1', 'k500']) == [b'v1', None]
-        assert self.redis.hmget('foo', 'k1', 'k500') == [b'v1', None]
-
-    def test_hmget_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hmget('foo', 'key1', 'key2')
-
-    def test_hdel(self):
-        self.redis.hset('foo', 'k1', 'v1')
-        self.redis.hset('foo', 'k2', 'v2')
-        self.redis.hset('foo', 'k3', 'v3')
-        assert self.redis.hget('foo', 'k1') == b'v1'
-        assert self.redis.hdel('foo', 'k1') == True
-        assert self.redis.hget('foo', 'k1') is None
-        assert self.redis.hdel('foo', 'k1') == False
-        # Since redis>=2.7.6 returns number of deleted items.
-        assert self.redis.hdel('foo', 'k2', 'k3') == 2
-        assert self.redis.hget('foo', 'k2') is None
-        assert self.redis.hget('foo', 'k3') is None
-        assert self.redis.hdel('foo', 'k2', 'k3') == False
-
-    def test_hdel_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hdel('foo', 'key')
-
-    def test_hincrby(self):
-        self.redis.hset('foo', 'counter', 0)
-        assert self.redis.hincrby('foo', 'counter') == 1
-        assert self.redis.hincrby('foo', 'counter') == 2
-        assert self.redis.hincrby('foo', 'counter') == 3
-
-    def test_hincrby_with_no_starting_value(self):
-        assert self.redis.hincrby('foo', 'counter') == 1
-        assert self.redis.hincrby('foo', 'counter') == 2
-        assert self.redis.hincrby('foo', 'counter') == 3
-
-    def test_hincrby_with_range_param(self):
-        assert self.redis.hincrby('foo', 'counter', 2) == 2
-        assert self.redis.hincrby('foo', 'counter', 2) == 4
-        assert self.redis.hincrby('foo', 'counter', 2) == 6
-
-    def test_hincrby_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hincrby('foo', 'key', 2)
-
-    def test_hincrbyfloat(self):
-        self.redis.hset('foo', 'counter', 0.0)
-        assert self.redis.hincrbyfloat('foo', 'counter') == 1.0
-        assert self.redis.hincrbyfloat('foo', 'counter') == 2.0
-        assert self.redis.hincrbyfloat('foo', 'counter') == 3.0
-
-    def test_hincrbyfloat_with_no_starting_value(self):
-        assert self.redis.hincrbyfloat('foo', 'counter') == 1.0
-        assert self.redis.hincrbyfloat('foo', 'counter') == 2.0
-        assert self.redis.hincrbyfloat('foo', 'counter') == 3.0
-
-    def test_hincrbyfloat_with_range_param(self):
-        assert self.redis.hincrbyfloat('foo', 'counter', 0.1) == pytest.approx(0.1)
-        assert self.redis.hincrbyfloat('foo', 'counter', 0.1) == pytest.approx(0.2)
-        assert self.redis.hincrbyfloat('foo', 'counter', 0.1) == pytest.approx(0.3)
-
-    def test_hincrbyfloat_on_non_float_value_raises_error(self):
-        self.redis.hset('foo', 'counter', 'cat')
-        with pytest.raises(redis.ResponseError):
-            self.redis.hincrbyfloat('foo', 'counter')
-
-    def test_hincrbyfloat_with_non_float_amount_raises_error(self):
-        with pytest.raises(redis.ResponseError):
-            self.redis.hincrbyfloat('foo', 'counter', 'cat')
-
-    def test_hincrbyfloat_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hincrbyfloat('foo', 'key', 0.1)
-
-    def test_hincrbyfloat_precision(self):
-        x = 1.23456789123456789
-        assert self.redis.hincrbyfloat('foo', 'bar', x) == x
-        assert float(self.redis.hget('foo', 'bar')) == x
-
-    def test_hsetnx(self):
-        assert self.redis.hsetnx('foo', 'newkey', 'v1') == True
-        assert self.redis.hsetnx('foo', 'newkey', 'v1') == False
-        assert self.redis.hget('foo', 'newkey') == b'v1'
-
-    def test_hmsetset_empty_raises_error(self):
-        with pytest.raises(redis.DataError):
-            self.redis.hmset('foo', {})
-
-    def test_hmsetset(self):
-        self.redis.hset('foo', 'k1', 'v1')
-        assert self.redis.hmset('foo', {'k2': 'v2', 'k3': 'v3'}) == True
-
-    @redis2_only
-    def test_hmset_convert_values(self):
-        self.redis.hmset('foo', {'k1': True, 'k2': 1})
-        assert self.redis.hgetall('foo') == {b'k1': b'True', b'k2': b'1'}
-
-    @redis2_only
-    def test_hmset_does_not_mutate_input_params(self):
-        original = {'key': [123, 456]}
-        self.redis.hmset('foo', original)
-        assert original == {'key': [123, 456]}
-
-    def test_hmset_wrong_type(self):
-        self.zadd('foo', {'bar': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.hmset('foo', {'key': 'value'})
-
-    def test_empty_hash(self):
-        self.redis.hset('foo', 'bar', 'baz')
-        self.redis.hdel('foo', 'bar')
-        assert not self.redis.exists('foo')
-
-    def test_sadd(self):
-        assert self.redis.sadd('foo', 'member1') == 1
-        assert self.redis.sadd('foo', 'member1') == 0
-        assert self.redis.smembers('foo') == {b'member1'}
-        assert self.redis.sadd('foo', 'member2', 'member3') == 2
-        assert self.redis.smembers('foo') == {b'member1', b'member2', b'member3'}
-        assert self.redis.sadd('foo', 'member3', 'member4') == 1
-        assert self.redis.smembers('foo') == {b'member1', b'member2', b'member3', b'member4'}
-
-    def test_sadd_as_str_type(self):
-        assert self.redis.sadd('foo', *range(3)) == 3
-        assert self.redis.smembers('foo') == {b'0', b'1', b'2'}
-
-    def test_sadd_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.sadd('foo', 'member2')
-
-    def test_scan_single(self):
-        self.redis.set('foo1', 'bar1')
-        assert self.redis.scan(match="foo*") == (0, [b'foo1'])
-
-    def test_scan_iter_single_page(self):
-        self.redis.set('foo1', 'bar1')
-        self.redis.set('foo2', 'bar2')
-        assert set(self.redis.scan_iter(match="foo*")) == {b'foo1', b'foo2'}
-        assert set(self.redis.scan_iter()) == {b'foo1', b'foo2'}
-        assert set(self.redis.scan_iter(match="")) == set()
-
-    def test_scan_iter_multiple_pages(self):
-        all_keys = key_val_dict(size=100)
-        assert all(self.redis.set(k, v) for k, v in all_keys.items())
-        assert set(self.redis.scan_iter()) == set(all_keys)
-
-    def test_scan_iter_multiple_pages_with_match(self):
-        all_keys = key_val_dict(size=100)
-        assert all(self.redis.set(k, v) for k, v in all_keys.items())
-        # Now add a few keys that don't match the key:<number> pattern.
-        self.redis.set('otherkey', 'foo')
-        self.redis.set('andanother', 'bar')
-        actual = set(self.redis.scan_iter(match='key:*'))
-        assert actual == set(all_keys)
-
-    def test_scan_multiple_pages_with_count_arg(self):
-        all_keys = key_val_dict(size=100)
-        assert all(self.redis.set(k, v) for k, v in all_keys.items())
-        assert set(self.redis.scan_iter(count=1000)) == set(all_keys)
-
-    def test_scan_all_in_single_call(self):
-        all_keys = key_val_dict(size=100)
-        assert all(self.redis.set(k, v) for k, v in all_keys.items())
-        # Specify way more than the 100 keys we've added.
-        actual = self.redis.scan(count=1000)
-        assert set(actual[1]) == set(all_keys)
-        assert actual[0] == 0
-
-    @pytest.mark.slow
-    def test_scan_expired_key(self):
-        self.redis.set('expiringkey', 'value')
-        self.redis.pexpire('expiringkey', 1)
-        sleep(1)
-        assert self.redis.scan()[1] == []
-
-    def test_scard(self):
-        self.redis.sadd('foo', 'member1')
-        self.redis.sadd('foo', 'member2')
-        self.redis.sadd('foo', 'member2')
-        assert self.redis.scard('foo') == 2
-
-    def test_scard_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.scard('foo')
-
-    def test_sdiff(self):
-        self.redis.sadd('foo', 'member1')
-        self.redis.sadd('foo', 'member2')
-        self.redis.sadd('bar', 'member2')
-        self.redis.sadd('bar', 'member3')
-        assert self.redis.sdiff('foo', 'bar') == {b'member1'}
-        # Original sets shouldn't be modified.
-        assert self.redis.smembers('foo') == {b'member1', b'member2'}
-        assert self.redis.smembers('bar') == {b'member2', b'member3'}
-
-    def test_sdiff_one_key(self):
-        self.redis.sadd('foo', 'member1')
-        self.redis.sadd('foo', 'member2')
-        assert self.redis.sdiff('foo') == {b'member1', b'member2'}
-
-    def test_sdiff_empty(self):
-        assert self.redis.sdiff('foo') == set()
-
-    def test_sdiff_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        self.redis.sadd('bar', 'member')
-        with pytest.raises(redis.ResponseError):
-            self.redis.sdiff('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.sdiff('bar', 'foo')
-
-    def test_sdiffstore(self):
-        self.redis.sadd('foo', 'member1')
-        self.redis.sadd('foo', 'member2')
-        self.redis.sadd('bar', 'member2')
-        self.redis.sadd('bar', 'member3')
-        assert self.redis.sdiffstore('baz', 'foo', 'bar') == 1
-
-        # Catch instances where we store bytes and strings inconsistently
-        # and thus baz = {'member1', b'member1'}
-        self.redis.sadd('baz', 'member1')
-        assert self.redis.scard('baz') == 1
-
-    def test_setrange(self):
-        self.redis.set('foo', 'test')
-        assert self.redis.setrange('foo', 1, 'aste') == 5
-        assert self.redis.get('foo') == b'taste'
-
-        self.redis.set('foo', 'test')
-        assert self.redis.setrange('foo', 1, 'a') == 4
-        assert self.redis.get('foo') == b'tast'
-
-        assert self.redis.setrange('bar', 2, 'test') == 6
-        assert self.redis.get('bar') == b'\x00\x00test'
-
-    def test_setrange_expiry(self):
-        self.redis.set('foo', 'test', ex=10)
-        self.redis.setrange('foo', 1, 'aste')
-        assert self.redis.ttl('foo') > 0
-
-    def test_sinter(self):
-        self.redis.sadd('foo', 'member1')
-        self.redis.sadd('foo', 'member2')
-        self.redis.sadd('bar', 'member2')
-        self.redis.sadd('bar', 'member3')
-        assert self.redis.sinter('foo', 'bar') == {b'member2'}
-        assert self.redis.sinter('foo') == {b'member1', b'member2'}
-
-    def test_sinter_bytes_keys(self):
-        foo = os.urandom(10)
-        bar = os.urandom(10)
-        self.redis.sadd(foo, 'member1')
-        self.redis.sadd(foo, 'member2')
-        self.redis.sadd(bar, 'member2')
-        self.redis.sadd(bar, 'member3')
-        assert self.redis.sinter(foo, bar) == {b'member2'}
-        assert self.redis.sinter(foo) == {b'member1', b'member2'}
-
-    def test_sinter_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        self.redis.sadd('bar', 'member')
-        with pytest.raises(redis.ResponseError):
-            self.redis.sinter('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.sinter('bar', 'foo')
-
-    def test_sinterstore(self):
-        self.redis.sadd('foo', 'member1')
-        self.redis.sadd('foo', 'member2')
-        self.redis.sadd('bar', 'member2')
-        self.redis.sadd('bar', 'member3')
-        assert self.redis.sinterstore('baz', 'foo', 'bar') == 1
-
-        # Catch instances where we store bytes and strings inconsistently
-        # and thus baz = {'member2', b'member2'}
-        self.redis.sadd('baz', 'member2')
-        assert self.redis.scard('baz') == 1
-
-    def test_sismember(self):
-        assert self.redis.sismember('foo', 'member1') == False
-        self.redis.sadd('foo', 'member1')
-        assert self.redis.sismember('foo', 'member1') == True
-
-    def test_sismember_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.sismember('foo', 'member')
-
-    def test_smembers(self):
-        assert self.redis.smembers('foo') == set()
-
-    def test_smembers_copy(self):
-        self.redis.sadd('foo', 'member1')
-        set = self.redis.smembers('foo')
-        self.redis.sadd('foo', 'member2')
-        assert self.redis.smembers('foo') != set
-
-    def test_smembers_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.smembers('foo')
-
-    def test_smembers_runtime_error(self):
-        self.redis.sadd('foo', 'member1', 'member2')
-        for member in self.redis.smembers('foo'):
-            self.redis.srem('foo', member)
-
-    def test_smove(self):
-        self.redis.sadd('foo', 'member1')
-        self.redis.sadd('foo', 'member2')
-        assert self.redis.smove('foo', 'bar', 'member1') == True
-        assert self.redis.smembers('bar') == {b'member1'}
-
-    def test_smove_non_existent_key(self):
-        assert self.redis.smove('foo', 'bar', 'member1') == False
-
-    def test_smove_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        self.redis.sadd('bar', 'member')
-        with pytest.raises(redis.ResponseError):
-            self.redis.smove('bar', 'foo', 'member')
-        # Must raise the error before removing member from bar
-        assert self.redis.smembers('bar') == {b'member'}
-        with pytest.raises(redis.ResponseError):
-            self.redis.smove('foo', 'bar', 'member')
-
-    def test_spop(self):
-        # This is tricky because it pops a random element.
-        self.redis.sadd('foo', 'member1')
-        assert self.redis.spop('foo') == b'member1'
-        assert self.redis.spop('foo') is None
-
-    def test_spop_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.spop('foo')
-
-    def test_srandmember(self):
-        self.redis.sadd('foo', 'member1')
-        assert self.redis.srandmember('foo') == b'member1'
-        # Shouldn't be removed from the set.
-        assert self.redis.srandmember('foo') == b'member1'
-
-    def test_srandmember_number(self):
-        """srandmember works with the number argument."""
-        assert self.redis.srandmember('foo', 2) == []
-        self.redis.sadd('foo', b'member1')
-        assert self.redis.srandmember('foo', 2) == [b'member1']
-        self.redis.sadd('foo', b'member2')
-        assert set(self.redis.srandmember('foo', 2)) == {b'member1', b'member2'}
-        self.redis.sadd('foo', b'member3')
-        res = self.redis.srandmember('foo', 2)
-        assert len(res) == 2
-        for e in res:
-            assert e in {b'member1', b'member2', b'member3'}
-
-    def test_srandmember_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.srandmember('foo')
-
-    def test_srem(self):
-        self.redis.sadd('foo', 'member1', 'member2', 'member3', 'member4')
-        assert self.redis.smembers('foo') == {b'member1', b'member2', b'member3', b'member4'}
-        assert self.redis.srem('foo', 'member1') == True
-        assert self.redis.smembers('foo') == {b'member2', b'member3', b'member4'}
-        assert self.redis.srem('foo', 'member1') == False
-        # Since redis>=2.7.6 returns number of deleted items.
-        assert self.redis.srem('foo', 'member2', 'member3') == 2
-        assert self.redis.smembers('foo') == {b'member4'}
-        assert self.redis.srem('foo', 'member3', 'member4') == True
-        assert self.redis.smembers('foo') == set()
-        assert self.redis.srem('foo', 'member3', 'member4') == False
-
-    def test_srem_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        with pytest.raises(redis.ResponseError):
-            self.redis.srem('foo', 'member')
-
-    def test_sunion(self):
-        self.redis.sadd('foo', 'member1')
-        self.redis.sadd('foo', 'member2')
-        self.redis.sadd('bar', 'member2')
-        self.redis.sadd('bar', 'member3')
-        assert self.redis.sunion('foo', 'bar') == {b'member1', b'member2', b'member3'}
-
-    def test_sunion_wrong_type(self):
-        self.zadd('foo', {'member': 1})
-        self.redis.sadd('bar', 'member')
-        with pytest.raises(redis.ResponseError):
-            self.redis.sunion('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.sunion('bar', 'foo')
-
-    def test_sunionstore(self):
-        self.redis.sadd('foo', 'member1')
-        self.redis.sadd('foo', 'member2')
-        self.redis.sadd('bar', 'member2')
-        self.redis.sadd('bar', 'member3')
-        assert self.redis.sunionstore('baz', 'foo', 'bar') == 3
-        assert self.redis.smembers('baz') == {b'member1', b'member2', b'member3'}
-
-        # Catch instances where we store bytes and strings inconsistently
-        # and thus baz = {b'member1', b'member2', b'member3', 'member3'}
-        self.redis.sadd('baz', 'member3')
-        assert self.redis.scard('baz') == 3
-
-    def test_empty_set(self):
-        self.redis.sadd('foo', 'bar')
-        self.redis.srem('foo', 'bar')
-        assert not self.redis.exists('foo')
-
-    def test_zadd(self):
-        self.zadd('foo', {'four': 4})
-        self.zadd('foo', {'three': 3})
-        assert self.zadd('foo', {'two': 2, 'one': 1, 'zero': 0}) == 3
-        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'one', b'two', b'three', b'four']
-        assert self.zadd('foo', {'zero': 7, 'one': 1, 'five': 5}) == 1
-        assert (
-            self.redis.zrange('foo', 0, -1)
-            == [b'one', b'two', b'three', b'four', b'five', b'zero']
-        )
-
-    @redis2_only
-    def test_zadd_uses_str(self):
-        self.redis.zadd('foo', 12345, (1, 2, 3))
-        assert self.redis.zrange('foo', 0, 0) == [b'(1, 2, 3)']
-
-    @redis2_only
-    def test_zadd_errors(self):
-        # The args are backwards, it should be 2, "two", so we
-        # expect an exception to be raised.
-        with pytest.raises(redis.ResponseError):
-            self.redis.zadd('foo', 'two', 2)
-        with pytest.raises(redis.ResponseError):
-            self.redis.zadd('foo', two='two')
-        # It's expected an equal number of values and scores
-        with pytest.raises(redis.RedisError):
-            self.redis.zadd('foo', 'two')
-
-    def test_zadd_empty(self):
-        # Have to add at least one key/value pair
-        with pytest.raises(redis.RedisError):
-            self.zadd('foo', {})
-
-    def test_zadd_minus_zero(self):
-        # Changing -0 to +0 is ignored
-        self.zadd('foo', {'a': -0.0})
-        self.zadd('foo', {'a': 0.0})
-        assert self.raw_command('zscore', 'foo', 'a') == b'-0'
-
-    def test_zadd_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.zadd('foo', {'two': 2})
-
-    def test_zadd_multiple(self):
-        self.zadd('foo', {'one': 1, 'two': 2})
-        assert self.redis.zrange('foo', 0, 0) == [b'one']
-        assert self.redis.zrange('foo', 1, 1) == [b'two']
-
-    @redis3_only
-    def test_zadd_with_nx(self):
-        self.zadd('foo', {'four': 4.0, 'three': 3.0})
-
-        updates = [
-            UpdateCommand(
-                input={'four': 2.0, 'three': 1.0},
-                expected_return_value=0,
-                expected_state=[(b'four', 4.0), (b'three', 3.0)]),
-            UpdateCommand(
-                input={'four': 2.0, 'three': 1.0, 'zero': 0.0},
-                expected_return_value=1,
-                expected_state=[(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]),
-            UpdateCommand(
-                input={'two': 2.0, 'one': 1.0},
-                expected_return_value=2,
-                expected_state=[(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]),
-        ]
-
-        for update in updates:
-            assert self.zadd('foo', update.input, nx=True) == update.expected_return_value
-            assert (
-                sorted(self.redis.zrange('foo', 0, -1, withscores=True))
-                == sorted(update.expected_state)
-            )
-
-    @redis3_only
-    def test_zadd_with_ch(self):
-        self.zadd('foo', {'four': 4.0, 'three': 3.0})
-
-        updates = [
-            UpdateCommand(
-                input={'four': 4.0, 'three': 1.0},
-                expected_return_value=1,
-                expected_state=[(b'four', 4.0), (b'three', 1.0)]),
-            UpdateCommand(
-                input={'four': 4.0, 'three': 3.0, 'zero': 0.0},
-                expected_return_value=2,
-                expected_state=[(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]),
-            UpdateCommand(
-                input={'two': 2.0, 'one': 1.0},
-                expected_return_value=2,
-                expected_state=[(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]),
-        ]
-
-        for update in updates:
-            assert self.zadd('foo', update.input, ch=True) == update.expected_return_value
-            assert (
-                sorted(self.redis.zrange('foo', 0, -1, withscores=True))
-                == sorted(update.expected_state)
-            )
-
-    @redis3_only
-    def test_zadd_with_xx(self):
-        self.zadd('foo', {'four': 4.0, 'three': 3.0})
-
-        updates = [
-            UpdateCommand(
-                input={'four': 2.0, 'three': 1.0},
-                expected_return_value=0,
-                expected_state=[(b'four', 2.0), (b'three', 1.0)]),
-            UpdateCommand(
-                input={'four': 4.0, 'three': 3.0, 'zero': 0.0},
-                expected_return_value=0,
-                expected_state=[(b'four', 4.0), (b'three', 3.0)]),
-            UpdateCommand(
-                input={'two': 2.0, 'one': 1.0},
-                expected_return_value=0,
-                expected_state=[(b'four', 4.0), (b'three', 3.0)]),
-        ]
-
-        for update in updates:
-            assert self.zadd('foo', update.input, xx=True) == update.expected_return_value
-            assert (
-                sorted(self.redis.zrange('foo', 0, -1, withscores=True))
-                == sorted(update.expected_state)
-            )
-
-    @redis3_only
-    def test_zadd_with_nx_and_xx(self):
-        self.zadd('foo', {'four': 4.0, 'three': 3.0})
-        with pytest.raises(redis.DataError):
-            self.zadd('foo', {'four': -4.0, 'three': -3.0}, nx=True, xx=True)
-        with pytest.raises(redis.DataError):
-            self.zadd('foo', {'four': -4.0, 'three': -3.0}, nx=True, xx=True, ch=True)
-
-    @redis3_only
-    def test_zadd_with_nx_and_ch(self):
-        self.zadd('foo', {'four': 4.0, 'three': 3.0})
-
-        updates = [
-            UpdateCommand(
-                input={'four': 2.0, 'three': 1.0},
-                expected_return_value=0,
-                expected_state=[(b'four', 4.0), (b'three', 3.0)]),
-            UpdateCommand(
-                input={'four': 2.0, 'three': 1.0, 'zero': 0.0},
-                expected_return_value=1,
-                expected_state=[(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]),
-            UpdateCommand(
-                input={'two': 2.0, 'one': 1.0},
-                expected_return_value=2,
-                expected_state=[(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]),
-        ]
-
-        for update in updates:
-            assert self.zadd('foo', update.input, nx=True, ch=True) == update.expected_return_value
-            assert (
-                sorted(self.redis.zrange('foo', 0, -1, withscores=True))
-                == sorted(update.expected_state)
-            )
-
-    @redis3_only
-    def test_zadd_with_xx_and_ch(self):
-        self.zadd('foo', {'four': 4.0, 'three': 3.0})
-
-        updates = [
-            UpdateCommand(
-                input={'four': 2.0, 'three': 1.0},
-                expected_return_value=2,
-                expected_state=[(b'four', 2.0), (b'three', 1.0)]),
-            UpdateCommand(
-                input={'four': 4.0, 'three': 3.0, 'zero': 0.0},
-                expected_return_value=2,
-                expected_state=[(b'four', 4.0), (b'three', 3.0)]),
-            UpdateCommand(
-                input={'two': 2.0, 'one': 1.0},
-                expected_return_value=0,
-                expected_state=[(b'four', 4.0), (b'three', 3.0)]),
-        ]
-
-        for update in updates:
-            assert self.zadd('foo', update.input, xx=True, ch=True) == update.expected_return_value
-            assert (
-                sorted(self.redis.zrange('foo', 0, -1, withscores=True))
-                == sorted(update.expected_state)
-            )
-
-    def test_zrange_same_score(self):
-        self.zadd('foo', {'two_a': 2})
-        self.zadd('foo', {'two_b': 2})
-        self.zadd('foo', {'two_c': 2})
-        self.zadd('foo', {'two_d': 2})
-        self.zadd('foo', {'two_e': 2})
-        assert self.redis.zrange('foo', 2, 3) == [b'two_c', b'two_d']
-
-    def test_zcard(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        assert self.redis.zcard('foo') == 2
-
-    def test_zcard_non_existent_key(self):
-        assert self.redis.zcard('foo') == 0
-
-    def test_zcard_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zcard('foo')
-
-    def test_zcount(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'three': 2})
-        self.zadd('foo', {'five': 5})
-        assert self.redis.zcount('foo', 2, 4) == 1
-        assert self.redis.zcount('foo', 1, 4) == 2
-        assert self.redis.zcount('foo', 0, 5) == 3
-        assert self.redis.zcount('foo', 4, '+inf') == 1
-        assert self.redis.zcount('foo', '-inf', 4) == 2
-        assert self.redis.zcount('foo', '-inf', '+inf') == 3
-
-    def test_zcount_exclusive(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'three': 2})
-        self.zadd('foo', {'five': 5})
-        assert self.redis.zcount('foo', '-inf', '(2') == 1
-        assert self.redis.zcount('foo', '-inf', 2) == 2
-        assert self.redis.zcount('foo', '(5', '+inf') == 0
-        assert self.redis.zcount('foo', '(1', 5) == 2
-        assert self.redis.zcount('foo', '(2', '(5') == 0
-        assert self.redis.zcount('foo', '(1', '(5') == 1
-        assert self.redis.zcount('foo', 2, '(5') == 1
-
-    def test_zcount_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zcount('foo', '-inf', '+inf')
-
-    def test_zincrby(self):
-        self.zadd('foo', {'one': 1})
-        assert self.zincrby('foo', 10, 'one') == 11
-        assert self.redis.zrange('foo', 0, -1, withscores=True) == [(b'one', 11)]
-
-    def test_zincrby_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.zincrby('foo', 10, 'one')
-
-    def test_zrange_descending(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zrange('foo', 0, -1, desc=True) == [b'three', b'two', b'one']
-
-    def test_zrange_descending_with_scores(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert (
-            self.redis.zrange('foo', 0, -1, desc=True, withscores=True)
-            == [(b'three', 3), (b'two', 2), (b'one', 1)]
-        )
-
-    def test_zrange_with_positive_indices(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zrange('foo', 0, 1) == [b'one', b'two']
-
-    def test_zrange_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrange('foo', 0, -1)
-
-    def test_zrange_score_cast(self):
-        self.zadd('foo', {'one': 1.2})
-        self.zadd('foo', {'two': 2.2})
-
-        expected_without_cast_round = [(b'one', 1.2), (b'two', 2.2)]
-        expected_with_cast_round = [(b'one', 1.0), (b'two', 2.0)]
-        assert self.redis.zrange('foo', 0, 2, withscores=True) == expected_without_cast_round
-        assert (
-            self.redis.zrange('foo', 0, 2, withscores=True, score_cast_func=self._round_str)
-            == expected_with_cast_round
-        )
-
-    def test_zrank(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zrank('foo', 'one') == 0
-        assert self.redis.zrank('foo', 'two') == 1
-        assert self.redis.zrank('foo', 'three') == 2
-
-    def test_zrank_non_existent_member(self):
-        assert self.redis.zrank('foo', 'one') is None
-
-    def test_zrank_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrank('foo', 'one')
-
-    def test_zrem(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        self.zadd('foo', {'four': 4})
-        assert self.redis.zrem('foo', 'one') == True
-        assert self.redis.zrange('foo', 0, -1) == [b'two', b'three', b'four']
-        # Since redis>=2.7.6 returns number of deleted items.
-        assert self.redis.zrem('foo', 'two', 'three') == 2
-        assert self.redis.zrange('foo', 0, -1) == [b'four']
-        assert self.redis.zrem('foo', 'three', 'four') == True
-        assert self.redis.zrange('foo', 0, -1) == []
-        assert self.redis.zrem('foo', 'three', 'four') == False
-
-    def test_zrem_non_existent_member(self):
-        assert not self.redis.zrem('foo', 'one')
-
-    def test_zrem_numeric_member(self):
-        self.zadd('foo', {'128': 13.0, '129': 12.0})
-        assert self.redis.zrem('foo', 128) == True
-        assert self.redis.zrange('foo', 0, -1) == [b'129']
-
-    def test_zrem_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrem('foo', 'bar')
-
-    def test_zscore(self):
-        self.zadd('foo', {'one': 54})
-        assert self.redis.zscore('foo', 'one') == 54
-
-    def test_zscore_non_existent_member(self):
-        assert self.redis.zscore('foo', 'one') is None
-
-    def test_zscore_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zscore('foo', 'one')
-
-    def test_zrevrank(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zrevrank('foo', 'one') == 2
-        assert self.redis.zrevrank('foo', 'two') == 1
-        assert self.redis.zrevrank('foo', 'three') == 0
-
-    def test_zrevrank_non_existent_member(self):
-        assert self.redis.zrevrank('foo', 'one') is None
-
-    def test_zrevrank_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrank('foo', 'one')
-
-    def test_zrevrange(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zrevrange('foo', 0, 1) == [b'three', b'two']
-        assert self.redis.zrevrange('foo', 0, -1) == [b'three', b'two', b'one']
-
-    def test_zrevrange_sorted_keys(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'two_b': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zrevrange('foo', 0, 2) == [b'three', b'two_b', b'two']
-        assert self.redis.zrevrange('foo', 0, -1) == [b'three', b'two_b', b'two', b'one']
-
-    def test_zrevrange_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrange('foo', 0, 2)
-
-    def test_zrevrange_score_cast(self):
-        self.zadd('foo', {'one': 1.2})
-        self.zadd('foo', {'two': 2.2})
-
-        expected_without_cast_round = [(b'two', 2.2), (b'one', 1.2)]
-        expected_with_cast_round = [(b'two', 2.0), (b'one', 1.0)]
-        assert self.redis.zrevrange('foo', 0, 2, withscores=True) == expected_without_cast_round
-        assert (
-            self.redis.zrevrange('foo', 0, 2, withscores=True, score_cast_func=self._round_str)
-            == expected_with_cast_round
-        )
-
-    def test_zrangebyscore(self):
-        self.zadd('foo', {'zero': 0})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'two_a_also': 2})
-        self.zadd('foo', {'two_b_also': 2})
-        self.zadd('foo', {'four': 4})
-        assert self.redis.zrangebyscore('foo', 1, 3) == [b'two', b'two_a_also', b'two_b_also']
-        assert self.redis.zrangebyscore('foo', 2, 3) == [b'two', b'two_a_also', b'two_b_also']
-        assert (
-            self.redis.zrangebyscore('foo', 0, 4)
-            == [b'zero', b'two', b'two_a_also', b'two_b_also', b'four']
-        )
-        assert self.redis.zrangebyscore('foo', '-inf', 1) == [b'zero']
-        assert (
-            self.redis.zrangebyscore('foo', 2, '+inf')
-            == [b'two', b'two_a_also', b'two_b_also', b'four']
-        )
-        assert (
-            self.redis.zrangebyscore('foo', '-inf', '+inf')
-            == [b'zero', b'two', b'two_a_also', b'two_b_also', b'four']
-        )
-
-    def test_zrangebysore_exclusive(self):
-        self.zadd('foo', {'zero': 0})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'four': 4})
-        self.zadd('foo', {'five': 5})
-        assert self.redis.zrangebyscore('foo', '(0', 6) == [b'two', b'four', b'five']
-        assert self.redis.zrangebyscore('foo', '(2', '(5') == [b'four']
-        assert self.redis.zrangebyscore('foo', 0, '(4') == [b'zero', b'two']
-
-    def test_zrangebyscore_raises_error(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrangebyscore('foo', 'one', 2)
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrangebyscore('foo', 2, 'three')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrangebyscore('foo', 2, '3)')
-        with pytest.raises(redis.RedisError):
-            self.redis.zrangebyscore('foo', 2, '3)', 0, None)
-
-    def test_zrangebyscore_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrangebyscore('foo', '(1', '(2')
-
-    def test_zrangebyscore_slice(self):
-        self.zadd('foo', {'two_a': 2})
-        self.zadd('foo', {'two_b': 2})
-        self.zadd('foo', {'two_c': 2})
-        self.zadd('foo', {'two_d': 2})
-        assert self.redis.zrangebyscore('foo', 0, 4, 0, 2) == [b'two_a', b'two_b']
-        assert self.redis.zrangebyscore('foo', 0, 4, 1, 3) == [b'two_b', b'two_c', b'two_d']
-
-    def test_zrangebyscore_withscores(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zrangebyscore('foo', 1, 3, 0, 2, True) == [(b'one', 1), (b'two', 2)]
-
-    def test_zrangebyscore_cast_scores(self):
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'two_a_also': 2.2})
-
-        expected_without_cast_round = [(b'two', 2.0), (b'two_a_also', 2.2)]
-        expected_with_cast_round = [(b'two', 2.0), (b'two_a_also', 2.0)]
-        assert (
-            sorted(self.redis.zrangebyscore('foo', 2, 3, withscores=True))
-            == sorted(expected_without_cast_round)
-        )
-        assert (
-            sorted(self.redis.zrangebyscore('foo', 2, 3, withscores=True,
-                                            score_cast_func=self._round_str))
-            == sorted(expected_with_cast_round)
-        )
-
-    def test_zrevrangebyscore(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zrevrangebyscore('foo', 3, 1) == [b'three', b'two', b'one']
-        assert self.redis.zrevrangebyscore('foo', 3, 2) == [b'three', b'two']
-        assert self.redis.zrevrangebyscore('foo', 3, 1, 0, 1) == [b'three']
-        assert self.redis.zrevrangebyscore('foo', 3, 1, 1, 2) == [b'two', b'one']
-
-    def test_zrevrangebyscore_exclusive(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zrevrangebyscore('foo', '(3', 1) == [b'two', b'one']
-        assert self.redis.zrevrangebyscore('foo', 3, '(2') == [b'three']
-        assert self.redis.zrevrangebyscore('foo', '(3', '(1') == [b'two']
-        assert self.redis.zrevrangebyscore('foo', '(2', 1, 0, 1) == [b'one']
-        assert self.redis.zrevrangebyscore('foo', '(2', '(1', 0, 1) == []
-        assert self.redis.zrevrangebyscore('foo', '(3', '(0', 1, 2) == [b'one']
-
-    def test_zrevrangebyscore_raises_error(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebyscore('foo', 'three', 1)
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebyscore('foo', 3, 'one')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebyscore('foo', 3, '1)')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebyscore('foo', '((3', '1)')
-
-    def test_zrevrangebyscore_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebyscore('foo', '(3', '(1')
-
-    def test_zrevrangebyscore_cast_scores(self):
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'two_a_also': 2.2})
-
-        expected_without_cast_round = [(b'two_a_also', 2.2), (b'two', 2.0)]
-        expected_with_cast_round = [(b'two_a_also', 2.0), (b'two', 2.0)]
-        assert (
-            self.redis.zrevrangebyscore('foo', 3, 2, withscores=True)
-             == expected_without_cast_round
-        )
-        assert (
-            self.redis.zrevrangebyscore('foo', 3, 2, withscores=True,
-                                        score_cast_func=self._round_str)
-            == expected_with_cast_round
-        )
-
-    def test_zrangebylex(self):
-        self.zadd('foo', {'one_a': 0})
-        self.zadd('foo', {'two_a': 0})
-        self.zadd('foo', {'two_b': 0})
-        self.zadd('foo', {'three_a': 0})
-        assert self.redis.zrangebylex('foo', b'(t', b'+') == [b'three_a', b'two_a', b'two_b']
-        assert self.redis.zrangebylex('foo', b'(t', b'[two_b') == [b'three_a', b'two_a', b'two_b']
-        assert self.redis.zrangebylex('foo', b'(t', b'(two_b') == [b'three_a', b'two_a']
-        assert (
-            self.redis.zrangebylex('foo', b'[three_a', b'[two_b')
-            == [b'three_a', b'two_a', b'two_b']
-        )
-        assert self.redis.zrangebylex('foo', b'(three_a', b'[two_b') == [b'two_a', b'two_b']
-        assert self.redis.zrangebylex('foo', b'-', b'(two_b') == [b'one_a', b'three_a', b'two_a']
-        assert self.redis.zrangebylex('foo', b'[two_b', b'(two_b') == []
-        # reversed max + and min - boundaries
-        # these will be always empty, but allowed by redis
-        assert self.redis.zrangebylex('foo', b'+', b'-') == []
-        assert self.redis.zrangebylex('foo', b'+', b'[three_a') == []
-        assert self.redis.zrangebylex('foo', b'[o', b'-') == []
-
-    def test_zrangebylex_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrangebylex('foo', b'-', b'+')
-
-    def test_zlexcount(self):
-        self.zadd('foo', {'one_a': 0})
-        self.zadd('foo', {'two_a': 0})
-        self.zadd('foo', {'two_b': 0})
-        self.zadd('foo', {'three_a': 0})
-        assert self.redis.zlexcount('foo', b'(t', b'+') == 3
-        assert self.redis.zlexcount('foo', b'(t', b'[two_b') == 3
-        assert self.redis.zlexcount('foo', b'(t', b'(two_b') == 2
-        assert self.redis.zlexcount('foo', b'[three_a', b'[two_b') == 3
-        assert self.redis.zlexcount('foo', b'(three_a', b'[two_b') == 2
-        assert self.redis.zlexcount('foo', b'-', b'(two_b') == 3
-        assert self.redis.zlexcount('foo', b'[two_b', b'(two_b') == 0
-        # reversed max + and min - boundaries
-        # these will be always empty, but allowed by redis
-        assert self.redis.zlexcount('foo', b'+', b'-') == 0
-        assert self.redis.zlexcount('foo', b'+', b'[three_a') == 0
-        assert self.redis.zlexcount('foo', b'[o', b'-') == 0
-
-    def test_zlexcount_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zlexcount('foo', b'-', b'+')
-
-    def test_zrangebylex_with_limit(self):
-        self.zadd('foo', {'one_a': 0})
-        self.zadd('foo', {'two_a': 0})
-        self.zadd('foo', {'two_b': 0})
-        self.zadd('foo', {'three_a': 0})
-        assert self.redis.zrangebylex('foo', b'-', b'+', 1, 2) == [b'three_a', b'two_a']
-
-        # negative offset no results
-        assert self.redis.zrangebylex('foo', b'-', b'+', -1, 3) == []
-
-        # negative limit ignored
-        assert (
-            self.redis.zrangebylex('foo', b'-', b'+', 0, -2)
-            == [b'one_a', b'three_a', b'two_a', b'two_b']
-        )
-        assert self.redis.zrangebylex('foo', b'-', b'+', 1, -2) == [b'three_a', b'two_a', b'two_b']
-        assert self.redis.zrangebylex('foo', b'+', b'-', 1, 1) == []
-
-    def test_zrangebylex_raises_error(self):
-        self.zadd('foo', {'one_a': 0})
-        self.zadd('foo', {'two_a': 0})
-        self.zadd('foo', {'two_b': 0})
-        self.zadd('foo', {'three_a': 0})
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrangebylex('foo', b'', b'[two_b')
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrangebylex('foo', b'-', b'two_b')
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrangebylex('foo', b'(t', b'two_b')
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrangebylex('foo', b't', b'+')
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrangebylex('foo', b'[two_a', b'')
-
-        with pytest.raises(redis.RedisError):
-            self.redis.zrangebylex('foo', b'(two_a', b'[two_b', 1)
-
-    def test_zrevrangebylex(self):
-        self.zadd('foo', {'one_a': 0})
-        self.zadd('foo', {'two_a': 0})
-        self.zadd('foo', {'two_b': 0})
-        self.zadd('foo', {'three_a': 0})
-        assert self.redis.zrevrangebylex('foo', b'+', b'(t') == [b'two_b', b'two_a', b'three_a']
-        assert (
-            self.redis.zrevrangebylex('foo', b'[two_b', b'(t')
-            == [b'two_b', b'two_a', b'three_a']
-        )
-        assert self.redis.zrevrangebylex('foo', b'(two_b', b'(t') == [b'two_a', b'three_a']
-        assert (
-            self.redis.zrevrangebylex('foo', b'[two_b', b'[three_a')
-            == [b'two_b', b'two_a', b'three_a']
-        )
-        assert self.redis.zrevrangebylex('foo', b'[two_b', b'(three_a') == [b'two_b', b'two_a']
-        assert self.redis.zrevrangebylex('foo', b'(two_b', b'-') == [b'two_a', b'three_a', b'one_a']
-        assert self.redis.zrangebylex('foo', b'(two_b', b'[two_b') == []
-        # reversed max + and min - boundaries
-        # these will be always empty, but allowed by redis
-        assert self.redis.zrevrangebylex('foo', b'-', b'+') == []
-        assert self.redis.zrevrangebylex('foo', b'[three_a', b'+') == []
-        assert self.redis.zrevrangebylex('foo', b'-', b'[o') == []
-
-    def test_zrevrangebylex_with_limit(self):
-        self.zadd('foo', {'one_a': 0})
-        self.zadd('foo', {'two_a': 0})
-        self.zadd('foo', {'two_b': 0})
-        self.zadd('foo', {'three_a': 0})
-        assert self.redis.zrevrangebylex('foo', b'+', b'-', 1, 2) == [b'two_a', b'three_a']
-
-    def test_zrevrangebylex_raises_error(self):
-        self.zadd('foo', {'one_a': 0})
-        self.zadd('foo', {'two_a': 0})
-        self.zadd('foo', {'two_b': 0})
-        self.zadd('foo', {'three_a': 0})
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebylex('foo', b'[two_b', b'')
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebylex('foo', b'two_b', b'-')
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebylex('foo', b'two_b', b'(t')
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebylex('foo', b'+', b't')
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebylex('foo', b'', b'[two_a')
-
-        with pytest.raises(redis.RedisError):
-            self.redis.zrevrangebylex('foo', b'[two_a', b'(two_b', 1)
-
-    def test_zrevrangebylex_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zrevrangebylex('foo', b'+', b'-')
-
-    def test_zremrangebyrank(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zremrangebyrank('foo', 0, 1) == 2
-        assert self.redis.zrange('foo', 0, -1) == [b'three']
-
-    def test_zremrangebyrank_negative_indices(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'three': 3})
-        assert self.redis.zremrangebyrank('foo', -2, -1) == 2
-        assert self.redis.zrange('foo', 0, -1) == [b'one']
-
-    def test_zremrangebyrank_out_of_bounds(self):
-        self.zadd('foo', {'one': 1})
-        assert self.redis.zremrangebyrank('foo', 1, 3) == 0
-
-    def test_zremrangebyrank_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zremrangebyrank('foo', 1, 3)
-
-    def test_zremrangebyscore(self):
-        self.zadd('foo', {'zero': 0})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'four': 4})
-        # Outside of range.
-        assert self.redis.zremrangebyscore('foo', 5, 10) == 0
-        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'two', b'four']
-        # Middle of range.
-        assert self.redis.zremrangebyscore('foo', 1, 3) == 1
-        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'four']
-        assert self.redis.zremrangebyscore('foo', 1, 3) == 0
-        # Entire range.
-        assert self.redis.zremrangebyscore('foo', 0, 4) == 2
-        assert self.redis.zrange('foo', 0, -1) == []
-
-    def test_zremrangebyscore_exclusive(self):
-        self.zadd('foo', {'zero': 0})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'four': 4})
-        assert self.redis.zremrangebyscore('foo', '(0', 1) == 0
-        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'two', b'four']
-        assert self.redis.zremrangebyscore('foo', '-inf', '(0') == 0
-        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'two', b'four']
-        assert self.redis.zremrangebyscore('foo', '(2', 5) == 1
-        assert self.redis.zrange('foo', 0, -1) == [b'zero', b'two']
-        assert self.redis.zremrangebyscore('foo', 0, '(2') == 1
-        assert self.redis.zrange('foo', 0, -1) == [b'two']
-        assert self.redis.zremrangebyscore('foo', '(1', '(3') == 1
-        assert self.redis.zrange('foo', 0, -1) == []
-
-    def test_zremrangebyscore_raises_error(self):
-        self.zadd('foo', {'zero': 0})
-        self.zadd('foo', {'two': 2})
-        self.zadd('foo', {'four': 4})
-        with pytest.raises(redis.ResponseError):
-            self.redis.zremrangebyscore('foo', 'three', 1)
-        with pytest.raises(redis.ResponseError):
-            self.redis.zremrangebyscore('foo', 3, 'one')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zremrangebyscore('foo', 3, '1)')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zremrangebyscore('foo', '((3', '1)')
-
-    def test_zremrangebyscore_badkey(self):
-        assert self.redis.zremrangebyscore('foo', 0, 2) == 0
-
-    def test_zremrangebyscore_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zremrangebyscore('foo', 0, 2)
-
-    def test_zremrangebylex(self):
-        self.zadd('foo', {'two_a': 0})
-        self.zadd('foo', {'two_b': 0})
-        self.zadd('foo', {'one_a': 0})
-        self.zadd('foo', {'three_a': 0})
-        assert self.redis.zremrangebylex('foo', b'(three_a', b'[two_b') == 2
-        assert self.redis.zremrangebylex('foo', b'(three_a', b'[two_b') == 0
-        assert self.redis.zremrangebylex('foo', b'-', b'(o') == 0
-        assert self.redis.zremrangebylex('foo', b'-', b'[one_a') == 1
-        assert self.redis.zremrangebylex('foo', b'[tw', b'+') == 0
-        assert self.redis.zremrangebylex('foo', b'[t', b'+') == 1
-        assert self.redis.zremrangebylex('foo', b'[t', b'+') == 0
-
-    def test_zremrangebylex_error(self):
-        self.zadd('foo', {'two_a': 0})
-        self.zadd('foo', {'two_b': 0})
-        self.zadd('foo', {'one_a': 0})
-        self.zadd('foo', {'three_a': 0})
-        with pytest.raises(redis.ResponseError):
-            self.redis.zremrangebylex('foo', b'(t', b'two_b')
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zremrangebylex('foo', b't', b'+')
-
-        with pytest.raises(redis.ResponseError):
-            self.redis.zremrangebylex('foo', b'[two_a', b'')
-
-    def test_zremrangebylex_badkey(self):
-        assert self.redis.zremrangebylex('foo', b'(three_a', b'[two_b') == 0
-
-    def test_zremrangebylex_wrong_type(self):
-        self.redis.sadd('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zremrangebylex('foo', b'bar', b'baz')
-
-    def test_zunionstore(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('bar', {'one': 1})
-        self.zadd('bar', {'two': 2})
-        self.zadd('bar', {'three': 3})
-        self.redis.zunionstore('baz', ['foo', 'bar'])
-        assert (
-            self.redis.zrange('baz', 0, -1, withscores=True)
-            == [(b'one', 2), (b'three', 3), (b'two', 4)]
-        )
-
-    def test_zunionstore_sum(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('bar', {'one': 1})
-        self.zadd('bar', {'two': 2})
-        self.zadd('bar', {'three': 3})
-        self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='SUM')
-        assert (
-            self.redis.zrange('baz', 0, -1, withscores=True)
-            == [(b'one', 2), (b'three', 3), (b'two', 4)]
-        )
-
-    def test_zunionstore_max(self):
-        self.zadd('foo', {'one': 0})
-        self.zadd('foo', {'two': 0})
-        self.zadd('bar', {'one': 1})
-        self.zadd('bar', {'two': 2})
-        self.zadd('bar', {'three': 3})
-        self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='MAX')
-        assert (
-            self.redis.zrange('baz', 0, -1, withscores=True)
-            == [(b'one', 1), (b'two', 2), (b'three', 3)]
-        )
-
-    def test_zunionstore_min(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('bar', {'one': 0})
-        self.zadd('bar', {'two': 0})
-        self.zadd('bar', {'three': 3})
-        self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='MIN')
-        assert (
-            self.redis.zrange('baz', 0, -1, withscores=True)
-            == [(b'one', 0), (b'two', 0), (b'three', 3)]
-        )
-
-    def test_zunionstore_weights(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('bar', {'one': 1})
-        self.zadd('bar', {'two': 2})
-        self.zadd('bar', {'four': 4})
-        self.redis.zunionstore('baz', {'foo': 1, 'bar': 2}, aggregate='SUM')
-        assert (
-            self.redis.zrange('baz', 0, -1, withscores=True)
-            == [(b'one', 3), (b'two', 6), (b'four', 8)]
-        )
-
-    def test_zunionstore_nan_to_zero(self):
-        self.zadd('foo', {'x': math.inf})
-        self.zadd('foo2', {'x': math.inf})
-        self.redis.zunionstore('bar', OrderedDict([('foo', 1.0), ('foo2', 0.0)]))
-        # This is different to test_zinterstore_nan_to_zero because of a quirk
-        # in redis. See https://github.com/antirez/redis/issues/3954.
-        assert self.redis.zscore('bar', 'x') == math.inf
-
-    def test_zunionstore_nan_to_zero2(self):
-        self.zadd('foo', {'zero': 0})
-        self.zadd('foo2', {'one': 1})
-        self.zadd('foo3', {'one': 1})
-        self.redis.zunionstore('bar', {'foo': math.inf}, aggregate='SUM')
-        assert self.redis.zrange('bar', 0, -1, withscores=True) == [(b'zero', 0)]
-        self.redis.zunionstore('bar', OrderedDict([('foo2', math.inf), ('foo3', -math.inf)]))
-        assert self.redis.zrange('bar', 0, -1, withscores=True) == [(b'one', 0)]
-
-    def test_zunionstore_nan_to_zero_ordering(self):
-        self.zadd('foo', {'e1': math.inf})
-        self.zadd('bar', {'e1': -math.inf, 'e2': 0.0})
-        self.redis.zunionstore('baz', ['foo', 'bar', 'foo'])
-        assert self.redis.zscore('baz', 'e1') == 0.0
-
-    def test_zunionstore_mixed_set_types(self):
-        # No score, redis will use 1.0.
-        self.redis.sadd('foo', 'one')
-        self.redis.sadd('foo', 'two')
-        self.zadd('bar', {'one': 1})
-        self.zadd('bar', {'two': 2})
-        self.zadd('bar', {'three': 3})
-        self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='SUM')
-        assert (
-            self.redis.zrange('baz', 0, -1, withscores=True)
-            == [(b'one', 2), (b'three', 3), (b'two', 3)]
-        )
-
-    def test_zunionstore_badkey(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.redis.zunionstore('baz', ['foo', 'bar'], aggregate='SUM')
-        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 1), (b'two', 2)]
-        self.redis.zunionstore('baz', {'foo': 1, 'bar': 2}, aggregate='SUM')
-        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 1), (b'two', 2)]
-
-    def test_zunionstore_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zunionstore('baz', ['foo', 'bar'])
-
-    def test_zinterstore(self):
-        self.zadd('foo', {'one': 1})
-        self.zadd('foo', {'two': 2})
-        self.zadd('bar', {'one': 1})
-        self.zadd('bar', {'two': 2})
-        self.zadd('bar', {'three': 3})
-        self.redis.zinterstore('baz', ['foo', 'bar'])
-        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 2), (b'two', 4)]
-
-    def test_zinterstore_mixed_set_types(self):
-        self.redis.sadd('foo', 'one')
-        self.redis.sadd('foo', 'two')
-        self.zadd('bar', {'one': 1})
-        self.zadd('bar', {'two': 2})
-        self.zadd('bar', {'three': 3})
-        self.redis.zinterstore('baz', ['foo', 'bar'], aggregate='SUM')
-        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 2), (b'two', 3)]
-
-    def test_zinterstore_max(self):
-        self.zadd('foo', {'one': 0})
-        self.zadd('foo', {'two': 0})
-        self.zadd('bar', {'one': 1})
-        self.zadd('bar', {'two': 2})
-        self.zadd('bar', {'three': 3})
-        self.redis.zinterstore('baz', ['foo', 'bar'], aggregate='MAX')
-        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 1), (b'two', 2)]
-
-    def test_zinterstore_onekey(self):
-        self.zadd('foo', {'one': 1})
-        self.redis.zinterstore('baz', ['foo'], aggregate='MAX')
-        assert self.redis.zrange('baz', 0, -1, withscores=True) == [(b'one', 1)]
-
-    def test_zinterstore_nokey(self):
-        with pytest.raises(redis.ResponseError):
-            self.redis.zinterstore('baz', [], aggregate='MAX')
-
-    def test_zinterstore_nan_to_zero(self):
-        self.zadd('foo', {'x': math.inf})
-        self.zadd('foo2', {'x': math.inf})
-        self.redis.zinterstore('bar', OrderedDict([('foo', 1.0), ('foo2', 0.0)]))
-        assert self.redis.zscore('bar', 'x') == 0.0
-
-    def test_zunionstore_nokey(self):
-        with pytest.raises(redis.ResponseError):
-            self.redis.zunionstore('baz', [], aggregate='MAX')
-
-    def test_zinterstore_wrong_type(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError):
-            self.redis.zinterstore('baz', ['foo', 'bar'])
-
-    def test_empty_zset(self):
-        self.zadd('foo', {'one': 1})
-        self.redis.zrem('foo', 'one')
-        assert not self.redis.exists('foo')
-
-    def test_multidb(self):
-        r1 = self.create_redis(db=0)
-        r2 = self.create_redis(db=1)
-
-        r1['r1'] = 'r1'
-        r2['r2'] = 'r2'
-
-        assert 'r2' not in r1
-        assert 'r1' not in r2
-
-        assert r1['r1'] == b'r1'
-        assert r2['r2'] == b'r2'
-
-        assert r1.flushall() == True
-
-        assert 'r1' not in r1
-        assert 'r2' not in r2
-
-    def test_basic_sort(self):
-        self.redis.rpush('foo', '2')
-        self.redis.rpush('foo', '1')
-        self.redis.rpush('foo', '3')
-
-        assert self.redis.sort('foo') == [b'1', b'2', b'3']
-
-    def test_empty_sort(self):
-        assert self.redis.sort('foo') == []
-
-    def test_sort_range_offset_range(self):
-        self.redis.rpush('foo', '2')
-        self.redis.rpush('foo', '1')
-        self.redis.rpush('foo', '4')
-        self.redis.rpush('foo', '3')
-
-        assert self.redis.sort('foo', start=0, num=2) == [b'1', b'2']
-
-    def test_sort_range_offset_range_and_desc(self):
-        self.redis.rpush('foo', '2')
-        self.redis.rpush('foo', '1')
-        self.redis.rpush('foo', '4')
-        self.redis.rpush('foo', '3')
-
-        assert self.redis.sort("foo", start=0, num=1, desc=True) == [b"4"]
-
-    def test_sort_range_offset_norange(self):
-        with pytest.raises(redis.RedisError):
-            self.redis.sort('foo', start=1)
-
-    def test_sort_range_with_large_range(self):
-        self.redis.rpush('foo', '2')
-        self.redis.rpush('foo', '1')
-        self.redis.rpush('foo', '4')
-        self.redis.rpush('foo', '3')
-        # num=20 even though len(foo) is 4.
-        assert self.redis.sort('foo', start=1, num=20) == [b'2', b'3', b'4']
-
-    def test_sort_descending(self):
-        self.redis.rpush('foo', '1')
-        self.redis.rpush('foo', '2')
-        self.redis.rpush('foo', '3')
-        assert self.redis.sort('foo', desc=True) == [b'3', b'2', b'1']
-
-    def test_sort_alpha(self):
-        self.redis.rpush('foo', '2a')
-        self.redis.rpush('foo', '1b')
-        self.redis.rpush('foo', '2b')
-        self.redis.rpush('foo', '1a')
-
-        assert self.redis.sort('foo', alpha=True) == [b'1a', b'1b', b'2a', b'2b']
-
-    def test_sort_wrong_type(self):
-        self.redis.set('string', '3')
-        with pytest.raises(redis.ResponseError):
-            self.redis.sort('string')
-
-    def test_foo(self):
-        self.redis.rpush('foo', '2a')
-        self.redis.rpush('foo', '1b')
-        self.redis.rpush('foo', '2b')
-        self.redis.rpush('foo', '1a')
-        with pytest.raises(redis.ResponseError):
-            self.redis.sort('foo', alpha=False)
-
-    def test_sort_with_store_option(self):
-        self.redis.rpush('foo', '2')
-        self.redis.rpush('foo', '1')
-        self.redis.rpush('foo', '4')
-        self.redis.rpush('foo', '3')
-
-        assert self.redis.sort('foo', store='bar') == 4
-        assert self.redis.lrange('bar', 0, -1) == [b'1', b'2', b'3', b'4']
-
-    def test_sort_with_by_and_get_option(self):
-        self.redis.rpush('foo', '2')
-        self.redis.rpush('foo', '1')
-        self.redis.rpush('foo', '4')
-        self.redis.rpush('foo', '3')
-
-        self.redis['weight_1'] = '4'
-        self.redis['weight_2'] = '3'
-        self.redis['weight_3'] = '2'
-        self.redis['weight_4'] = '1'
-
-        self.redis['data_1'] = 'one'
-        self.redis['data_2'] = 'two'
-        self.redis['data_3'] = 'three'
-        self.redis['data_4'] = 'four'
-
-        assert (
-            self.redis.sort('foo', by='weight_*', get='data_*')
-            == [b'four', b'three', b'two', b'one']
-        )
-        assert self.redis.sort('foo', by='weight_*', get='#') == [b'4', b'3', b'2', b'1']
-        assert (
-            self.redis.sort('foo', by='weight_*', get=('data_*', '#'))
-            == [b'four', b'4', b'three', b'3', b'two', b'2', b'one', b'1']
-        )
-        assert self.redis.sort('foo', by='weight_*', get='data_1') == [None, None, None, None]
-
-    def test_sort_with_hash(self):
-        self.redis.rpush('foo', 'middle')
-        self.redis.rpush('foo', 'eldest')
-        self.redis.rpush('foo', 'youngest')
-        self.redis.hset('record_youngest', 'age', 1)
-        self.redis.hset('record_youngest', 'name', 'baby')
-
-        self.redis.hset('record_middle', 'age', 10)
-        self.redis.hset('record_middle', 'name', 'teen')
-
-        self.redis.hset('record_eldest', 'age', 20)
-        self.redis.hset('record_eldest', 'name', 'adult')
-
-        assert self.redis.sort('foo', by='record_*->age') == [b'youngest', b'middle', b'eldest']
-        assert (
-            self.redis.sort('foo', by='record_*->age', get='record_*->name')
-            == [b'baby', b'teen', b'adult']
-        )
-
-    def test_sort_with_set(self):
-        self.redis.sadd('foo', '3')
-        self.redis.sadd('foo', '1')
-        self.redis.sadd('foo', '2')
-        assert self.redis.sort('foo') == [b'1', b'2', b'3']
-
-    def test_pipeline(self):
-        # The pipeline method returns an object for
-        # issuing multiple commands in a batch.
-        p = self.redis.pipeline()
-        p.watch('bam')
-        p.multi()
-        p.set('foo', 'bar').get('foo')
-        p.lpush('baz', 'quux')
-        p.lpush('baz', 'quux2').lrange('baz', 0, -1)
-        res = p.execute()
-
-        # Check return values returned as list.
-        assert res == [True, b'bar', 1, 2, [b'quux2', b'quux']]
-
-        # Check side effects happened as expected.
-        assert self.redis.lrange('baz', 0, -1) == [b'quux2', b'quux']
-
-        # Check that the command buffer has been emptied.
-        assert p.execute() == []
-
-    def test_pipeline_ignore_errors(self):
-        """Test the pipeline ignoring errors when asked."""
-        with self.redis.pipeline() as p:
-            p.set('foo', 'bar')
-            p.rename('baz', 'bats')
-            with pytest.raises(redis.exceptions.ResponseError):
-                p.execute()
-            assert [] == p.execute()
-        with self.redis.pipeline() as p:
-            p.set('foo', 'bar')
-            p.rename('baz', 'bats')
-            res = p.execute(raise_on_error=False)
-
-            assert [] == p.execute()
-
-            assert len(res) == 2
-            assert isinstance(res[1], redis.exceptions.ResponseError)
-
-    def test_multiple_successful_watch_calls(self):
-        p = self.redis.pipeline()
-        p.watch('bam')
-        p.multi()
-        p.set('foo', 'bar')
-        # Check that the watched keys buffer has been emptied.
-        p.execute()
-
-        # bam is no longer being watched, so it's ok to modify
-        # it now.
-        p.watch('foo')
-        self.redis.set('bam', 'boo')
-        p.multi()
-        p.set('foo', 'bats')
-        assert p.execute() == [True]
-
-    def test_pipeline_non_transactional(self):
-        # For our simple-minded model I don't think
-        # there is any observable difference.
-        p = self.redis.pipeline(transaction=False)
-        res = p.set('baz', 'quux').get('baz').execute()
-
-        assert res == [True, b'quux']
-
-    def test_pipeline_raises_when_watched_key_changed(self):
-        self.redis.set('foo', 'bar')
-        self.redis.rpush('greet', 'hello')
-        p = self.redis.pipeline()
-        try:
-            p.watch('greet', 'foo')
-            nextf = six.ensure_binary(p.get('foo')) + b'baz'
-            # Simulate change happening on another thread.
-            self.redis.rpush('greet', 'world')
-            # Begin pipelining.
-            p.multi()
-            p.set('foo', nextf)
-
-            with pytest.raises(redis.WatchError):
-                p.execute()
-        finally:
-            p.reset()
-
-    def test_pipeline_succeeds_despite_unwatched_key_changed(self):
-        # Same setup as before except for the params to the WATCH command.
-        self.redis.set('foo', 'bar')
-        self.redis.rpush('greet', 'hello')
-        p = self.redis.pipeline()
-        try:
-            # Only watch one of the 2 keys.
-            p.watch('foo')
-            nextf = six.ensure_binary(p.get('foo')) + b'baz'
-            # Simulate change happening on another thread.
-            self.redis.rpush('greet', 'world')
-            p.multi()
-            p.set('foo', nextf)
-            p.execute()
-
-            # Check the commands were executed.
-            assert self.redis.get('foo') == b'barbaz'
-        finally:
-            p.reset()
-
-    def test_pipeline_succeeds_when_watching_nonexistent_key(self):
-        self.redis.set('foo', 'bar')
-        self.redis.rpush('greet', 'hello')
-        p = self.redis.pipeline()
-        try:
-            # Also watch a nonexistent key.
-            p.watch('foo', 'bam')
-            nextf = six.ensure_binary(p.get('foo')) + b'baz'
-            # Simulate change happening on another thread.
-            self.redis.rpush('greet', 'world')
-            p.multi()
-            p.set('foo', nextf)
-            p.execute()
-
-            # Check the commands were executed.
-            assert self.redis.get('foo') == b'barbaz'
-        finally:
-            p.reset()
-
-    def test_watch_state_is_cleared_across_multiple_watches(self):
-        self.redis.set('foo', 'one')
-        self.redis.set('bar', 'baz')
-        p = self.redis.pipeline()
-
-        try:
-            p.watch('foo')
-            # Simulate change happening on another thread.
-            self.redis.set('foo', 'three')
-            p.multi()
-            p.set('foo', 'three')
-            with pytest.raises(redis.WatchError):
-                p.execute()
-
-            # Now watch another key.  It should be ok to change
-            # foo as we're no longer watching it.
-            p.watch('bar')
-            self.redis.set('foo', 'four')
-            p.multi()
-            p.set('bar', 'five')
-            assert p.execute() == [True]
-        finally:
-            p.reset()
-
-    def test_pipeline_transaction_shortcut(self):
-        # This example taken pretty much from the redis-py documentation.
-        self.redis.set('OUR-SEQUENCE-KEY', 13)
-        calls = []
-
-        def client_side_incr(pipe):
-            calls.append((pipe,))
-            current_value = pipe.get('OUR-SEQUENCE-KEY')
-            next_value = int(current_value) + 1
-
-            if len(calls) < 3:
-                # Simulate a change from another thread.
-                self.redis.set('OUR-SEQUENCE-KEY', next_value)
-
-            pipe.multi()
-            pipe.set('OUR-SEQUENCE-KEY', next_value)
-
-        res = self.redis.transaction(client_side_incr, 'OUR-SEQUENCE-KEY')
-
-        assert res == [True]
-        assert int(self.redis.get('OUR-SEQUENCE-KEY')) == 16
-        assert len(calls) == 3
-
-    def test_pipeline_transaction_value_from_callable(self):
-        def callback(pipe):
-            # No need to do anything here since we only want the return value
-            return 'OUR-RETURN-VALUE'
-
-        res = self.redis.transaction(callback, 'OUR-SEQUENCE-KEY',
-                                     value_from_callable=True)
-        assert res == 'OUR-RETURN-VALUE'
-
-    def test_pipeline_empty(self):
-        p = self.redis.pipeline()
-        assert len(p) == 0
-
-    def test_pipeline_length(self):
-        p = self.redis.pipeline()
-        p.set('baz', 'quux').get('baz')
-        assert len(p) == 2
-
-    def test_pipeline_no_commands(self):
-        # Prior to 3.4, redis-py's execute is a nop if there are no commands
-        # queued, so it succeeds even if watched keys have been changed.
-        self.redis.set('foo', '1')
-        p = self.redis.pipeline()
-        p.watch('foo')
-        self.redis.set('foo', '2')
-        if REDIS_VERSION >= '3.4':
-            with pytest.raises(redis.WatchError):
-                p.execute()
-        else:
-            assert p.execute() == []
-
-    def test_pipeline_failed_transaction(self):
-        p = self.redis.pipeline()
-        p.multi()
-        p.set('foo', 'bar')
-        # Deliberately induce a syntax error
-        p.execute_command('set')
-        # It should be an ExecAbortError, but redis-py tries to DISCARD after the
-        # failed EXEC, which raises a ResponseError.
-        with pytest.raises(redis.ResponseError):
-            p.execute()
-        assert not self.redis.exists('foo')
-
-    def test_pipeline_srem_no_change(self):
-        # A regression test for a case picked up by hypothesis tests
-        p = self.redis.pipeline()
-        p.watch('foo')
-        self.redis.srem('foo', 'bar')
-        p.multi()
-        p.set('foo', 'baz')
-        p.execute()
-        assert self.redis.get('foo') == b'baz'
-
-    def test_key_patterns(self):
-        self.redis.mset({'one': 1, 'two': 2, 'three': 3, 'four': 4})
-        assert sorted(self.redis.keys('*o*')) == [b'four', b'one', b'two']
-        assert self.redis.keys('t??') == [b'two']
-        assert sorted(self.redis.keys('*')) == [b'four', b'one', b'three', b'two']
-        assert sorted(self.redis.keys()) == [b'four', b'one', b'three', b'two']
-
-    def test_ping(self):
-        assert self.redis.ping()
-        assert self.raw_command('ping', 'test') == b'test'
-
-    @redis3_only
-    def test_ping_pubsub(self):
-        p = self.redis.pubsub()
-        p.subscribe('channel')
-        p.parse_response()    # Consume the subscribe reply
-        p.ping()
-        assert p.parse_response() == [b'pong', b'']
-        p.ping('test')
-        assert p.parse_response() == [b'pong', b'test']
-
-    @redis3_only
-    def test_swapdb(self):
-        r1 = self.create_redis(1)
-        self.redis.set('foo', 'abc')
-        self.redis.set('bar', 'xyz')
-        r1.set('foo', 'foo')
-        r1.set('baz', 'baz')
-        assert self.redis.swapdb(0, 1)
-        assert self.redis.get('foo') == b'foo'
-        assert self.redis.get('bar') is None
-        assert self.redis.get('baz') == b'baz'
-        assert r1.get('foo') == b'abc'
-        assert r1.get('bar') == b'xyz'
-        assert r1.get('baz') is None
-
-    @redis3_only
-    def test_swapdb_same_db(self):
-        assert self.redis.swapdb(1, 1)
-
-    def test_save(self):
-        assert self.redis.save()
-
-    def test_bgsave(self):
-        assert self.redis.bgsave()
-
-    def test_lastsave(self):
-        assert isinstance(self.redis.lastsave(), datetime)
-
-    @pytest.mark.slow
-    def test_bgsave_timestamp_update(self):
-        early_timestamp = self.redis.lastsave()
-        sleep(1)
-        assert self.redis.bgsave()
-        sleep(1)
-        late_timestamp = self.redis.lastsave()
-        assert early_timestamp <late_timestamp
-
-    @pytest.mark.slow
-    def test_save_timestamp_update(self):
-        early_timestamp = self.redis.lastsave()
-        sleep(1)
-        assert self.redis.save()
-        late_timestamp = self.redis.lastsave()
-        assert early_timestamp < late_timestamp
-
-    def test_type(self):
-        self.redis.set('string_key', "value")
-        self.redis.lpush("list_key", "value")
-        self.redis.sadd("set_key", "value")
-        self.zadd("zset_key", {"value": 1})
-        self.redis.hset('hset_key', 'key', 'value')
-
-        assert self.redis.type('string_key') == b'string'
-        assert self.redis.type('list_key') == b'list'
-        assert self.redis.type('set_key') == b'set'
-        assert self.redis.type('zset_key') == b'zset'
-        assert self.redis.type('hset_key') == b'hash'
-        assert self.redis.type('none_key') == b'none'
-
-    @pytest.mark.slow
-    def test_pubsub_subscribe(self):
-        pubsub = self.redis.pubsub()
-        pubsub.subscribe("channel")
-        sleep(1)
-        expected_message = {'type': 'subscribe', 'pattern': None,
-                            'channel': b'channel', 'data': 1}
-        message = pubsub.get_message()
-        keys = list(pubsub.channels.keys())
-
-        key = keys[0]
-        if not self.decode_responses:
-            key = (key if type(key) == bytes
-                   else bytes(key, encoding='utf-8'))
-
-        assert len(keys) == 1
-        assert key == b'channel'
-        assert message == expected_message
-
-    @pytest.mark.slow
-    def test_pubsub_psubscribe(self):
-        pubsub = self.redis.pubsub()
-        pubsub.psubscribe("channel.*")
-        sleep(1)
-        expected_message = {'type': 'psubscribe', 'pattern': None,
-                            'channel': b'channel.*', 'data': 1}
-
-        message = pubsub.get_message()
-        keys = list(pubsub.patterns.keys())
-        assert len(keys) == 1
-        assert message == expected_message
-
-    @pytest.mark.slow
-    def test_pubsub_unsubscribe(self):
-        pubsub = self.redis.pubsub()
-        pubsub.subscribe('channel-1', 'channel-2', 'channel-3')
-        sleep(1)
-        expected_message = {'type': 'unsubscribe', 'pattern': None,
-                            'channel': b'channel-1', 'data': 2}
-        pubsub.get_message()
-        pubsub.get_message()
-        pubsub.get_message()
-
-        # unsubscribe from one
-        pubsub.unsubscribe('channel-1')
-        sleep(1)
-        message = pubsub.get_message()
-        keys = list(pubsub.channels.keys())
-        assert message == expected_message
-        assert len(keys) == 2
-
-        # unsubscribe from multiple
-        pubsub.unsubscribe()
-        sleep(1)
-        pubsub.get_message()
-        pubsub.get_message()
-        keys = list(pubsub.channels.keys())
-        assert message == expected_message
-        assert len(keys) == 0
-
-    @pytest.mark.slow
-    def test_pubsub_punsubscribe(self):
-        pubsub = self.redis.pubsub()
-        pubsub.psubscribe('channel-1.*', 'channel-2.*', 'channel-3.*')
-        sleep(1)
-        expected_message = {'type': 'punsubscribe', 'pattern': None,
-                            'channel': b'channel-1.*', 'data': 2}
-        pubsub.get_message()
-        pubsub.get_message()
-        pubsub.get_message()
-
-        # unsubscribe from one
-        pubsub.punsubscribe('channel-1.*')
-        sleep(1)
-        message = pubsub.get_message()
-        keys = list(pubsub.patterns.keys())
-        assert message == expected_message
-        assert len(keys) == 2
-
-        # unsubscribe from multiple
-        pubsub.punsubscribe()
-        sleep(1)
-        pubsub.get_message()
-        pubsub.get_message()
-        keys = list(pubsub.patterns.keys())
-        assert len(keys) == 0
-
-    @pytest.mark.slow
-    def test_pubsub_listen(self):
-        def _listen(pubsub, q):
-            count = 0
-            for message in pubsub.listen():
-                q.put(message)
-                count += 1
-                if count == 4:
-                    pubsub.close()
-
-        channel = 'ch1'
-        patterns = ['ch1*', 'ch[1]', 'ch?']
-        pubsub = self.redis.pubsub()
-        pubsub.subscribe(channel)
-        pubsub.psubscribe(*patterns)
-        sleep(1)
-        msg1 = pubsub.get_message()
-        msg2 = pubsub.get_message()
-        msg3 = pubsub.get_message()
-        msg4 = pubsub.get_message()
-        assert msg1['type'] == 'subscribe'
-        assert msg2['type'] == 'psubscribe'
-        assert msg3['type'] == 'psubscribe'
-        assert msg4['type'] == 'psubscribe'
-
-        q = Queue()
-        t = threading.Thread(target=_listen, args=(pubsub, q))
-        t.start()
-        msg = 'hello world'
-        self.redis.publish(channel, msg)
-        t.join()
-
-        msg1 = q.get()
-        msg2 = q.get()
-        msg3 = q.get()
-        msg4 = q.get()
-
-        if self.decode_responses:
-            bpatterns = patterns + [channel]
-        else:
-            bpatterns = [pattern.encode() for pattern in patterns]
-            bpatterns.append(channel.encode())
-        msg = msg.encode()
-        assert msg1['data'] == msg
-        assert msg1['channel'] in bpatterns
-        assert msg2['data'] == msg
-        assert msg2['channel'] in bpatterns
-        assert msg3['data'] == msg
-        assert msg3['channel'] in bpatterns
-        assert msg4['data'] == msg
-        assert msg4['channel'] in bpatterns
-
-    @pytest.mark.slow
-    def test_pubsub_listen_handler(self):
-        def _handler(message):
-            calls.append(message)
-
-        channel = 'ch1'
-        patterns = {'ch?': _handler}
-        calls = []
-
-        pubsub = self.redis.pubsub()
-        pubsub.subscribe(ch1=_handler)
-        pubsub.psubscribe(**patterns)
-        sleep(1)
-        msg1 = pubsub.get_message()
-        msg2 = pubsub.get_message()
-        assert msg1['type'] == 'subscribe'
-        assert msg2['type'] == 'psubscribe'
-        msg = 'hello world'
-        self.redis.publish(channel, msg)
-        sleep(1)
-        for i in range(2):
-            msg = pubsub.get_message()
-            assert msg is None   # get_message returns None when handler is used
-        pubsub.close()
-        calls.sort(key=lambda call: call['type'])
-        assert calls == [
-            {'pattern': None, 'channel': b'ch1', 'data': b'hello world', 'type': 'message'},
-            {'pattern': b'ch?', 'channel': b'ch1', 'data': b'hello world', 'type': 'pmessage'}
-        ]
-
-    @pytest.mark.slow
-    def test_pubsub_ignore_sub_messages_listen(self):
-        def _listen(pubsub, q):
-            count = 0
-            for message in pubsub.listen():
-                q.put(message)
-                count += 1
-                if count == 4:
-                    pubsub.close()
-
-        channel = 'ch1'
-        patterns = ['ch1*', 'ch[1]', 'ch?']
-        pubsub = self.redis.pubsub(ignore_subscribe_messages=True)
-        pubsub.subscribe(channel)
-        pubsub.psubscribe(*patterns)
-        sleep(1)
-
-        q = Queue()
-        t = threading.Thread(target=_listen, args=(pubsub, q))
-        t.start()
-        msg = 'hello world'
-        self.redis.publish(channel, msg)
-        t.join()
-
-        msg1 = q.get()
-        msg2 = q.get()
-        msg3 = q.get()
-        msg4 = q.get()
-
-        if self.decode_responses:
-            bpatterns = patterns + [channel]
-        else:
-            bpatterns = [pattern.encode() for pattern in patterns]
-            bpatterns.append(channel.encode())
-        msg = msg.encode()
-        assert msg1['data'] == msg
-        assert msg1['channel'] in bpatterns
-        assert msg2['data'] == msg
-        assert msg2['channel'] in bpatterns
-        assert msg3['data'] == msg
-        assert msg3['channel'] in bpatterns
-        assert msg4['data'] == msg
-        assert msg4['channel'] in bpatterns
-
-    @pytest.mark.slow
-    def test_pubsub_binary(self):
-        if self.decode_responses:
-            # Reading the non-UTF-8 message will break if decoding
-            # responses.
-            return
-
-        def _listen(pubsub, q):
-            for message in pubsub.listen():
-                q.put(message)
-                pubsub.close()
-
-        pubsub = self.redis.pubsub(ignore_subscribe_messages=True)
-        pubsub.subscribe('channel\r\n\xff')
-        sleep(1)
-
-        q = Queue()
-        t = threading.Thread(target=_listen, args=(pubsub, q))
-        t.start()
-        msg = b'\x00hello world\r\n\xff'
-        self.redis.publish('channel\r\n\xff', msg)
-        t.join()
-
-        received = q.get()
-        assert received['data'] == msg
-
-    @pytest.mark.slow
-    def test_pubsub_run_in_thread(self):
-        q = Queue()
-
-        pubsub = self.redis.pubsub()
-        pubsub.subscribe(channel=q.put)
-        pubsub_thread = pubsub.run_in_thread()
-
-        msg = b"Hello World"
-        self.redis.publish("channel", msg)
-
-        retrieved = q.get()
-        assert retrieved["data"] == msg
-
-        pubsub_thread.stop()
-        # Newer versions of redis wait for an unsubscribe message, which sometimes comes early
-        # https://github.com/andymccurdy/redis-py/issues/1150
-        if pubsub.channels:
-            pubsub.channels = {}
-        pubsub_thread.join()
-        assert not pubsub_thread.is_alive()
-
-        pubsub.subscribe(channel=None)
-        with pytest.raises(redis.exceptions.PubSubError):
-            pubsub_thread = pubsub.run_in_thread()
-
-        pubsub.unsubscribe("channel")
-
-        pubsub.psubscribe(channel=None)
-        with pytest.raises(redis.exceptions.PubSubError):
-            pubsub_thread = pubsub.run_in_thread()
-
-    @pytest.mark.slow
-    def test_pubsub_timeout(self):
-        def publish():
-            sleep(0.1)
-            self.redis.publish('channel', 'hello')
-
-        p = self.redis.pubsub()
-        p.subscribe('channel')
-        p.parse_response()   # Drains the subscribe message
-        publish_thread = threading.Thread(target=publish)
-        publish_thread.start()
-        message = p.get_message(timeout=1)
-        assert message == {
-            'type': 'message', 'pattern': None,
-            'channel': b'channel', 'data': b'hello'
-        }
-        publish_thread.join()
-        message = p.get_message(timeout=0.5)
-        assert message is None
-
-    def test_pfadd(self):
-        key = "hll-pfadd"
-        assert self.redis.pfadd(key, "a", "b", "c", "d", "e", "f", "g") == 1
-        assert self.redis.pfcount(key) == 7
-
-    def test_pfcount(self):
-        key1 = "hll-pfcount01"
-        key2 = "hll-pfcount02"
-        key3 = "hll-pfcount03"
-        assert self.redis.pfadd(key1, "foo", "bar", "zap") == 1
-        assert self.redis.pfadd(key1, "zap", "zap", "zap") == 0
-        assert self.redis.pfadd(key1, "foo", "bar") == 0
-        assert self.redis.pfcount(key1) == 3
-        assert self.redis.pfadd(key2, "1", "2", "3") == 1
-        assert self.redis.pfcount(key2) == 3
-        assert self.redis.pfcount(key1, key2) == 6
-        assert self.redis.pfadd(key3, "foo", "bar", "zip") == 1
-        assert self.redis.pfcount(key3) == 3
-        assert self.redis.pfcount(key1, key3) == 4
-        assert self.redis.pfcount(key1, key2, key3) == 7
-
-    def test_pfmerge(self):
-        key1 = "hll-pfmerge01"
-        key2 = "hll-pfmerge02"
-        key3 = "hll-pfmerge03"
-        assert self.redis.pfadd(key1, "foo", "bar", "zap", "a") == 1
-        assert self.redis.pfadd(key2, "a", "b", "c", "foo") == 1
-        assert self.redis.pfmerge(key3, key1, key2)
-        assert self.redis.pfcount(key3) == 6
-
-    def test_scan(self):
-        # Setup the data
-        for ix in range(20):
-            k = 'scan-test:%s' % ix
-            v = 'result:%s' % ix
-            self.redis.set(k, v)
-        expected = self.redis.keys()
-        assert len(expected) == 20  # Ensure we know what we're testing
-
-        # Test that we page through the results and get everything out
-        results = []
-        cursor = '0'
-        while cursor != 0:
-            cursor, data = self.redis.scan(cursor, count=6)
-            results.extend(data)
-        assert set(expected) == set(results)
-
-        # Now test that the MATCH functionality works
-        results = []
-        cursor = '0'
-        while cursor != 0:
-            cursor, data = self.redis.scan(cursor, match='*7', count=100)
-            results.extend(data)
-        assert b'scan-test:7' in results
-        assert b'scan-test:17' in results
-        assert len(results) == 2
-
-        # Test the match on iterator
-        results = [r for r in self.redis.scan_iter(match='*7')]
-        assert b'scan-test:7' in results
-        assert b'scan-test:17' in results
-        assert len(results) == 2
-
-    def test_sscan(self):
-        # Setup the data
-        name = 'sscan-test'
-        for ix in range(20):
-            k = 'sscan-test:%s' % ix
-            self.redis.sadd(name, k)
-        expected = self.redis.smembers(name)
-        assert len(expected) == 20  # Ensure we know what we're testing
-
-        # Test that we page through the results and get everything out
-        results = []
-        cursor = '0'
-        while cursor != 0:
-            cursor, data = self.redis.sscan(name, cursor, count=6)
-            results.extend(data)
-        assert set(expected) == set(results)
-
-        # Test the iterator version
-        results = [r for r in self.redis.sscan_iter(name, count=6)]
-        assert set(expected) == set(results)
-
-        # Now test that the MATCH functionality works
-        results = []
-        cursor = '0'
-        while cursor != 0:
-            cursor, data = self.redis.sscan(name, cursor, match='*7', count=100)
-            results.extend(data)
-        assert b'sscan-test:7' in results
-        assert b'sscan-test:17' in results
-        assert len(results) == 2
-
-        # Test the match on iterator
-        results = [r for r in self.redis.sscan_iter(name, match='*7')]
-        assert b'sscan-test:7' in results
-        assert b'sscan-test:17' in results
-        assert len(results) == 2
-
-    def test_hscan(self):
-        # Setup the data
-        name = 'hscan-test'
-        for ix in range(20):
-            k = 'key:%s' % ix
-            v = 'result:%s' % ix
-            self.redis.hset(name, k, v)
-        expected = self.redis.hgetall(name)
-        assert len(expected) == 20  # Ensure we know what we're testing
-
-        # Test that we page through the results and get everything out
-        results = {}
-        cursor = '0'
-        while cursor != 0:
-            cursor, data = self.redis.hscan(name, cursor, count=6)
-            results.update(data)
-        assert expected == results
-
-        # Test the iterator version
-        results = {}
-        for key, val in self.redis.hscan_iter(name, count=6):
-            results[key] = val
-        assert expected == results
-
-        # Now test that the MATCH functionality works
-        results = {}
-        cursor = '0'
-        while cursor != 0:
-            cursor, data = self.redis.hscan(name, cursor, match='*7', count=100)
-            results.update(data)
-        assert b'key:7' in results
-        assert b'key:17' in results
-        assert len(results) == 2
-
-        # Test the match on iterator
-        results = {}
-        for key, val in self.redis.hscan_iter(name, match='*7'):
-            results[key] = val
-        assert b'key:7' in results
-        assert b'key:17' in results
-        assert len(results) == 2
-
-    def test_zscan(self):
-        # Setup the data
-        name = 'zscan-test'
-        for ix in range(20):
-            self.zadd(name, {'key:%s' % ix: ix})
-        expected = dict(self.redis.zrange(name, 0, -1, withscores=True))
-
-        # Test the basic version
-        results = {}
-        for key, val in self.redis.zscan_iter(name, count=6):
-            results[key] = val
-        assert results == expected
-
-        # Now test that the MATCH functionality works
-        results = {}
-        cursor = '0'
-        while cursor != 0:
-            cursor, data = self.redis.zscan(name, cursor, match='*7', count=6)
-            results.update(data)
-        assert results == {b'key:7': 7.0, b'key:17': 17.0}
-
-    @pytest.mark.slow
-    def test_set_ex_should_expire_value(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        self.redis.set('foo', 'bar', ex=1)
-        sleep(2)
-        assert self.redis.get('foo') is None
-
-    @pytest.mark.slow
-    def test_set_px_should_expire_value(self):
-        self.redis.set('foo', 'bar', px=500)
-        sleep(1.5)
-        assert self.redis.get('foo') is None
-
-    @pytest.mark.slow
-    def test_psetex_expire_value(self):
-        with pytest.raises(ResponseError):
-            self.redis.psetex('foo', 0, 'bar')
-        self.redis.psetex('foo', 500, 'bar')
-        sleep(1.5)
-        assert self.redis.get('foo') is None
-
-    @pytest.mark.slow
-    def test_psetex_expire_value_using_timedelta(self):
-        with pytest.raises(ResponseError):
-            self.redis.psetex('foo', timedelta(seconds=0), 'bar')
-        self.redis.psetex('foo', timedelta(seconds=0.5), 'bar')
-        sleep(1.5)
-        assert self.redis.get('foo') is None
-
-    @pytest.mark.slow
-    def test_expire_should_expire_key(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        self.redis.expire('foo', 1)
-        sleep(1.5)
-        assert self.redis.get('foo') is None
-        assert self.redis.expire('bar', 1) == False
-
-    def test_expire_should_return_true_for_existing_key(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.expire('foo', 1) is True
-
-    def test_expire_should_return_false_for_missing_key(self):
-        assert self.redis.expire('missing', 1) is False
-
-    @pytest.mark.slow
-    def test_expire_should_expire_key_using_timedelta(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        self.redis.expire('foo', timedelta(seconds=1))
-        sleep(1.5)
-        assert self.redis.get('foo') is None
-        assert self.redis.expire('bar', 1) == False
-
-    @pytest.mark.slow
-    def test_expire_should_expire_immediately_with_millisecond_timedelta(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        self.redis.expire('foo', timedelta(milliseconds=750))
-        assert self.redis.get('foo') is None
-        assert self.redis.expire('bar', 1) == False
-
-    @pytest.mark.slow
-    def test_pexpire_should_expire_key(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        self.redis.pexpire('foo', 150)
-        sleep(0.2)
-        assert self.redis.get('foo') is None
-        assert self.redis.pexpire('bar', 1) == False
-
-    def test_pexpire_should_return_truthy_for_existing_key(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.pexpire('foo', 1)
-
-    def test_pexpire_should_return_falsey_for_missing_key(self):
-        assert not self.redis.pexpire('missing', 1)
-
-    @pytest.mark.slow
-    def test_pexpire_should_expire_key_using_timedelta(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        self.redis.pexpire('foo', timedelta(milliseconds=750))
-        sleep(0.5)
-        assert self.redis.get('foo') == b'bar'
-        sleep(0.5)
-        assert self.redis.get('foo') is None
-        assert self.redis.pexpire('bar', 1) == False
-
-    @pytest.mark.slow
-    def test_expireat_should_expire_key_by_datetime(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        self.redis.expireat('foo', datetime.now() + timedelta(seconds=1))
-        sleep(1.5)
-        assert self.redis.get('foo') is None
-        assert self.redis.expireat('bar', datetime.now()) == False
-
-    @pytest.mark.slow
-    def test_expireat_should_expire_key_by_timestamp(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        self.redis.expireat('foo', int(time() + 1))
-        sleep(1.5)
-        assert self.redis.get('foo') is None
-        assert self.redis.expire('bar', 1) == False
-
-    def test_expireat_should_return_true_for_existing_key(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.expireat('foo', int(time() + 1)) is True
-
-    def test_expireat_should_return_false_for_missing_key(self):
-        assert self.redis.expireat('missing', int(time() + 1)) is False
-
-    @pytest.mark.slow
-    def test_pexpireat_should_expire_key_by_datetime(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        self.redis.pexpireat('foo', datetime.now() + timedelta(milliseconds=150))
-        sleep(0.2)
-        assert self.redis.get('foo') is None
-        assert self.redis.pexpireat('bar', datetime.now()) == False
-
-    @pytest.mark.slow
-    def test_pexpireat_should_expire_key_by_timestamp(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        self.redis.pexpireat('foo', int(time() * 1000 + 150))
-        sleep(0.2)
-        assert self.redis.get('foo') is None
-        assert self.redis.expire('bar', 1) == False
-
-    def test_pexpireat_should_return_true_for_existing_key(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.pexpireat('foo', int(time() * 1000 + 150))
-
-    def test_pexpireat_should_return_false_for_missing_key(self):
-        assert not self.redis.pexpireat('missing', int(time() * 1000 + 150))
-
-    def test_expire_should_not_handle_floating_point_values(self):
-        self.redis.set('foo', 'bar')
-        with pytest.raises(redis.ResponseError, match='value is not an integer or out of range'):
-            self.redis.expire('something_new', 1.2)
-            self.redis.pexpire('something_new', 1000.2)
-            self.redis.expire('some_unused_key', 1.2)
-            self.redis.pexpire('some_unused_key', 1000.2)
-
-    def test_ttl_should_return_minus_one_for_non_expiring_key(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        assert self.redis.ttl('foo') == -1
-
-    def test_ttl_should_return_minus_two_for_non_existent_key(self):
-        assert self.redis.get('foo') is None
-        assert self.redis.ttl('foo') == -2
-
-    def test_pttl_should_return_minus_one_for_non_expiring_key(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        assert self.redis.pttl('foo') == -1
-
-    def test_pttl_should_return_minus_two_for_non_existent_key(self):
-        assert self.redis.get('foo') is None
-        assert self.redis.pttl('foo') == -2
-
-    def test_persist(self):
-        self.redis.set('foo', 'bar', ex=20)
-        assert self.redis.persist('foo') == 1
-        assert self.redis.ttl('foo') == -1
-        assert self.redis.persist('foo') == 0
-
-    def test_set_existing_key_persists(self):
-        self.redis.set('foo', 'bar', ex=20)
-        self.redis.set('foo', 'foo')
-        assert self.redis.ttl('foo') == -1
-
-    def test_eval_set_value_to_arg(self):
-        self.redis.eval('redis.call("SET", KEYS[1], ARGV[1])', 1, 'foo', 'bar')
-        val = self.redis.get('foo')
-        assert val == b'bar'
-
-    def test_eval_conditional(self):
-        lua = """
-        local val = redis.call("GET", KEYS[1])
-        if val == ARGV[1] then
-            redis.call("SET", KEYS[1], ARGV[2])
-        else
-            redis.call("SET", KEYS[1], ARGV[1])
-        end
-        """
-        self.redis.eval(lua, 1, 'foo', 'bar', 'baz')
-        val = self.redis.get('foo')
-        assert val == b'bar'
-        self.redis.eval(lua, 1, 'foo', 'bar', 'baz')
-        val = self.redis.get('foo')
-        assert val == b'baz'
-
-    def test_eval_table(self):
-        lua = """
-        local a = {}
-        a[1] = "foo"
-        a[2] = "bar"
-        a[17] = "baz"
-        return a
-        """
-        val = self.redis.eval(lua, 0)
-        assert val == [b'foo', b'bar']
-
-    def test_eval_table_with_nil(self):
-        lua = """
-        local a = {}
-        a[1] = "foo"
-        a[2] = nil
-        a[3] = "bar"
-        return a
-        """
-        val = self.redis.eval(lua, 0)
-        assert val == [b'foo']
-
-    def test_eval_table_with_numbers(self):
-        lua = """
-        local a = {}
-        a[1] = 42
-        return a
-        """
-        val = self.redis.eval(lua, 0)
-        assert val == [42]
-
-    def test_eval_nested_table(self):
-        lua = """
-        local a = {}
-        a[1] = {}
-        a[1][1] = "foo"
-        return a
-        """
-        val = self.redis.eval(lua, 0)
-        assert val == [[b'foo']]
-
-    def test_eval_iterate_over_argv(self):
-        lua = """
-        for i, v in ipairs(ARGV) do
-        end
-        return ARGV
-        """
-        val = self.redis.eval(lua, 0, "a", "b", "c")
-        assert val == [b"a", b"b", b"c"]
-
-    def test_eval_iterate_over_keys(self):
-        lua = """
-        for i, v in ipairs(KEYS) do
-        end
-        return KEYS
-        """
-        val = self.redis.eval(lua, 2, "a", "b", "c")
-        assert val == [b"a", b"b"]
-
-    def test_eval_mget(self):
-        self.redis.set('foo1', 'bar1')
-        self.redis.set('foo2', 'bar2')
-        val = self.redis.eval('return redis.call("mget", "foo1", "foo2")', 2, 'foo1', 'foo2')
-        assert val == [b'bar1', b'bar2']
-
-    @redis2_only
-    def test_eval_mget_none(self):
-        self.redis.set('foo1', None)
-        self.redis.set('foo2', None)
-        val = self.redis.eval('return redis.call("mget", "foo1", "foo2")', 2, 'foo1', 'foo2')
-        assert val == [b'None', b'None']
-
-    def test_eval_mget_not_set(self):
-        val = self.redis.eval('return redis.call("mget", "foo1", "foo2")', 2, 'foo1', 'foo2')
-        assert val == [None, None]
-
-    def test_eval_hgetall(self):
-        self.redis.hset('foo', 'k1', 'bar')
-        self.redis.hset('foo', 'k2', 'baz')
-        val = self.redis.eval('return redis.call("hgetall", "foo")', 1, 'foo')
-        sorted_val = sorted([val[:2], val[2:]])
-        assert sorted_val == [[b'k1', b'bar'], [b'k2', b'baz']]
-
-    def test_eval_hgetall_iterate(self):
-        self.redis.hset('foo', 'k1', 'bar')
-        self.redis.hset('foo', 'k2', 'baz')
-        lua = """
-        local result = redis.call("hgetall", "foo")
-        for i, v in ipairs(result) do
-        end
-        return result
-        """
-        val = self.redis.eval(lua, 1, 'foo')
-        sorted_val = sorted([val[:2], val[2:]])
-        assert sorted_val == [[b'k1', b'bar'], [b'k2', b'baz']]
-
-    @redis2_only
-    def test_eval_list_with_nil(self):
-        self.redis.lpush('foo', 'bar')
-        self.redis.lpush('foo', None)
-        self.redis.lpush('foo', 'baz')
-        val = self.redis.eval('return redis.call("lrange", KEYS[1], 0, 2)', 1, 'foo')
-        assert val == [b'baz', b'None', b'bar']
-
-    def test_eval_invalid_command(self):
-        with pytest.raises(ResponseError):
-            self.redis.eval(
-                'return redis.call("FOO")',
-                0
-            )
-
-    def test_eval_syntax_error(self):
-        with pytest.raises(ResponseError):
-            self.redis.eval('return "', 0)
-
-    def test_eval_runtime_error(self):
-        with pytest.raises(ResponseError):
-            self.redis.eval('error("CRASH")', 0)
-
-    def test_eval_more_keys_than_args(self):
-        with pytest.raises(ResponseError):
-            self.redis.eval('return 1', 42)
-
-    def test_eval_numkeys_float_string(self):
-        with pytest.raises(ResponseError):
-            self.redis.eval('return KEYS[1]', '0.7', 'foo')
-
-    def test_eval_numkeys_integer_string(self):
-        val = self.redis.eval('return KEYS[1]', "1", "foo")
-        assert val == b'foo'
-
-    def test_eval_numkeys_negative(self):
-        with pytest.raises(ResponseError):
-            self.redis.eval('return KEYS[1]', -1, "foo")
-
-    def test_eval_numkeys_float(self):
-        with pytest.raises(ResponseError):
-            self.redis.eval('return KEYS[1]', 0.7, "foo")
-
-    def test_eval_global_variable(self):
-        # Redis doesn't allow script to define global variables
-        with pytest.raises(ResponseError):
-            self.redis.eval('a=10', 0)
-
-    def test_eval_global_and_return_ok(self):
-        # Redis doesn't allow script to define global variables
-        with pytest.raises(ResponseError):
-            self.redis.eval(
-                '''
-                a=10
-                return redis.status_reply("Everything is awesome")
-                ''',
-                0
-            )
-
-    def test_eval_convert_number(self):
-        # Redis forces all Lua numbers to integer
-        val = self.redis.eval('return 3.2', 0)
-        assert val == 3
-        val = self.redis.eval('return 3.8', 0)
-        assert val == 3
-        val = self.redis.eval('return -3.8', 0)
-        assert val == -3
-
-    def test_eval_convert_bool(self):
-        # Redis converts true to 1 and false to nil (which redis-py converts to None)
-        assert self.redis.eval('return false', 0) is None
-        val = self.redis.eval('return true', 0)
-        assert val == 1
-        assert not isinstance(val, bool)
-
-    def test_eval_call_bool(self):
-        # Redis doesn't allow Lua bools to be passed to [p]call
-        with pytest.raises(redis.ResponseError,
-                           match=r'Lua redis\(\) command arguments must be strings or integers'):
-            self.redis.eval('return redis.call("SET", KEYS[1], true)', 1, "testkey")
-
-    @redis2_only
-    def test_eval_none_arg(self):
-        val = self.redis.eval('return ARGV[1] == "None"', 0, None)
-        assert val
-
-    def test_eval_return_error(self):
-        with pytest.raises(redis.ResponseError, match='Testing') as exc_info:
-            self.redis.eval('return {err="Testing"}', 0)
-        assert isinstance(exc_info.value.args[0], str)
-        with pytest.raises(redis.ResponseError, match='Testing') as exc_info:
-            self.redis.eval('return redis.error_reply("Testing")', 0)
-        assert isinstance(exc_info.value.args[0], str)
-
-    def test_eval_return_redis_error(self):
-        with pytest.raises(redis.ResponseError) as exc_info:
-            self.redis.eval('return redis.pcall("BADCOMMAND")', 0)
-        assert isinstance(exc_info.value.args[0], str)
-
-    def test_eval_return_ok(self):
-        val = self.redis.eval('return {ok="Testing"}', 0)
-        assert val == b'Testing'
-        val = self.redis.eval('return redis.status_reply("Testing")', 0)
-        assert val == b'Testing'
-
-    def test_eval_return_ok_nested(self):
-        val = self.redis.eval(
-            '''
-            local a = {}
-            a[1] = {ok="Testing"}
-            return a
-            ''',
-            0
-        )
-        assert val == [b'Testing']
-
-    def test_eval_return_ok_wrong_type(self):
-        with pytest.raises(redis.ResponseError):
-            self.redis.eval('return redis.status_reply(123)', 0)
-
-    def test_eval_pcall(self):
-        val = self.redis.eval(
-            '''
-            local a = {}
-            a[1] = redis.pcall("foo")
-            return a
-            ''',
-            0
-        )
-        assert isinstance(val, list)
-        assert len(val) == 1
-        assert isinstance(val[0], ResponseError)
-
-    def test_eval_pcall_return_value(self):
-        with pytest.raises(ResponseError):
-            self.redis.eval('return redis.pcall("foo")', 0)
-
-    def test_eval_delete(self):
-        self.redis.set('foo', 'bar')
-        val = self.redis.get('foo')
-        assert val == b'bar'
-        val = self.redis.eval('redis.call("DEL", KEYS[1])', 1, 'foo')
-        assert val is None
-
-    def test_eval_exists(self):
-        val = self.redis.eval('return redis.call("exists", KEYS[1]) == 0', 1, 'foo')
-        assert val == 1
-
-    def test_eval_flushdb(self):
-        self.redis.set('foo', 'bar')
-        val = self.redis.eval(
-            '''
-            local value = redis.call("FLUSHDB");
-            return type(value) == "table" and value.ok == "OK";
-            ''', 0
-        )
-        assert val == 1
-
-    def test_eval_flushall(self):
-        r1 = self.create_redis(db=0)
-        r2 = self.create_redis(db=1)
-
-        r1['r1'] = 'r1'
-        r2['r2'] = 'r2'
-
-        val = self.redis.eval(
-            '''
-            local value = redis.call("FLUSHALL");
-            return type(value) == "table" and value.ok == "OK";
-            ''', 0
-        )
-
-        assert val == 1
-        assert 'r1' not in r1
-        assert 'r2' not in r2
-
-    def test_eval_incrbyfloat(self):
-        self.redis.set('foo', 0.5)
-        val = self.redis.eval(
-            '''
-            local value = redis.call("INCRBYFLOAT", KEYS[1], 2.0);
-            return type(value) == "string" and tonumber(value) == 2.5;
-            ''', 1, 'foo'
-        )
-        assert val == 1
-
-    def test_eval_lrange(self):
-        self.redis.rpush('foo', 'a', 'b')
-        val = self.redis.eval(
-            '''
-            local value = redis.call("LRANGE", KEYS[1], 0, -1);
-            return type(value) == "table" and value[1] == "a" and value[2] == "b";
-            ''', 1, 'foo'
-        )
-        assert val == 1
-
-    def test_eval_ltrim(self):
-        self.redis.rpush('foo', 'a', 'b', 'c', 'd')
-        val = self.redis.eval(
-            '''
-            local value = redis.call("LTRIM", KEYS[1], 1, 2);
-            return type(value) == "table" and value.ok == "OK";
-            ''', 1, 'foo'
-        )
-        assert val == 1
-        assert self.redis.lrange('foo', 0, -1) == [b'b', b'c']
-
-    def test_eval_lset(self):
-        self.redis.rpush('foo', 'a', 'b')
-        val = self.redis.eval(
-            '''
-            local value = redis.call("LSET", KEYS[1], 0, "z");
-            return type(value) == "table" and value.ok == "OK";
-            ''', 1, 'foo'
-        )
-        assert val == 1
-        assert self.redis.lrange('foo', 0, -1) == [b'z', b'b']
-
-    def test_eval_sdiff(self):
-        self.redis.sadd('foo', 'a', 'b', 'c', 'f', 'e', 'd')
-        self.redis.sadd('bar', 'b')
-        val = self.redis.eval(
-            '''
-            local value = redis.call("SDIFF", KEYS[1], KEYS[2]);
-            if type(value) ~= "table" then
-                return redis.error_reply(type(value) .. ", should be table");
-            else
-                return value;
-            end
-            ''', 2, 'foo', 'bar')
-        # Note: while fakeredis sorts the result when using Lua, this isn't
-        # actually part of the redis contract (see
-        # https://github.com/antirez/redis/issues/5538), and for Redis 5 we
-        # need to sort val to pass the test.
-        assert sorted(val) == [b'a', b'c', b'd', b'e', b'f']
-
-    def test_script(self):
-        script = self.redis.register_script('return ARGV[1]')
-        result = script(args=[42])
-        assert result == b'42'
-
-    @fake_only("requires access to redis log file")
-    def test_lua_log(self, caplog):
-        logger = fakeredis._server.LOGGER
-        script = """
-            redis.log(redis.LOG_DEBUG, "debug")
-            redis.log(redis.LOG_VERBOSE, "verbose")
-            redis.log(redis.LOG_NOTICE, "notice")
-            redis.log(redis.LOG_WARNING, "warning")
-        """
-        script = self.redis.register_script(script)
-        with caplog.at_level('DEBUG'):
-            script()
-        assert caplog.record_tuples == [
-            (logger.name, logging.DEBUG, 'debug'),
-            (logger.name, logging.INFO, 'verbose'),
-            (logger.name, logging.INFO, 'notice'),
-            (logger.name, logging.WARNING, 'warning')
-        ]
-
-    def test_lua_log_no_message(self):
-        script = "redis.log(redis.LOG_DEBUG)"
-        script = self.redis.register_script(script)
-        with pytest.raises(redis.ResponseError):
-            script()
-
-    @fake_only("requires access to redis log file")
-    def test_lua_log_different_types(self, caplog):
-        logger = fakeredis._server.LOGGER
-        script = "redis.log(redis.LOG_DEBUG, 'string', 1, true, 3.14, 'string')"
-        script = self.redis.register_script(script)
-        with caplog.at_level('DEBUG'):
-            script()
-        assert caplog.record_tuples == [
-            (logger.name, logging.DEBUG, 'string 1 3.14 string')
-        ]
-
-    def test_lua_log_wrong_level(self):
-        script = "redis.log(10, 'string')"
-        script = self.redis.register_script(script)
-        with pytest.raises(redis.ResponseError):
-            script()
-
-    @fake_only("requires access to redis log file")
-    def test_lua_log_defined_vars(self, caplog):
-        logger = fakeredis._server.LOGGER
-        script = """
-            local var='string'
-            redis.log(redis.LOG_DEBUG, var)
-        """
-        script = self.redis.register_script(script)
-        with caplog.at_level('DEBUG'):
-            script()
-        assert caplog.record_tuples == [(logger.name, logging.DEBUG, 'string')]
-
-    @redis3_only
-    def test_unlink(self):
-        self.redis.set('foo', 'bar')
-        self.redis.unlink('foo')
-        assert self.redis.get('foo') is None
+def test_set_then_get(r):
+    assert r.set('foo', 'bar') == True
+    assert r.get('foo') == b'bar'
 
 
 @redis2_only
-class TestFakeRedis:
-    decode_responses = False
+def test_set_None_value(r):
+    assert r.set('foo', None) == True
+    assert r.get('foo') == b'None'
 
-    def setup(self):
-        self.server = fakeredis.FakeServer()
-        self.redis = self.create_redis()
 
-    def teardown(self):
-        self.redis.flushall()
-        del self.redis
+def test_set_float_value(r):
+    x = 1.23456789123456789
+    r.set('foo', x)
+    assert float(r.get('foo')) == x
 
-    def create_redis(self, db=0):
-        return fakeredis.FakeRedis(db=db, server=self.server)
 
-    def test_setex(self):
-        assert self.redis.setex('foo', 'bar', 100) == True
-        assert self.redis.get('foo') == b'bar'
+def test_saving_non_ascii_chars_as_value(r):
+    assert r.set('foo', 'Ñandu') == True
+    assert r.get('foo') == 'Ñandu'.encode()
 
-    def test_setex_using_timedelta(self):
-        assert self.redis.setex('foo', 'bar', timedelta(seconds=100)) == True
-        assert self.redis.get('foo') == b'bar'
 
-    def test_lrem_positive_count(self):
-        self.redis.lpush('foo', 'same')
-        self.redis.lpush('foo', 'same')
-        self.redis.lpush('foo', 'different')
-        self.redis.lrem('foo', 'same', 2)
-        assert self.redis.lrange('foo', 0, -1) == [b'different']
+def test_saving_unicode_type_as_value(r):
+    assert r.set('foo', 'Ñandu') == True
+    assert r.get('foo') == 'Ñandu'.encode()
 
-    def test_lrem_negative_count(self):
-        self.redis.lpush('foo', 'removeme')
-        self.redis.lpush('foo', 'three')
-        self.redis.lpush('foo', 'two')
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'removeme')
-        self.redis.lrem('foo', 'removeme', -1)
+
+def test_saving_non_ascii_chars_as_key(r):
+    assert r.set('Ñandu', 'foo') == True
+    assert r.get('Ñandu') == b'foo'
+
+
+def test_saving_unicode_type_as_key(r):
+    assert r.set('Ñandu', 'foo') == True
+    assert r.get('Ñandu') == b'foo'
+
+
+def test_future_newbytes(r):
+    bytes = pytest.importorskip('builtins', reason='future.types not available').bytes
+    r.set(bytes(b'\xc3\x91andu'), 'foo')
+    assert r.get('Ñandu') == b'foo'
+
+
+def test_future_newstr(r):
+    str = pytest.importorskip('builtins', reason='future.types not available').str
+    r.set(str('Ñandu'), 'foo')
+    assert r.get('Ñandu') == b'foo'
+
+
+def test_get_does_not_exist(r):
+    assert r.get('foo') is None
+
+
+def test_get_with_non_str_keys(r):
+    assert r.set('2', 'bar') == True
+    assert r.get(2) == b'bar'
+
+
+def test_get_invalid_type(r):
+    assert r.hset('foo', 'key', 'value') == 1
+    with pytest.raises(redis.ResponseError):
+        r.get('foo')
+
+
+def test_set_non_str_keys(r):
+    assert r.set(2, 'bar') == True
+    assert r.get(2) == b'bar'
+    assert r.get('2') == b'bar'
+
+
+def test_getbit(r):
+    r.setbit('foo', 3, 1)
+    assert r.getbit('foo', 0) == 0
+    assert r.getbit('foo', 1) == 0
+    assert r.getbit('foo', 2) == 0
+    assert r.getbit('foo', 3) == 1
+    assert r.getbit('foo', 4) == 0
+    assert r.getbit('foo', 100) == 0
+
+
+def test_getbit_wrong_type(r):
+    r.rpush('foo', b'x')
+    with pytest.raises(redis.ResponseError):
+        r.getbit('foo', 1)
+
+
+def test_multiple_bits_set(r):
+    r.setbit('foo', 1, 1)
+    r.setbit('foo', 3, 1)
+    r.setbit('foo', 5, 1)
+
+    assert r.getbit('foo', 0) == 0
+    assert r.getbit('foo', 1) == 1
+    assert r.getbit('foo', 2) == 0
+    assert r.getbit('foo', 3) == 1
+    assert r.getbit('foo', 4) == 0
+    assert r.getbit('foo', 5) == 1
+    assert r.getbit('foo', 6) == 0
+
+
+def test_unset_bits(r):
+    r.setbit('foo', 1, 1)
+    r.setbit('foo', 2, 0)
+    r.setbit('foo', 3, 1)
+    assert r.getbit('foo', 1) == 1
+    r.setbit('foo', 1, 0)
+    assert r.getbit('foo', 1) == 0
+    r.setbit('foo', 3, 0)
+    assert r.getbit('foo', 3) == 0
+
+
+def test_get_set_bits(r):
+    # set bit 5
+    assert not r.setbit('a', 5, True)
+    assert r.getbit('a', 5)
+    # unset bit 4
+    assert not r.setbit('a', 4, False)
+    assert not r.getbit('a', 4)
+    # set bit 4
+    assert not r.setbit('a', 4, True)
+    assert r.getbit('a', 4)
+    # set bit 5 again
+    assert r.setbit('a', 5, True)
+    assert r.getbit('a', 5)
+
+
+def test_setbits_and_getkeys(r):
+    # The bit operations and the get commands
+    # should play nicely with each other.
+    r.setbit('foo', 1, 1)
+    assert r.get('foo') == b'@'
+    r.setbit('foo', 2, 1)
+    assert r.get('foo') == b'`'
+    r.setbit('foo', 3, 1)
+    assert r.get('foo') == b'p'
+    r.setbit('foo', 9, 1)
+    assert r.get('foo') == b'p@'
+    r.setbit('foo', 54, 1)
+    assert r.get('foo') == b'p@\x00\x00\x00\x00\x02'
+
+
+def test_setbit_wrong_type(r):
+    r.rpush('foo', b'x')
+    with pytest.raises(redis.ResponseError):
+        r.setbit('foo', 0, 1)
+
+
+def test_setbit_expiry(r):
+    r.set('foo', b'0x00', ex=10)
+    r.setbit('foo', 1, 1)
+    assert r.ttl('foo') > 0
+
+
+def test_bitcount(r):
+    r.delete('foo')
+    assert r.bitcount('foo') == 0
+    r.setbit('foo', 1, 1)
+    assert r.bitcount('foo') == 1
+    r.setbit('foo', 8, 1)
+    assert r.bitcount('foo') == 2
+    assert r.bitcount('foo', 1, 1) == 1
+    r.setbit('foo', 57, 1)
+    assert r.bitcount('foo') == 3
+    r.set('foo', ' ')
+    assert r.bitcount('foo') == 1
+
+
+def test_bitcount_wrong_type(r):
+    r.rpush('foo', b'x')
+    with pytest.raises(redis.ResponseError):
+        r.bitcount('foo')
+
+
+def test_getset_not_exist(r):
+    val = r.getset('foo', 'bar')
+    assert val is None
+    assert r.get('foo') == b'bar'
+
+
+def test_getset_exists(r):
+    r.set('foo', 'bar')
+    val = r.getset('foo', b'baz')
+    assert val == b'bar'
+    val = r.getset('foo', b'baz2')
+    assert val == b'baz'
+
+
+def test_getset_wrong_type(r):
+    r.rpush('foo', b'x')
+    with pytest.raises(redis.ResponseError):
+        r.getset('foo', 'bar')
+
+
+def test_setitem_getitem(r):
+    assert r.keys() == []
+    r['foo'] = 'bar'
+    assert r['foo'] == b'bar'
+
+
+def test_getitem_non_existent_key(r):
+    assert r.keys() == []
+    with pytest.raises(KeyError):
+        r['noexists']
+
+
+def test_strlen(r):
+    r['foo'] = 'bar'
+
+    assert r.strlen('foo') == 3
+    assert r.strlen('noexists') == 0
+
+
+def test_strlen_wrong_type(r):
+    r.rpush('foo', b'x')
+    with pytest.raises(redis.ResponseError):
+        r.strlen('foo')
+
+
+def test_substr(r):
+    r['foo'] = 'one_two_three'
+    assert r.substr('foo', 0) == b'one_two_three'
+    assert r.substr('foo', 0, 2) == b'one'
+    assert r.substr('foo', 4, 6) == b'two'
+    assert r.substr('foo', -5) == b'three'
+    assert r.substr('foo', -4, -5) == b''
+    assert r.substr('foo', -5, -3) == b'thr'
+
+
+def test_substr_noexist_key(r):
+    assert r.substr('foo', 0) == b''
+    assert r.substr('foo', 10) == b''
+    assert r.substr('foo', -5, -1) == b''
+
+
+def test_substr_wrong_type(r):
+    r.rpush('foo', b'x')
+    with pytest.raises(redis.ResponseError):
+        r.substr('foo', 0)
+
+
+def test_append(r):
+    assert r.set('foo', 'bar')
+    assert r.append('foo', 'baz') == 6
+    assert r.get('foo') == b'barbaz'
+
+
+def test_append_with_no_preexisting_key(r):
+    assert r.append('foo', 'bar') == 3
+    assert r.get('foo') == b'bar'
+
+
+def test_append_wrong_type(r):
+    r.rpush('foo', b'x')
+    with pytest.raises(redis.ResponseError):
+        r.append('foo', b'x')
+
+
+def test_incr_with_no_preexisting_key(r):
+    assert r.incr('foo') == 1
+    assert r.incr('bar', 2) == 2
+
+
+def test_incr_by(r):
+    assert r.incrby('foo') == 1
+    assert r.incrby('bar', 2) == 2
+
+
+def test_incr_preexisting_key(r):
+    r.set('foo', 15)
+    assert r.incr('foo', 5) == 20
+    assert r.get('foo') == b'20'
+
+
+def test_incr_expiry(r):
+    r.set('foo', 15, ex=10)
+    r.incr('foo', 5)
+    assert r.ttl('foo') > 0
+
+
+def test_incr_bad_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.incr('foo', 15)
+    r.rpush('foo2', 1)
+    with pytest.raises(redis.ResponseError):
+        r.incr('foo2', 15)
+
+
+def test_incr_with_float(r):
+    with pytest.raises(redis.ResponseError):
+        r.incr('foo', 2.0)
+
+
+def test_incr_followed_by_mget(r):
+    r.set('foo', 15)
+    assert r.incr('foo', 5) == 20
+    assert r.get('foo') == b'20'
+
+
+def test_incr_followed_by_mget_returns_strings(r):
+    r.incr('foo', 1)
+    assert r.mget(['foo']) == [b'1']
+
+
+def test_incrbyfloat(r):
+    r.set('foo', 0)
+    assert r.incrbyfloat('foo', 1.0) == 1.0
+    assert r.incrbyfloat('foo', 1.0) == 2.0
+
+
+def test_incrbyfloat_with_noexist(r):
+    assert r.incrbyfloat('foo', 1.0) == 1.0
+    assert r.incrbyfloat('foo', 1.0) == 2.0
+
+
+def test_incrbyfloat_expiry(r):
+    r.set('foo', 1.5, ex=10)
+    r.incrbyfloat('foo', 2.5)
+    assert r.ttl('foo') > 0
+
+
+def test_incrbyfloat_bad_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError, match='not a valid float'):
+        r.incrbyfloat('foo', 1.0)
+    r.rpush('foo2', 1)
+    with pytest.raises(redis.ResponseError):
+        r.incrbyfloat('foo2', 1.0)
+
+
+def test_incrbyfloat_precision(r):
+    x = 1.23456789123456789
+    assert r.incrbyfloat('foo', x) == x
+    assert float(r.get('foo')) == x
+
+
+def test_decr(r):
+    r.set('foo', 10)
+    assert r.decr('foo') == 9
+    assert r.get('foo') == b'9'
+
+
+def test_decr_newkey(r):
+    r.decr('foo')
+    assert r.get('foo') == b'-1'
+
+
+def test_decr_expiry(r):
+    r.set('foo', 10, ex=10)
+    r.decr('foo', 5)
+    assert r.ttl('foo') > 0
+
+
+def test_decr_badtype(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.decr('foo', 15)
+    r.rpush('foo2', 1)
+    with pytest.raises(redis.ResponseError):
+        r.decr('foo2', 15)
+
+
+def test_keys(r):
+    r.set('', 'empty')
+    r.set('abc\n', '')
+    r.set('abc\\', '')
+    r.set('abcde', '')
+    r.set(b'\xfe\xcd', '')
+    assert sorted(r.keys()) == [b'', b'abc\n', b'abc\\', b'abcde', b'\xfe\xcd']
+    assert r.keys('??') == [b'\xfe\xcd']
+    # empty pattern not the same as no pattern
+    assert r.keys('') == [b'']
+    # ? must match \n
+    assert sorted(r.keys('abc?')) == [b'abc\n', b'abc\\']
+    # must be anchored at both ends
+    assert r.keys('abc') == []
+    assert r.keys('bcd') == []
+    # wildcard test
+    assert r.keys('a*de') == [b'abcde']
+    # positive groups
+    assert sorted(r.keys('abc[d\n]*')) == [b'abc\n', b'abcde']
+    assert r.keys('abc[c-e]?') == [b'abcde']
+    assert r.keys('abc[e-c]?') == [b'abcde']
+    assert r.keys('abc[e-e]?') == []
+    assert r.keys('abcd[ef') == [b'abcde']
+    assert r.keys('abcd[]') == []
+    # negative groups
+    assert r.keys('abc[^d\\\\]*') == [b'abc\n']
+    assert r.keys('abc[^]e') == [b'abcde']
+    # escaping
+    assert r.keys(r'abc\?e') == []
+    assert r.keys(r'abc\de') == [b'abcde']
+    assert r.keys(r'abc[\d]e') == [b'abcde']
+    # some escaping cases that redis handles strangely
+    assert r.keys('abc\\') == [b'abc\\']
+    assert r.keys(r'abc[\c-e]e') == []
+    assert r.keys(r'abc[c-\e]e') == []
+
+
+def test_exists(r):
+    assert 'foo' not in r
+    r.set('foo', 'bar')
+    assert 'foo' in r
+
+
+def test_contains(r):
+    assert not r.exists('foo')
+    r.set('foo', 'bar')
+    assert r.exists('foo')
+
+
+def test_rename(r):
+    r.set('foo', 'unique value')
+    assert r.rename('foo', 'bar')
+    assert r.get('foo') is None
+    assert r.get('bar') == b'unique value'
+
+
+def test_rename_nonexistent_key(r):
+    with pytest.raises(redis.ResponseError):
+        r.rename('foo', 'bar')
+
+
+def test_renamenx_doesnt_exist(r):
+    r.set('foo', 'unique value')
+    assert r.renamenx('foo', 'bar')
+    assert r.get('foo') is None
+    assert r.get('bar') == b'unique value'
+
+
+def test_rename_does_exist(r):
+    r.set('foo', 'unique value')
+    r.set('bar', 'unique value2')
+    assert not r.renamenx('foo', 'bar')
+    assert r.get('foo') == b'unique value'
+    assert r.get('bar') == b'unique value2'
+
+
+def test_rename_expiry(r):
+    r.set('foo', 'value1', ex=10)
+    r.set('bar', 'value2')
+    r.rename('foo', 'bar')
+    assert r.ttl('bar') > 0
+
+
+def test_mget(r):
+    r.set('foo', 'one')
+    r.set('bar', 'two')
+    assert r.mget(['foo', 'bar']) == [b'one', b'two']
+    assert r.mget(['foo', 'bar', 'baz']) == [b'one', b'two', None]
+    assert r.mget('foo', 'bar') == [b'one', b'two']
+
+
+@redis2_only
+def test_mget_none(r):
+    r.set('foo', 'one')
+    r.set('bar', 'two')
+    assert r.mget('foo', 'bar', None) == [b'one', b'two', None]
+
+
+def test_mget_with_no_keys(r):
+    if REDIS3:
+        assert r.mget([]) == []
+    else:
+        with pytest.raises(redis.ResponseError, match='wrong number of arguments'):
+            r.mget([])
+
+
+def test_mget_mixed_types(r):
+    r.hset('hash', 'bar', 'baz')
+    zadd(r, 'zset', {'bar': 1})
+    r.sadd('set', 'member')
+    r.rpush('list', 'item1')
+    r.set('string', 'value')
+    assert (
+        r.mget(['hash', 'zset', 'set', 'string', 'absent'])
+        == [None, None, None, b'value', None]
+    )
+
+
+def test_mset_with_no_keys(r):
+    with pytest.raises(redis.ResponseError):
+        r.mset({})
+
+
+def test_mset(r):
+    assert r.mset({'foo': 'one', 'bar': 'two'}) == True
+    assert r.mset({'foo': 'one', 'bar': 'two'}) == True
+    assert r.mget('foo', 'bar') == [b'one', b'two']
+
+
+@redis2_only
+def test_mset_accepts_kwargs(r):
+    assert r.mset(foo='one', bar='two') == True
+    assert r.mset(foo='one', baz='three') == True
+    assert r.mget('foo', 'bar', 'baz') == [b'one', b'two', b'three']
+
+
+def test_msetnx(r):
+    assert r.msetnx({'foo': 'one', 'bar': 'two'}) == True
+    assert r.msetnx({'bar': 'two', 'baz': 'three'}) == False
+    assert r.mget('foo', 'bar', 'baz') == [b'one', b'two', None]
+
+
+def test_setex(r):
+    assert r.setex('foo', 100, 'bar') == True
+    assert r.get('foo') == b'bar'
+
+
+def test_setex_using_timedelta(r):
+    assert r.setex('foo', timedelta(seconds=100), 'bar') == True
+    assert r.get('foo') == b'bar'
+
+
+def test_setex_using_float(r):
+    with pytest.raises(redis.ResponseError, match='integer'):
+        r.setex('foo', 1.2, 'bar')
+
+
+def test_set_ex(r):
+    assert r.set('foo', 'bar', ex=100) == True
+    assert r.get('foo') == b'bar'
+
+
+def test_set_ex_using_timedelta(r):
+    assert r.set('foo', 'bar', ex=timedelta(seconds=100)) == True
+    assert r.get('foo') == b'bar'
+
+
+def test_set_px(r):
+    assert r.set('foo', 'bar', px=100) == True
+    assert r.get('foo') == b'bar'
+
+
+def test_set_px_using_timedelta(r):
+    assert r.set('foo', 'bar', px=timedelta(milliseconds=100)) == True
+    assert r.get('foo') == b'bar'
+
+
+def test_set_raises_wrong_ex(r):
+    with pytest.raises(ResponseError):
+        r.set('foo', 'bar', ex=-100)
+    with pytest.raises(ResponseError):
+        r.set('foo', 'bar', ex=0)
+    assert not r.exists('foo')
+
+
+def test_set_using_timedelta_raises_wrong_ex(r):
+    with pytest.raises(ResponseError):
+        r.set('foo', 'bar', ex=timedelta(seconds=-100))
+    with pytest.raises(ResponseError):
+        r.set('foo', 'bar', ex=timedelta(seconds=0))
+    assert not r.exists('foo')
+
+
+def test_set_raises_wrong_px(r):
+    with pytest.raises(ResponseError):
+        r.set('foo', 'bar', px=-100)
+    with pytest.raises(ResponseError):
+        r.set('foo', 'bar', px=0)
+    assert not r.exists('foo')
+
+
+def test_set_using_timedelta_raises_wrong_px(r):
+    with pytest.raises(ResponseError):
+        r.set('foo', 'bar', px=timedelta(milliseconds=-100))
+    with pytest.raises(ResponseError):
+        r.set('foo', 'bar', px=timedelta(milliseconds=0))
+    assert not r.exists('foo')
+
+
+def test_setex_raises_wrong_ex(r):
+    with pytest.raises(ResponseError):
+        r.setex('foo', -100, 'bar')
+    with pytest.raises(ResponseError):
+        r.setex('foo', 0, 'bar')
+    assert not r.exists('foo')
+
+
+def test_setex_using_timedelta_raises_wrong_ex(r):
+    with pytest.raises(ResponseError):
+        r.setex('foo', timedelta(seconds=-100), 'bar')
+    with pytest.raises(ResponseError):
+        r.setex('foo', timedelta(seconds=-100), 'bar')
+    assert not r.exists('foo')
+
+
+def test_setnx(r):
+    assert r.setnx('foo', 'bar') == True
+    assert r.get('foo') == b'bar'
+    assert r.setnx('foo', 'baz') == False
+    assert r.get('foo') == b'bar'
+
+
+def test_set_nx(r):
+    assert r.set('foo', 'bar', nx=True) == True
+    assert r.get('foo') == b'bar'
+    assert r.set('foo', 'bar', nx=True) is None
+    assert r.get('foo') == b'bar'
+
+
+def test_set_xx(r):
+    assert r.set('foo', 'bar', xx=True) is None
+    r.set('foo', 'bar')
+    assert r.set('foo', 'bar', xx=True) == True
+
+
+def test_del_operator(r):
+    r['foo'] = 'bar'
+    del r['foo']
+    assert r.get('foo') is None
+
+
+def test_delete(r):
+    r['foo'] = 'bar'
+    assert r.delete('foo') == True
+    assert r.get('foo') is None
+
+
+def test_echo(r):
+    assert r.echo(b'hello') == b'hello'
+    assert r.echo('hello') == b'hello'
+
+
+@pytest.mark.slow
+def test_delete_expire(r):
+    r.set("foo", "bar", ex=1)
+    r.delete("foo")
+    r.set("foo", "bar")
+    sleep(2)
+    assert r.get("foo") == b'bar'
+
+
+def test_delete_multiple(r):
+    r['one'] = 'one'
+    r['two'] = 'two'
+    r['three'] = 'three'
+    # Since redis>=2.7.6 returns number of deleted items.
+    assert r.delete('one', 'two') == 2
+    assert r.get('one') is None
+    assert r.get('two') is None
+    assert r.get('three') == b'three'
+    assert r.delete('one', 'two') == 0
+    # If any keys are deleted, True is returned.
+    assert r.delete('two', 'three', 'three') == 1
+    assert r.get('three') is None
+
+
+def test_delete_nonexistent_key(r):
+    assert r.delete('foo') == False
+
+
+# Tests for the list type.
+
+@redis2_only
+def test_rpush_then_lrange_with_nested_list1(r):
+    assert r.rpush('foo', [12345, 6789]) == 1
+    assert r.rpush('foo', [54321, 9876]) == 2
+    assert r.lrange('foo', 0, -1) == [b'[12345, 6789]', b'[54321, 9876]']
+
+
+@redis2_only
+def test_rpush_then_lrange_with_nested_list2(r):
+    assert r.rpush('foo', [12345, 'banana']) == 1
+    assert r.rpush('foo', [54321, 'elephant']) == 2
+    assert r.lrange('foo', 0, -1), [b'[12345, \'banana\']', b'[54321, \'elephant\']']
+
+
+@redis2_only
+def test_rpush_then_lrange_with_nested_list3(r):
+    assert r.rpush('foo', [12345, []]) == 1
+    assert r.rpush('foo', [54321, []]) == 2
+    assert r.lrange('foo', 0, -1) == [b'[12345, []]', b'[54321, []]']
+
+
+def test_lpush_then_lrange_all(r):
+    assert r.lpush('foo', 'bar') == 1
+    assert r.lpush('foo', 'baz') == 2
+    assert r.lpush('foo', 'bam', 'buzz') == 4
+    assert r.lrange('foo', 0, -1) == [b'buzz', b'bam', b'baz', b'bar']
+
+
+def test_lpush_then_lrange_portion(r):
+    r.lpush('foo', 'one')
+    r.lpush('foo', 'two')
+    r.lpush('foo', 'three')
+    r.lpush('foo', 'four')
+    assert r.lrange('foo', 0, 2) == [b'four', b'three', b'two']
+    assert r.lrange('foo', 0, 3) == [b'four', b'three', b'two', b'one']
+
+
+def test_lrange_negative_indices(r):
+    r.rpush('foo', 'a', 'b', 'c')
+    assert r.lrange('foo', -1, -2) == []
+    assert r.lrange('foo', -2, -1) == [b'b', b'c']
+
+
+def test_lpush_key_does_not_exist(r):
+    assert r.lrange('foo', 0, -1) == []
+
+
+def test_lpush_with_nonstr_key(r):
+    r.lpush(1, 'one')
+    r.lpush(1, 'two')
+    r.lpush(1, 'three')
+    assert r.lrange(1, 0, 2) == [b'three', b'two', b'one']
+    assert r.lrange('1', 0, 2) == [b'three', b'two', b'one']
+
+
+def test_lpush_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.lpush('foo', 'element')
+
+
+def test_llen(r):
+    r.lpush('foo', 'one')
+    r.lpush('foo', 'two')
+    r.lpush('foo', 'three')
+    assert r.llen('foo') == 3
+
+
+def test_llen_no_exist(r):
+    assert r.llen('foo') == 0
+
+
+def test_llen_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.llen('foo')
+
+
+def test_lrem_positive_count(r):
+    r.lpush('foo', 'same')
+    r.lpush('foo', 'same')
+    r.lpush('foo', 'different')
+    r.lrem('foo', 2, 'same')
+    assert r.lrange('foo', 0, -1) == [b'different']
+
+
+def test_lrem_negative_count(r):
+    r.lpush('foo', 'removeme')
+    r.lpush('foo', 'three')
+    r.lpush('foo', 'two')
+    r.lpush('foo', 'one')
+    r.lpush('foo', 'removeme')
+    r.lrem('foo', -1, 'removeme')
+    # Should remove it from the end of the list,
+    # leaving the 'removeme' from the front of the list alone.
+    assert r.lrange('foo', 0, -1) == [b'removeme', b'one', b'two', b'three']
+
+
+def test_lrem_zero_count(r):
+    r.lpush('foo', 'one')
+    r.lpush('foo', 'one')
+    r.lpush('foo', 'one')
+    r.lrem('foo', 0, 'one')
+    assert r.lrange('foo', 0, -1) == []
+
+
+def test_lrem_default_value(r):
+    r.lpush('foo', 'one')
+    r.lpush('foo', 'one')
+    r.lpush('foo', 'one')
+    r.lrem('foo', 0, 'one')
+    assert r.lrange('foo', 0, -1) == []
+
+
+def test_lrem_does_not_exist(r):
+    r.lpush('foo', 'one')
+    r.lrem('foo', 0, 'one')
+    # These should be noops.
+    r.lrem('foo', -2, 'one')
+    r.lrem('foo', 2, 'one')
+
+
+def test_lrem_return_value(r):
+    r.lpush('foo', 'one')
+    count = r.lrem('foo', 0, 'one')
+    assert count == 1
+    assert r.lrem('foo', 0, 'one') == 0
+
+
+def test_lrem_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.lrem('foo', 0, 'element')
+
+
+def test_rpush(r):
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    r.rpush('foo', 'three')
+    r.rpush('foo', 'four', 'five')
+    assert r.lrange('foo', 0, -1) == [b'one', b'two', b'three', b'four', b'five']
+
+
+def test_rpush_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.rpush('foo', 'element')
+
+
+def test_lpop(r):
+    assert r.rpush('foo', 'one') == 1
+    assert r.rpush('foo', 'two') == 2
+    assert r.rpush('foo', 'three') == 3
+    assert r.lpop('foo') == b'one'
+    assert r.lpop('foo') == b'two'
+    assert r.lpop('foo') == b'three'
+
+
+def test_lpop_empty_list(r):
+    r.rpush('foo', 'one')
+    r.lpop('foo')
+    assert r.lpop('foo') is None
+    # Verify what happens if we try to pop from a key
+    # we've never seen before.
+    assert r.lpop('noexists') is None
+
+
+def test_lpop_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.lpop('foo')
+
+
+def test_lset(r):
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    r.rpush('foo', 'three')
+    r.lset('foo', 0, 'four')
+    r.lset('foo', -2, 'five')
+    assert r.lrange('foo', 0, -1) == [b'four', b'five', b'three']
+
+
+def test_lset_index_out_of_range(r):
+    r.rpush('foo', 'one')
+    with pytest.raises(redis.ResponseError):
+        r.lset('foo', 3, 'three')
+
+
+def test_lset_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.lset('foo', 0, 'element')
+
+
+def test_rpushx(r):
+    r.rpush('foo', 'one')
+    r.rpushx('foo', 'two')
+    r.rpushx('bar', 'three')
+    assert r.lrange('foo', 0, -1) == [b'one', b'two']
+    assert r.lrange('bar', 0, -1) == []
+
+
+def test_rpushx_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.rpushx('foo', 'element')
+
+
+def test_ltrim(r):
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    r.rpush('foo', 'three')
+    r.rpush('foo', 'four')
+
+    assert r.ltrim('foo', 1, 3)
+    assert r.lrange('foo', 0, -1) == [b'two', b'three', b'four']
+    assert r.ltrim('foo', 1, -1)
+    assert r.lrange('foo', 0, -1) == [b'three', b'four']
+
+
+def test_ltrim_with_non_existent_key(r):
+    assert r.ltrim('foo', 0, -1)
+
+
+def test_ltrim_expiry(r):
+    r.rpush('foo', 'one', 'two', 'three')
+    r.expire('foo', 10)
+    r.ltrim('foo', 1, 2)
+    assert r.ttl('foo') > 0
+
+
+def test_ltrim_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.ltrim('foo', 1, -1)
+
+
+def test_lindex(r):
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    assert r.lindex('foo', 0) == b'one'
+    assert r.lindex('foo', 4) is None
+    assert r.lindex('bar', 4) is None
+
+
+def test_lindex_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.lindex('foo', 0)
+
+
+def test_lpushx(r):
+    r.lpush('foo', 'two')
+    r.lpushx('foo', 'one')
+    r.lpushx('bar', 'one')
+    assert r.lrange('foo', 0, -1) == [b'one', b'two']
+    assert r.lrange('bar', 0, -1) == []
+
+
+def test_lpushx_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.lpushx('foo', 'element')
+
+
+def test_rpop(r):
+    assert r.rpop('foo') is None
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    assert r.rpop('foo') == b'two'
+    assert r.rpop('foo') == b'one'
+    assert r.rpop('foo') is None
+
+
+def test_rpop_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.rpop('foo')
+
+
+def test_linsert_before(r):
+    r.rpush('foo', 'hello')
+    r.rpush('foo', 'world')
+    assert r.linsert('foo', 'before', 'world', 'there') == 3
+    assert r.lrange('foo', 0, -1) == [b'hello', b'there', b'world']
+
+
+def test_linsert_after(r):
+    r.rpush('foo', 'hello')
+    r.rpush('foo', 'world')
+    assert r.linsert('foo', 'after', 'hello', 'there') == 3
+    assert r.lrange('foo', 0, -1) == [b'hello', b'there', b'world']
+
+
+def test_linsert_no_pivot(r):
+    r.rpush('foo', 'hello')
+    r.rpush('foo', 'world')
+    assert r.linsert('foo', 'after', 'goodbye', 'bar') == -1
+    assert r.lrange('foo', 0, -1) == [b'hello', b'world']
+
+
+def test_linsert_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.linsert('foo', 'after', 'bar', 'element')
+
+
+def test_rpoplpush(r):
+    assert r.rpoplpush('foo', 'bar') is None
+    assert r.lpop('bar') is None
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    r.rpush('bar', 'one')
+
+    assert r.rpoplpush('foo', 'bar') == b'two'
+    assert r.lrange('foo', 0, -1) == [b'one']
+    assert r.lrange('bar', 0, -1) == [b'two', b'one']
+
+    # Catch instances where we store bytes and strings inconsistently
+    # and thus bar = ['two', b'one']
+    assert r.lrem('bar', -1, 'two') == 1
+
+
+def test_rpoplpush_to_nonexistent_destination(r):
+    r.rpush('foo', 'one')
+    assert r.rpoplpush('foo', 'bar') == b'one'
+    assert r.rpop('bar') == b'one'
+
+
+def test_rpoplpush_expiry(r):
+    r.rpush('foo', 'one')
+    r.rpush('bar', 'two')
+    r.expire('bar', 10)
+    r.rpoplpush('foo', 'bar')
+    assert r.ttl('bar') > 0
+
+
+def test_rpoplpush_one_to_self(r):
+    r.rpush('list', 'element')
+    assert r.brpoplpush('list', 'list') == b'element'
+    assert r.lrange('list', 0, -1) == [b'element']
+
+
+def test_rpoplpush_wrong_type(r):
+    r.set('foo', 'bar')
+    r.rpush('list', 'element')
+    with pytest.raises(redis.ResponseError):
+        r.rpoplpush('foo', 'list')
+    assert r.get('foo') == b'bar'
+    assert r.lrange('list', 0, -1) == [b'element']
+    with pytest.raises(redis.ResponseError):
+        r.rpoplpush('list', 'foo')
+    assert r.get('foo') == b'bar'
+    assert r.lrange('list', 0, -1) == [b'element']
+
+
+def test_blpop_single_list(r):
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    r.rpush('foo', 'three')
+    assert r.blpop(['foo'], timeout=1) == (b'foo', b'one')
+
+
+def test_blpop_test_multiple_lists(r):
+    r.rpush('baz', 'zero')
+    assert r.blpop(['foo', 'baz'], timeout=1) == (b'baz', b'zero')
+    assert not r.exists('baz')
+
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    # bar has nothing, so the returned value should come
+    # from foo.
+    assert r.blpop(['bar', 'foo'], timeout=1) == (b'foo', b'one')
+    r.rpush('bar', 'three')
+    # bar now has something, so the returned value should come
+    # from bar.
+    assert r.blpop(['bar', 'foo'], timeout=1) == (b'bar', b'three')
+    assert r.blpop(['bar', 'foo'], timeout=1) == (b'foo', b'two')
+
+
+def test_blpop_allow_single_key(r):
+    # blpop converts single key arguments to a one element list.
+    r.rpush('foo', 'one')
+    assert r.blpop('foo', timeout=1) == (b'foo', b'one')
+
+
+@pytest.mark.slow
+def test_blpop_block(r):
+    def push_thread():
+        sleep(0.5)
+        r.rpush('foo', 'value1')
+        sleep(0.5)
+        # Will wake the condition variable
+        r.set('bar', 'go back to sleep some more')
+        r.rpush('foo', 'value2')
+
+    thread = threading.Thread(target=push_thread)
+    thread.start()
+    try:
+        assert r.blpop('foo') == (b'foo', b'value1')
+        assert r.blpop('foo', timeout=5) == (b'foo', b'value2')
+    finally:
+        thread.join()
+
+
+def test_blpop_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.blpop('foo', timeout=1)
+
+
+def test_blpop_transaction(r):
+    p = r.pipeline()
+    p.multi()
+    p.blpop('missing', timeout=1000)
+    result = p.execute()
+    # Blocking commands behave like non-blocking versions in transactions
+    assert result == [None]
+
+
+def test_eval_blpop(r):
+    r.rpush('foo', 'bar')
+    with pytest.raises(redis.ResponseError, match='not allowed from scripts'):
+        r.eval('return redis.pcall("BLPOP", KEYS[1], 1)', 1, 'foo')
+
+
+def test_brpop_test_multiple_lists(r):
+    r.rpush('baz', 'zero')
+    assert r.brpop(['foo', 'baz'], timeout=1) == (b'baz', b'zero')
+    assert not r.exists('baz')
+
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    assert r.brpop(['bar', 'foo'], timeout=1) == (b'foo', b'two')
+
+
+def test_brpop_single_key(r):
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    assert r.brpop('foo', timeout=1) == (b'foo', b'two')
+
+
+@pytest.mark.slow
+def test_brpop_block(r):
+    def push_thread():
+        sleep(0.5)
+        r.rpush('foo', 'value1')
+        sleep(0.5)
+        # Will wake the condition variable
+        r.set('bar', 'go back to sleep some more')
+        r.rpush('foo', 'value2')
+
+    thread = threading.Thread(target=push_thread)
+    thread.start()
+    try:
+        assert r.brpop('foo') == (b'foo', b'value1')
+        assert r.brpop('foo', timeout=5) == (b'foo', b'value2')
+    finally:
+        thread.join()
+
+
+def test_brpop_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.brpop('foo', timeout=1)
+
+
+def test_brpoplpush_multi_keys(r):
+    assert r.lpop('bar') is None
+    r.rpush('foo', 'one')
+    r.rpush('foo', 'two')
+    assert r.brpoplpush('foo', 'bar', timeout=1) == b'two'
+    assert r.lrange('bar', 0, -1) == [b'two']
+
+    # Catch instances where we store bytes and strings inconsistently
+    # and thus bar = ['two']
+    assert r.lrem('bar', -1, 'two') == 1
+
+
+def test_brpoplpush_wrong_type(r):
+    r.set('foo', 'bar')
+    r.rpush('list', 'element')
+    with pytest.raises(redis.ResponseError):
+        r.brpoplpush('foo', 'list')
+    assert r.get('foo') == b'bar'
+    assert r.lrange('list', 0, -1) == [b'element']
+    with pytest.raises(redis.ResponseError):
+        r.brpoplpush('list', 'foo')
+    assert r.get('foo') == b'bar'
+    assert r.lrange('list', 0, -1) == [b'element']
+
+
+@pytest.mark.slow
+def test_blocking_operations_when_empty(r):
+    assert r.blpop(['foo'], timeout=1) is None
+    assert r.blpop(['bar', 'foo'], timeout=1) is None
+    assert r.brpop('foo', timeout=1) is None
+    assert r.brpoplpush('foo', 'bar', timeout=1) is None
+
+
+def test_empty_list(r):
+    r.rpush('foo', 'bar')
+    r.rpop('foo')
+    assert not r.exists('foo')
+
+
+# Tests for the hash type.
+
+def test_hstrlen_missing(r):
+    assert r.hstrlen('foo', 'doesnotexist') == 0
+
+    r.hset('foo', 'key', 'value')
+    assert r.hstrlen('foo', 'doesnotexist') == 0
+
+
+def test_hstrlen(r):
+    r.hset('foo', 'key', 'value')
+    assert r.hstrlen('foo', 'key') == 5
+
+
+def test_hset_then_hget(r):
+    assert r.hset('foo', 'key', 'value') == 1
+    assert r.hget('foo', 'key') == b'value'
+
+
+def test_hset_update(r):
+    assert r.hset('foo', 'key', 'value') == 1
+    assert r.hset('foo', 'key', 'value') == 0
+
+
+def test_hset_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hset('foo', 'key', 'value')
+
+
+def test_hgetall(r):
+    assert r.hset('foo', 'k1', 'v1') == 1
+    assert r.hset('foo', 'k2', 'v2') == 1
+    assert r.hset('foo', 'k3', 'v3') == 1
+    assert r.hgetall('foo') == {
+        b'k1': b'v1',
+        b'k2': b'v2',
+        b'k3': b'v3'
+    }
+
+
+@redis2_only
+def test_hgetall_with_tuples(r):
+    assert r.hset('foo', (1, 2), (1, 2, 3)) == 1
+    assert r.hgetall('foo') == {b'(1, 2)': b'(1, 2, 3)'}
+
+
+def test_hgetall_empty_key(r):
+    assert r.hgetall('foo') == {}
+
+
+def test_hgetall_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hgetall('foo')
+
+
+def test_hexists(r):
+    r.hset('foo', 'bar', 'v1')
+    assert r.hexists('foo', 'bar') == 1
+    assert r.hexists('foo', 'baz') == 0
+    assert r.hexists('bar', 'bar') == 0
+
+
+def test_hexists_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hexists('foo', 'key')
+
+
+def test_hkeys(r):
+    r.hset('foo', 'k1', 'v1')
+    r.hset('foo', 'k2', 'v2')
+    assert set(r.hkeys('foo')) == {b'k1', b'k2'}
+    assert set(r.hkeys('bar')) == set()
+
+
+def test_hkeys_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hkeys('foo')
+
+
+def test_hlen(r):
+    r.hset('foo', 'k1', 'v1')
+    r.hset('foo', 'k2', 'v2')
+    assert r.hlen('foo') == 2
+
+
+def test_hlen_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hlen('foo')
+
+
+def test_hvals(r):
+    r.hset('foo', 'k1', 'v1')
+    r.hset('foo', 'k2', 'v2')
+    assert set(r.hvals('foo')) == {b'v1', b'v2'}
+    assert set(r.hvals('bar')) == set()
+
+
+def test_hvals_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hvals('foo')
+
+
+def test_hmget(r):
+    r.hset('foo', 'k1', 'v1')
+    r.hset('foo', 'k2', 'v2')
+    r.hset('foo', 'k3', 'v3')
+    # Normal case.
+    assert r.hmget('foo', ['k1', 'k3']) == [b'v1', b'v3']
+    assert r.hmget('foo', 'k1', 'k3') == [b'v1', b'v3']
+    # Key does not exist.
+    assert r.hmget('bar', ['k1', 'k3']) == [None, None]
+    assert r.hmget('bar', 'k1', 'k3') == [None, None]
+    # Some keys in the hash do not exist.
+    assert r.hmget('foo', ['k1', 'k500']) == [b'v1', None]
+    assert r.hmget('foo', 'k1', 'k500') == [b'v1', None]
+
+
+def test_hmget_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hmget('foo', 'key1', 'key2')
+
+
+def test_hdel(r):
+    r.hset('foo', 'k1', 'v1')
+    r.hset('foo', 'k2', 'v2')
+    r.hset('foo', 'k3', 'v3')
+    assert r.hget('foo', 'k1') == b'v1'
+    assert r.hdel('foo', 'k1') == True
+    assert r.hget('foo', 'k1') is None
+    assert r.hdel('foo', 'k1') == False
+    # Since redis>=2.7.6 returns number of deleted items.
+    assert r.hdel('foo', 'k2', 'k3') == 2
+    assert r.hget('foo', 'k2') is None
+    assert r.hget('foo', 'k3') is None
+    assert r.hdel('foo', 'k2', 'k3') == False
+
+
+def test_hdel_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hdel('foo', 'key')
+
+
+def test_hincrby(r):
+    r.hset('foo', 'counter', 0)
+    assert r.hincrby('foo', 'counter') == 1
+    assert r.hincrby('foo', 'counter') == 2
+    assert r.hincrby('foo', 'counter') == 3
+
+
+def test_hincrby_with_no_starting_value(r):
+    assert r.hincrby('foo', 'counter') == 1
+    assert r.hincrby('foo', 'counter') == 2
+    assert r.hincrby('foo', 'counter') == 3
+
+
+def test_hincrby_with_range_param(r):
+    assert r.hincrby('foo', 'counter', 2) == 2
+    assert r.hincrby('foo', 'counter', 2) == 4
+    assert r.hincrby('foo', 'counter', 2) == 6
+
+
+def test_hincrby_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hincrby('foo', 'key', 2)
+
+
+def test_hincrbyfloat(r):
+    r.hset('foo', 'counter', 0.0)
+    assert r.hincrbyfloat('foo', 'counter') == 1.0
+    assert r.hincrbyfloat('foo', 'counter') == 2.0
+    assert r.hincrbyfloat('foo', 'counter') == 3.0
+
+
+def test_hincrbyfloat_with_no_starting_value(r):
+    assert r.hincrbyfloat('foo', 'counter') == 1.0
+    assert r.hincrbyfloat('foo', 'counter') == 2.0
+    assert r.hincrbyfloat('foo', 'counter') == 3.0
+
+
+def test_hincrbyfloat_with_range_param(r):
+    assert r.hincrbyfloat('foo', 'counter', 0.1) == pytest.approx(0.1)
+    assert r.hincrbyfloat('foo', 'counter', 0.1) == pytest.approx(0.2)
+    assert r.hincrbyfloat('foo', 'counter', 0.1) == pytest.approx(0.3)
+
+
+def test_hincrbyfloat_on_non_float_value_raises_error(r):
+    r.hset('foo', 'counter', 'cat')
+    with pytest.raises(redis.ResponseError):
+        r.hincrbyfloat('foo', 'counter')
+
+
+def test_hincrbyfloat_with_non_float_amount_raises_error(r):
+    with pytest.raises(redis.ResponseError):
+        r.hincrbyfloat('foo', 'counter', 'cat')
+
+
+def test_hincrbyfloat_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hincrbyfloat('foo', 'key', 0.1)
+
+
+def test_hincrbyfloat_precision(r):
+    x = 1.23456789123456789
+    assert r.hincrbyfloat('foo', 'bar', x) == x
+    assert float(r.hget('foo', 'bar')) == x
+
+
+def test_hsetnx(r):
+    assert r.hsetnx('foo', 'newkey', 'v1') == True
+    assert r.hsetnx('foo', 'newkey', 'v1') == False
+    assert r.hget('foo', 'newkey') == b'v1'
+
+
+def test_hmsetset_empty_raises_error(r):
+    with pytest.raises(redis.DataError):
+        r.hmset('foo', {})
+
+
+def test_hmsetset(r):
+    r.hset('foo', 'k1', 'v1')
+    assert r.hmset('foo', {'k2': 'v2', 'k3': 'v3'}) == True
+
+
+@redis2_only
+def test_hmset_convert_values(r):
+    r.hmset('foo', {'k1': True, 'k2': 1})
+    assert r.hgetall('foo') == {b'k1': b'True', b'k2': b'1'}
+
+
+@redis2_only
+def test_hmset_does_not_mutate_input_params(r):
+    original = {'key': [123, 456]}
+    r.hmset('foo', original)
+    assert original == {'key': [123, 456]}
+
+
+def test_hmset_wrong_type(r):
+    zadd(r, 'foo', {'bar': 1})
+    with pytest.raises(redis.ResponseError):
+        r.hmset('foo', {'key': 'value'})
+
+
+def test_empty_hash(r):
+    r.hset('foo', 'bar', 'baz')
+    r.hdel('foo', 'bar')
+    assert not r.exists('foo')
+
+
+def test_sadd(r):
+    assert r.sadd('foo', 'member1') == 1
+    assert r.sadd('foo', 'member1') == 0
+    assert r.smembers('foo') == {b'member1'}
+    assert r.sadd('foo', 'member2', 'member3') == 2
+    assert r.smembers('foo') == {b'member1', b'member2', b'member3'}
+    assert r.sadd('foo', 'member3', 'member4') == 1
+    assert r.smembers('foo') == {b'member1', b'member2', b'member3', b'member4'}
+
+
+def test_sadd_as_str_type(r):
+    assert r.sadd('foo', *range(3)) == 3
+    assert r.smembers('foo') == {b'0', b'1', b'2'}
+
+
+def test_sadd_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    with pytest.raises(redis.ResponseError):
+        r.sadd('foo', 'member2')
+
+
+def test_scan_single(r):
+    r.set('foo1', 'bar1')
+    assert r.scan(match="foo*") == (0, [b'foo1'])
+
+
+def test_scan_iter_single_page(r):
+    r.set('foo1', 'bar1')
+    r.set('foo2', 'bar2')
+    assert set(r.scan_iter(match="foo*")) == {b'foo1', b'foo2'}
+    assert set(r.scan_iter()) == {b'foo1', b'foo2'}
+    assert set(r.scan_iter(match="")) == set()
+
+
+def test_scan_iter_multiple_pages(r):
+    all_keys = key_val_dict(size=100)
+    assert all(r.set(k, v) for k, v in all_keys.items())
+    assert set(r.scan_iter()) == set(all_keys)
+
+
+def test_scan_iter_multiple_pages_with_match(r):
+    all_keys = key_val_dict(size=100)
+    assert all(r.set(k, v) for k, v in all_keys.items())
+    # Now add a few keys that don't match the key:<number> pattern.
+    r.set('otherkey', 'foo')
+    r.set('andanother', 'bar')
+    actual = set(r.scan_iter(match='key:*'))
+    assert actual == set(all_keys)
+
+
+def test_scan_multiple_pages_with_count_arg(r):
+    all_keys = key_val_dict(size=100)
+    assert all(r.set(k, v) for k, v in all_keys.items())
+    assert set(r.scan_iter(count=1000)) == set(all_keys)
+
+
+def test_scan_all_in_single_call(r):
+    all_keys = key_val_dict(size=100)
+    assert all(r.set(k, v) for k, v in all_keys.items())
+    # Specify way more than the 100 keys we've added.
+    actual = r.scan(count=1000)
+    assert set(actual[1]) == set(all_keys)
+    assert actual[0] == 0
+
+
+@pytest.mark.slow
+def test_scan_expired_key(r):
+    r.set('expiringkey', 'value')
+    r.pexpire('expiringkey', 1)
+    sleep(1)
+    assert r.scan()[1] == []
+
+
+def test_scard(r):
+    r.sadd('foo', 'member1')
+    r.sadd('foo', 'member2')
+    r.sadd('foo', 'member2')
+    assert r.scard('foo') == 2
+
+
+def test_scard_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    with pytest.raises(redis.ResponseError):
+        r.scard('foo')
+
+
+def test_sdiff(r):
+    r.sadd('foo', 'member1')
+    r.sadd('foo', 'member2')
+    r.sadd('bar', 'member2')
+    r.sadd('bar', 'member3')
+    assert r.sdiff('foo', 'bar') == {b'member1'}
+    # Original sets shouldn't be modified.
+    assert r.smembers('foo') == {b'member1', b'member2'}
+    assert r.smembers('bar') == {b'member2', b'member3'}
+
+
+def test_sdiff_one_key(r):
+    r.sadd('foo', 'member1')
+    r.sadd('foo', 'member2')
+    assert r.sdiff('foo') == {b'member1', b'member2'}
+
+
+def test_sdiff_empty(r):
+    assert r.sdiff('foo') == set()
+
+
+def test_sdiff_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    r.sadd('bar', 'member')
+    with pytest.raises(redis.ResponseError):
+        r.sdiff('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.sdiff('bar', 'foo')
+
+
+def test_sdiffstore(r):
+    r.sadd('foo', 'member1')
+    r.sadd('foo', 'member2')
+    r.sadd('bar', 'member2')
+    r.sadd('bar', 'member3')
+    assert r.sdiffstore('baz', 'foo', 'bar') == 1
+
+    # Catch instances where we store bytes and strings inconsistently
+    # and thus baz = {'member1', b'member1'}
+    r.sadd('baz', 'member1')
+    assert r.scard('baz') == 1
+
+
+def test_setrange(r):
+    r.set('foo', 'test')
+    assert r.setrange('foo', 1, 'aste') == 5
+    assert r.get('foo') == b'taste'
+
+    r.set('foo', 'test')
+    assert r.setrange('foo', 1, 'a') == 4
+    assert r.get('foo') == b'tast'
+
+    assert r.setrange('bar', 2, 'test') == 6
+    assert r.get('bar') == b'\x00\x00test'
+
+
+def test_setrange_expiry(r):
+    r.set('foo', 'test', ex=10)
+    r.setrange('foo', 1, 'aste')
+    assert r.ttl('foo') > 0
+
+
+def test_sinter(r):
+    r.sadd('foo', 'member1')
+    r.sadd('foo', 'member2')
+    r.sadd('bar', 'member2')
+    r.sadd('bar', 'member3')
+    assert r.sinter('foo', 'bar') == {b'member2'}
+    assert r.sinter('foo') == {b'member1', b'member2'}
+
+
+def test_sinter_bytes_keys(r):
+    foo = os.urandom(10)
+    bar = os.urandom(10)
+    r.sadd(foo, 'member1')
+    r.sadd(foo, 'member2')
+    r.sadd(bar, 'member2')
+    r.sadd(bar, 'member3')
+    assert r.sinter(foo, bar) == {b'member2'}
+    assert r.sinter(foo) == {b'member1', b'member2'}
+
+
+def test_sinter_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    r.sadd('bar', 'member')
+    with pytest.raises(redis.ResponseError):
+        r.sinter('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.sinter('bar', 'foo')
+
+
+def test_sinterstore(r):
+    r.sadd('foo', 'member1')
+    r.sadd('foo', 'member2')
+    r.sadd('bar', 'member2')
+    r.sadd('bar', 'member3')
+    assert r.sinterstore('baz', 'foo', 'bar') == 1
+
+    # Catch instances where we store bytes and strings inconsistently
+    # and thus baz = {'member2', b'member2'}
+    r.sadd('baz', 'member2')
+    assert r.scard('baz') == 1
+
+
+def test_sismember(r):
+    assert r.sismember('foo', 'member1') == False
+    r.sadd('foo', 'member1')
+    assert r.sismember('foo', 'member1') == True
+
+
+def test_sismember_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    with pytest.raises(redis.ResponseError):
+        r.sismember('foo', 'member')
+
+
+def test_smembers(r):
+    assert r.smembers('foo') == set()
+
+
+def test_smembers_copy(r):
+    r.sadd('foo', 'member1')
+    set = r.smembers('foo')
+    r.sadd('foo', 'member2')
+    assert r.smembers('foo') != set
+
+
+def test_smembers_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    with pytest.raises(redis.ResponseError):
+        r.smembers('foo')
+
+
+def test_smembers_runtime_error(r):
+    r.sadd('foo', 'member1', 'member2')
+    for member in r.smembers('foo'):
+        r.srem('foo', member)
+
+
+def test_smove(r):
+    r.sadd('foo', 'member1')
+    r.sadd('foo', 'member2')
+    assert r.smove('foo', 'bar', 'member1') == True
+    assert r.smembers('bar') == {b'member1'}
+
+
+def test_smove_non_existent_key(r):
+    assert r.smove('foo', 'bar', 'member1') == False
+
+
+def test_smove_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    r.sadd('bar', 'member')
+    with pytest.raises(redis.ResponseError):
+        r.smove('bar', 'foo', 'member')
+    # Must raise the error before removing member from bar
+    assert r.smembers('bar') == {b'member'}
+    with pytest.raises(redis.ResponseError):
+        r.smove('foo', 'bar', 'member')
+
+
+def test_spop(r):
+    # This is tricky because it pops a random element.
+    r.sadd('foo', 'member1')
+    assert r.spop('foo') == b'member1'
+    assert r.spop('foo') is None
+
+
+def test_spop_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    with pytest.raises(redis.ResponseError):
+        r.spop('foo')
+
+
+def test_srandmember(r):
+    r.sadd('foo', 'member1')
+    assert r.srandmember('foo') == b'member1'
+    # Shouldn't be removed from the set.
+    assert r.srandmember('foo') == b'member1'
+
+
+def test_srandmember_number(r):
+    """srandmember works with the number argument."""
+    assert r.srandmember('foo', 2) == []
+    r.sadd('foo', b'member1')
+    assert r.srandmember('foo', 2) == [b'member1']
+    r.sadd('foo', b'member2')
+    assert set(r.srandmember('foo', 2)) == {b'member1', b'member2'}
+    r.sadd('foo', b'member3')
+    res = r.srandmember('foo', 2)
+    assert len(res) == 2
+    for e in res:
+        assert e in {b'member1', b'member2', b'member3'}
+
+
+def test_srandmember_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    with pytest.raises(redis.ResponseError):
+        r.srandmember('foo')
+
+
+def test_srem(r):
+    r.sadd('foo', 'member1', 'member2', 'member3', 'member4')
+    assert r.smembers('foo') == {b'member1', b'member2', b'member3', b'member4'}
+    assert r.srem('foo', 'member1') == True
+    assert r.smembers('foo') == {b'member2', b'member3', b'member4'}
+    assert r.srem('foo', 'member1') == False
+    # Since redis>=2.7.6 returns number of deleted items.
+    assert r.srem('foo', 'member2', 'member3') == 2
+    assert r.smembers('foo') == {b'member4'}
+    assert r.srem('foo', 'member3', 'member4') == True
+    assert r.smembers('foo') == set()
+    assert r.srem('foo', 'member3', 'member4') == False
+
+
+def test_srem_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    with pytest.raises(redis.ResponseError):
+        r.srem('foo', 'member')
+
+
+def test_sunion(r):
+    r.sadd('foo', 'member1')
+    r.sadd('foo', 'member2')
+    r.sadd('bar', 'member2')
+    r.sadd('bar', 'member3')
+    assert r.sunion('foo', 'bar') == {b'member1', b'member2', b'member3'}
+
+
+def test_sunion_wrong_type(r):
+    zadd(r, 'foo', {'member': 1})
+    r.sadd('bar', 'member')
+    with pytest.raises(redis.ResponseError):
+        r.sunion('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.sunion('bar', 'foo')
+
+
+def test_sunionstore(r):
+    r.sadd('foo', 'member1')
+    r.sadd('foo', 'member2')
+    r.sadd('bar', 'member2')
+    r.sadd('bar', 'member3')
+    assert r.sunionstore('baz', 'foo', 'bar') == 3
+    assert r.smembers('baz') == {b'member1', b'member2', b'member3'}
+
+    # Catch instances where we store bytes and strings inconsistently
+    # and thus baz = {b'member1', b'member2', b'member3', 'member3'}
+    r.sadd('baz', 'member3')
+    assert r.scard('baz') == 3
+
+
+def test_empty_set(r):
+    r.sadd('foo', 'bar')
+    r.srem('foo', 'bar')
+    assert not r.exists('foo')
+
+
+def test_zadd(r):
+    zadd(r, 'foo', {'four': 4})
+    zadd(r, 'foo', {'three': 3})
+    assert zadd(r, 'foo', {'two': 2, 'one': 1, 'zero': 0}) == 3
+    assert r.zrange('foo', 0, -1) == [b'zero', b'one', b'two', b'three', b'four']
+    assert zadd(r, 'foo', {'zero': 7, 'one': 1, 'five': 5}) == 1
+    assert (
+        r.zrange('foo', 0, -1)
+        == [b'one', b'two', b'three', b'four', b'five', b'zero']
+    )
+
+
+@redis2_only
+def test_zadd_uses_str(r):
+    r.zadd('foo', 12345, (1, 2, 3))
+    assert r.zrange('foo', 0, 0) == [b'(1, 2, 3)']
+
+
+@redis2_only
+def test_zadd_errors(r):
+    # The args are backwards, it should be 2, "two", so we
+    # expect an exception to be raised.
+    with pytest.raises(redis.ResponseError):
+        r.zadd('foo', 'two', 2)
+    with pytest.raises(redis.ResponseError):
+        r.zadd('foo', two='two')
+    # It's expected an equal number of values and scores
+    with pytest.raises(redis.RedisError):
+        r.zadd('foo', 'two')
+
+
+def test_zadd_empty(r):
+    # Have to add at least one key/value pair
+    with pytest.raises(redis.RedisError):
+        zadd(r, 'foo', {})
+
+
+def test_zadd_minus_zero(r):
+    # Changing -0 to +0 is ignored
+    zadd(r, 'foo', {'a': -0.0})
+    zadd(r, 'foo', {'a': 0.0})
+    assert raw_command(r, 'zscore', 'foo', 'a') == b'-0'
+
+
+def test_zadd_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        zadd(r, 'foo', {'two': 2})
+
+
+def test_zadd_multiple(r):
+    zadd(r, 'foo', {'one': 1, 'two': 2})
+    assert r.zrange('foo', 0, 0) == [b'one']
+    assert r.zrange('foo', 1, 1) == [b'two']
+
+
+@redis3_only
+def test_zadd_with_nx(r):
+    zadd(r, 'foo', {'four': 4.0, 'three': 3.0})
+
+    updates = [
+        UpdateCommand(
+            input={'four': 2.0, 'three': 1.0},
+            expected_return_value=0,
+            expected_state=[(b'four', 4.0), (b'three', 3.0)]),
+        UpdateCommand(
+            input={'four': 2.0, 'three': 1.0, 'zero': 0.0},
+            expected_return_value=1,
+            expected_state=[(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]),
+        UpdateCommand(
+            input={'two': 2.0, 'one': 1.0},
+            expected_return_value=2,
+            expected_state=[(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]),
+    ]
+
+    for update in updates:
+        assert zadd(r, 'foo', update.input, nx=True) == update.expected_return_value
+        assert (
+            sorted(r.zrange('foo', 0, -1, withscores=True))
+            == sorted(update.expected_state)
+        )
+
+
+@redis3_only
+def test_zadd_with_ch(r):
+    zadd(r, 'foo', {'four': 4.0, 'three': 3.0})
+
+    updates = [
+        UpdateCommand(
+            input={'four': 4.0, 'three': 1.0},
+            expected_return_value=1,
+            expected_state=[(b'four', 4.0), (b'three', 1.0)]),
+        UpdateCommand(
+            input={'four': 4.0, 'three': 3.0, 'zero': 0.0},
+            expected_return_value=2,
+            expected_state=[(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]),
+        UpdateCommand(
+            input={'two': 2.0, 'one': 1.0},
+            expected_return_value=2,
+            expected_state=[(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]),
+    ]
+
+    for update in updates:
+        assert zadd(r, 'foo', update.input, ch=True) == update.expected_return_value
+        assert (
+            sorted(r.zrange('foo', 0, -1, withscores=True))
+            == sorted(update.expected_state)
+        )
+
+
+@redis3_only
+def test_zadd_with_xx(r):
+    zadd(r, 'foo', {'four': 4.0, 'three': 3.0})
+
+    updates = [
+        UpdateCommand(
+            input={'four': 2.0, 'three': 1.0},
+            expected_return_value=0,
+            expected_state=[(b'four', 2.0), (b'three', 1.0)]),
+        UpdateCommand(
+            input={'four': 4.0, 'three': 3.0, 'zero': 0.0},
+            expected_return_value=0,
+            expected_state=[(b'four', 4.0), (b'three', 3.0)]),
+        UpdateCommand(
+            input={'two': 2.0, 'one': 1.0},
+            expected_return_value=0,
+            expected_state=[(b'four', 4.0), (b'three', 3.0)]),
+    ]
+
+    for update in updates:
+        assert zadd(r, 'foo', update.input, xx=True) == update.expected_return_value
+        assert (
+            sorted(r.zrange('foo', 0, -1, withscores=True))
+            == sorted(update.expected_state)
+        )
+
+
+@redis3_only
+def test_zadd_with_nx_and_xx(r):
+    zadd(r, 'foo', {'four': 4.0, 'three': 3.0})
+    with pytest.raises(redis.DataError):
+        zadd(r, 'foo', {'four': -4.0, 'three': -3.0}, nx=True, xx=True)
+    with pytest.raises(redis.DataError):
+        zadd(r, 'foo', {'four': -4.0, 'three': -3.0}, nx=True, xx=True, ch=True)
+
+
+@redis3_only
+def test_zadd_with_nx_and_ch(r):
+    zadd(r, 'foo', {'four': 4.0, 'three': 3.0})
+
+    updates = [
+        UpdateCommand(
+            input={'four': 2.0, 'three': 1.0},
+            expected_return_value=0,
+            expected_state=[(b'four', 4.0), (b'three', 3.0)]),
+        UpdateCommand(
+            input={'four': 2.0, 'three': 1.0, 'zero': 0.0},
+            expected_return_value=1,
+            expected_state=[(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]),
+        UpdateCommand(
+            input={'two': 2.0, 'one': 1.0},
+            expected_return_value=2,
+            expected_state=[(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]),
+    ]
+
+    for update in updates:
+        assert zadd(r, 'foo', update.input, nx=True, ch=True) == update.expected_return_value
+        assert (
+            sorted(r.zrange('foo', 0, -1, withscores=True))
+            == sorted(update.expected_state)
+        )
+
+
+@redis3_only
+def test_zadd_with_xx_and_ch(r):
+    zadd(r, 'foo', {'four': 4.0, 'three': 3.0})
+
+    updates = [
+        UpdateCommand(
+            input={'four': 2.0, 'three': 1.0},
+            expected_return_value=2,
+            expected_state=[(b'four', 2.0), (b'three', 1.0)]),
+        UpdateCommand(
+            input={'four': 4.0, 'three': 3.0, 'zero': 0.0},
+            expected_return_value=2,
+            expected_state=[(b'four', 4.0), (b'three', 3.0)]),
+        UpdateCommand(
+            input={'two': 2.0, 'one': 1.0},
+            expected_return_value=0,
+            expected_state=[(b'four', 4.0), (b'three', 3.0)]),
+    ]
+
+    for update in updates:
+        assert zadd(r, 'foo', update.input, xx=True, ch=True) == update.expected_return_value
+        assert (
+            sorted(r.zrange('foo', 0, -1, withscores=True))
+            == sorted(update.expected_state)
+        )
+
+
+def test_zrange_same_score(r):
+    zadd(r, 'foo', {'two_a': 2})
+    zadd(r, 'foo', {'two_b': 2})
+    zadd(r, 'foo', {'two_c': 2})
+    zadd(r, 'foo', {'two_d': 2})
+    zadd(r, 'foo', {'two_e': 2})
+    assert r.zrange('foo', 2, 3) == [b'two_c', b'two_d']
+
+
+def test_zcard(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    assert r.zcard('foo') == 2
+
+
+def test_zcard_non_existent_key(r):
+    assert r.zcard('foo') == 0
+
+
+def test_zcard_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zcard('foo')
+
+
+def test_zcount(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'three': 2})
+    zadd(r, 'foo', {'five': 5})
+    assert r.zcount('foo', 2, 4) == 1
+    assert r.zcount('foo', 1, 4) == 2
+    assert r.zcount('foo', 0, 5) == 3
+    assert r.zcount('foo', 4, '+inf') == 1
+    assert r.zcount('foo', '-inf', 4) == 2
+    assert r.zcount('foo', '-inf', '+inf') == 3
+
+
+def test_zcount_exclusive(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'three': 2})
+    zadd(r, 'foo', {'five': 5})
+    assert r.zcount('foo', '-inf', '(2') == 1
+    assert r.zcount('foo', '-inf', 2) == 2
+    assert r.zcount('foo', '(5', '+inf') == 0
+    assert r.zcount('foo', '(1', 5) == 2
+    assert r.zcount('foo', '(2', '(5') == 0
+    assert r.zcount('foo', '(1', '(5') == 1
+    assert r.zcount('foo', 2, '(5') == 1
+
+
+def test_zcount_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zcount('foo', '-inf', '+inf')
+
+
+def test_zincrby(r):
+    zadd(r, 'foo', {'one': 1})
+    assert zincrby(r, 'foo', 10, 'one') == 11
+    assert r.zrange('foo', 0, -1, withscores=True) == [(b'one', 11)]
+
+
+def test_zincrby_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        zincrby(r, 'foo', 10, 'one')
+
+
+def test_zrange_descending(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zrange('foo', 0, -1, desc=True) == [b'three', b'two', b'one']
+
+
+def test_zrange_descending_with_scores(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert (
+        r.zrange('foo', 0, -1, desc=True, withscores=True)
+        == [(b'three', 3), (b'two', 2), (b'one', 1)]
+    )
+
+
+def test_zrange_with_positive_indices(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zrange('foo', 0, 1) == [b'one', b'two']
+
+
+def test_zrange_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zrange('foo', 0, -1)
+
+
+def test_zrange_score_cast(r):
+    zadd(r, 'foo', {'one': 1.2})
+    zadd(r, 'foo', {'two': 2.2})
+
+    expected_without_cast_round = [(b'one', 1.2), (b'two', 2.2)]
+    expected_with_cast_round = [(b'one', 1.0), (b'two', 2.0)]
+    assert r.zrange('foo', 0, 2, withscores=True) == expected_without_cast_round
+    assert (
+        r.zrange('foo', 0, 2, withscores=True, score_cast_func=round_str)
+        == expected_with_cast_round
+    )
+
+
+def test_zrank(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zrank('foo', 'one') == 0
+    assert r.zrank('foo', 'two') == 1
+    assert r.zrank('foo', 'three') == 2
+
+
+def test_zrank_non_existent_member(r):
+    assert r.zrank('foo', 'one') is None
+
+
+def test_zrank_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zrank('foo', 'one')
+
+
+def test_zrem(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    zadd(r, 'foo', {'four': 4})
+    assert r.zrem('foo', 'one') == True
+    assert r.zrange('foo', 0, -1) == [b'two', b'three', b'four']
+    # Since redis>=2.7.6 returns number of deleted items.
+    assert r.zrem('foo', 'two', 'three') == 2
+    assert r.zrange('foo', 0, -1) == [b'four']
+    assert r.zrem('foo', 'three', 'four') == True
+    assert r.zrange('foo', 0, -1) == []
+    assert r.zrem('foo', 'three', 'four') == False
+
+
+def test_zrem_non_existent_member(r):
+    assert not r.zrem('foo', 'one')
+
+
+def test_zrem_numeric_member(r):
+    zadd(r, 'foo', {'128': 13.0, '129': 12.0})
+    assert r.zrem('foo', 128) == True
+    assert r.zrange('foo', 0, -1) == [b'129']
+
+
+def test_zrem_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zrem('foo', 'bar')
+
+
+def test_zscore(r):
+    zadd(r, 'foo', {'one': 54})
+    assert r.zscore('foo', 'one') == 54
+
+
+def test_zscore_non_existent_member(r):
+    assert r.zscore('foo', 'one') is None
+
+
+def test_zscore_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zscore('foo', 'one')
+
+
+def test_zrevrank(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zrevrank('foo', 'one') == 2
+    assert r.zrevrank('foo', 'two') == 1
+    assert r.zrevrank('foo', 'three') == 0
+
+
+def test_zrevrank_non_existent_member(r):
+    assert r.zrevrank('foo', 'one') is None
+
+
+def test_zrevrank_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zrevrank('foo', 'one')
+
+
+def test_zrevrange(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zrevrange('foo', 0, 1) == [b'three', b'two']
+    assert r.zrevrange('foo', 0, -1) == [b'three', b'two', b'one']
+
+
+def test_zrevrange_sorted_keys(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'two_b': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zrevrange('foo', 0, 2) == [b'three', b'two_b', b'two']
+    assert r.zrevrange('foo', 0, -1) == [b'three', b'two_b', b'two', b'one']
+
+
+def test_zrevrange_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zrevrange('foo', 0, 2)
+
+
+def test_zrevrange_score_cast(r):
+    zadd(r, 'foo', {'one': 1.2})
+    zadd(r, 'foo', {'two': 2.2})
+
+    expected_without_cast_round = [(b'two', 2.2), (b'one', 1.2)]
+    expected_with_cast_round = [(b'two', 2.0), (b'one', 1.0)]
+    assert r.zrevrange('foo', 0, 2, withscores=True) == expected_without_cast_round
+    assert (
+        r.zrevrange('foo', 0, 2, withscores=True, score_cast_func=round_str)
+        == expected_with_cast_round
+    )
+
+
+def test_zrangebyscore(r):
+    zadd(r, 'foo', {'zero': 0})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'two_a_also': 2})
+    zadd(r, 'foo', {'two_b_also': 2})
+    zadd(r, 'foo', {'four': 4})
+    assert r.zrangebyscore('foo', 1, 3) == [b'two', b'two_a_also', b'two_b_also']
+    assert r.zrangebyscore('foo', 2, 3) == [b'two', b'two_a_also', b'two_b_also']
+    assert (
+        r.zrangebyscore('foo', 0, 4)
+        == [b'zero', b'two', b'two_a_also', b'two_b_also', b'four']
+    )
+    assert r.zrangebyscore('foo', '-inf', 1) == [b'zero']
+    assert (
+        r.zrangebyscore('foo', 2, '+inf')
+        == [b'two', b'two_a_also', b'two_b_also', b'four']
+    )
+    assert (
+        r.zrangebyscore('foo', '-inf', '+inf')
+        == [b'zero', b'two', b'two_a_also', b'two_b_also', b'four']
+    )
+
+
+def test_zrangebysore_exclusive(r):
+    zadd(r, 'foo', {'zero': 0})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'four': 4})
+    zadd(r, 'foo', {'five': 5})
+    assert r.zrangebyscore('foo', '(0', 6) == [b'two', b'four', b'five']
+    assert r.zrangebyscore('foo', '(2', '(5') == [b'four']
+    assert r.zrangebyscore('foo', 0, '(4') == [b'zero', b'two']
+
+
+def test_zrangebyscore_raises_error(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    with pytest.raises(redis.ResponseError):
+        r.zrangebyscore('foo', 'one', 2)
+    with pytest.raises(redis.ResponseError):
+        r.zrangebyscore('foo', 2, 'three')
+    with pytest.raises(redis.ResponseError):
+        r.zrangebyscore('foo', 2, '3)')
+    with pytest.raises(redis.RedisError):
+        r.zrangebyscore('foo', 2, '3)', 0, None)
+
+
+def test_zrangebyscore_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zrangebyscore('foo', '(1', '(2')
+
+
+def test_zrangebyscore_slice(r):
+    zadd(r, 'foo', {'two_a': 2})
+    zadd(r, 'foo', {'two_b': 2})
+    zadd(r, 'foo', {'two_c': 2})
+    zadd(r, 'foo', {'two_d': 2})
+    assert r.zrangebyscore('foo', 0, 4, 0, 2) == [b'two_a', b'two_b']
+    assert r.zrangebyscore('foo', 0, 4, 1, 3) == [b'two_b', b'two_c', b'two_d']
+
+
+def test_zrangebyscore_withscores(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zrangebyscore('foo', 1, 3, 0, 2, True) == [(b'one', 1), (b'two', 2)]
+
+
+def test_zrangebyscore_cast_scores(r):
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'two_a_also': 2.2})
+
+    expected_without_cast_round = [(b'two', 2.0), (b'two_a_also', 2.2)]
+    expected_with_cast_round = [(b'two', 2.0), (b'two_a_also', 2.0)]
+    assert (
+        sorted(r.zrangebyscore('foo', 2, 3, withscores=True))
+        == sorted(expected_without_cast_round)
+    )
+    assert (
+        sorted(r.zrangebyscore('foo', 2, 3, withscores=True,
+                               score_cast_func=round_str))
+        == sorted(expected_with_cast_round)
+    )
+
+
+def test_zrevrangebyscore(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zrevrangebyscore('foo', 3, 1) == [b'three', b'two', b'one']
+    assert r.zrevrangebyscore('foo', 3, 2) == [b'three', b'two']
+    assert r.zrevrangebyscore('foo', 3, 1, 0, 1) == [b'three']
+    assert r.zrevrangebyscore('foo', 3, 1, 1, 2) == [b'two', b'one']
+
+
+def test_zrevrangebyscore_exclusive(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zrevrangebyscore('foo', '(3', 1) == [b'two', b'one']
+    assert r.zrevrangebyscore('foo', 3, '(2') == [b'three']
+    assert r.zrevrangebyscore('foo', '(3', '(1') == [b'two']
+    assert r.zrevrangebyscore('foo', '(2', 1, 0, 1) == [b'one']
+    assert r.zrevrangebyscore('foo', '(2', '(1', 0, 1) == []
+    assert r.zrevrangebyscore('foo', '(3', '(0', 1, 2) == [b'one']
+
+
+def test_zrevrangebyscore_raises_error(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebyscore('foo', 'three', 1)
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebyscore('foo', 3, 'one')
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebyscore('foo', 3, '1)')
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebyscore('foo', '((3', '1)')
+
+
+def test_zrevrangebyscore_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebyscore('foo', '(3', '(1')
+
+
+def test_zrevrangebyscore_cast_scores(r):
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'two_a_also': 2.2})
+
+    expected_without_cast_round = [(b'two_a_also', 2.2), (b'two', 2.0)]
+    expected_with_cast_round = [(b'two_a_also', 2.0), (b'two', 2.0)]
+    assert (
+        r.zrevrangebyscore('foo', 3, 2, withscores=True)
+         == expected_without_cast_round
+    )
+    assert (
+        r.zrevrangebyscore('foo', 3, 2, withscores=True,
+                           score_cast_func=round_str)
+        == expected_with_cast_round
+    )
+
+
+def test_zrangebylex(r):
+    zadd(r, 'foo', {'one_a': 0})
+    zadd(r, 'foo', {'two_a': 0})
+    zadd(r, 'foo', {'two_b': 0})
+    zadd(r, 'foo', {'three_a': 0})
+    assert r.zrangebylex('foo', b'(t', b'+') == [b'three_a', b'two_a', b'two_b']
+    assert r.zrangebylex('foo', b'(t', b'[two_b') == [b'three_a', b'two_a', b'two_b']
+    assert r.zrangebylex('foo', b'(t', b'(two_b') == [b'three_a', b'two_a']
+    assert (
+        r.zrangebylex('foo', b'[three_a', b'[two_b')
+        == [b'three_a', b'two_a', b'two_b']
+    )
+    assert r.zrangebylex('foo', b'(three_a', b'[two_b') == [b'two_a', b'two_b']
+    assert r.zrangebylex('foo', b'-', b'(two_b') == [b'one_a', b'three_a', b'two_a']
+    assert r.zrangebylex('foo', b'[two_b', b'(two_b') == []
+    # reversed max + and min - boundaries
+    # these will be always empty, but allowed by redis
+    assert r.zrangebylex('foo', b'+', b'-') == []
+    assert r.zrangebylex('foo', b'+', b'[three_a') == []
+    assert r.zrangebylex('foo', b'[o', b'-') == []
+
+
+def test_zrangebylex_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zrangebylex('foo', b'-', b'+')
+
+
+def test_zlexcount(r):
+    zadd(r, 'foo', {'one_a': 0})
+    zadd(r, 'foo', {'two_a': 0})
+    zadd(r, 'foo', {'two_b': 0})
+    zadd(r, 'foo', {'three_a': 0})
+    assert r.zlexcount('foo', b'(t', b'+') == 3
+    assert r.zlexcount('foo', b'(t', b'[two_b') == 3
+    assert r.zlexcount('foo', b'(t', b'(two_b') == 2
+    assert r.zlexcount('foo', b'[three_a', b'[two_b') == 3
+    assert r.zlexcount('foo', b'(three_a', b'[two_b') == 2
+    assert r.zlexcount('foo', b'-', b'(two_b') == 3
+    assert r.zlexcount('foo', b'[two_b', b'(two_b') == 0
+    # reversed max + and min - boundaries
+    # these will be always empty, but allowed by redis
+    assert r.zlexcount('foo', b'+', b'-') == 0
+    assert r.zlexcount('foo', b'+', b'[three_a') == 0
+    assert r.zlexcount('foo', b'[o', b'-') == 0
+
+
+def test_zlexcount_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zlexcount('foo', b'-', b'+')
+
+
+def test_zrangebylex_with_limit(r):
+    zadd(r, 'foo', {'one_a': 0})
+    zadd(r, 'foo', {'two_a': 0})
+    zadd(r, 'foo', {'two_b': 0})
+    zadd(r, 'foo', {'three_a': 0})
+    assert r.zrangebylex('foo', b'-', b'+', 1, 2) == [b'three_a', b'two_a']
+
+    # negative offset no results
+    assert r.zrangebylex('foo', b'-', b'+', -1, 3) == []
+
+    # negative limit ignored
+    assert (
+        r.zrangebylex('foo', b'-', b'+', 0, -2)
+        == [b'one_a', b'three_a', b'two_a', b'two_b']
+    )
+    assert r.zrangebylex('foo', b'-', b'+', 1, -2) == [b'three_a', b'two_a', b'two_b']
+    assert r.zrangebylex('foo', b'+', b'-', 1, 1) == []
+
+
+def test_zrangebylex_raises_error(r):
+    zadd(r, 'foo', {'one_a': 0})
+    zadd(r, 'foo', {'two_a': 0})
+    zadd(r, 'foo', {'two_b': 0})
+    zadd(r, 'foo', {'three_a': 0})
+
+    with pytest.raises(redis.ResponseError):
+        r.zrangebylex('foo', b'', b'[two_b')
+
+    with pytest.raises(redis.ResponseError):
+        r.zrangebylex('foo', b'-', b'two_b')
+
+    with pytest.raises(redis.ResponseError):
+        r.zrangebylex('foo', b'(t', b'two_b')
+
+    with pytest.raises(redis.ResponseError):
+        r.zrangebylex('foo', b't', b'+')
+
+    with pytest.raises(redis.ResponseError):
+        r.zrangebylex('foo', b'[two_a', b'')
+
+    with pytest.raises(redis.RedisError):
+        r.zrangebylex('foo', b'(two_a', b'[two_b', 1)
+
+
+def test_zrevrangebylex(r):
+    zadd(r, 'foo', {'one_a': 0})
+    zadd(r, 'foo', {'two_a': 0})
+    zadd(r, 'foo', {'two_b': 0})
+    zadd(r, 'foo', {'three_a': 0})
+    assert r.zrevrangebylex('foo', b'+', b'(t') == [b'two_b', b'two_a', b'three_a']
+    assert (
+        r.zrevrangebylex('foo', b'[two_b', b'(t')
+        == [b'two_b', b'two_a', b'three_a']
+    )
+    assert r.zrevrangebylex('foo', b'(two_b', b'(t') == [b'two_a', b'three_a']
+    assert (
+        r.zrevrangebylex('foo', b'[two_b', b'[three_a')
+        == [b'two_b', b'two_a', b'three_a']
+    )
+    assert r.zrevrangebylex('foo', b'[two_b', b'(three_a') == [b'two_b', b'two_a']
+    assert r.zrevrangebylex('foo', b'(two_b', b'-') == [b'two_a', b'three_a', b'one_a']
+    assert r.zrangebylex('foo', b'(two_b', b'[two_b') == []
+    # reversed max + and min - boundaries
+    # these will be always empty, but allowed by redis
+    assert r.zrevrangebylex('foo', b'-', b'+') == []
+    assert r.zrevrangebylex('foo', b'[three_a', b'+') == []
+    assert r.zrevrangebylex('foo', b'-', b'[o') == []
+
+
+def test_zrevrangebylex_with_limit(r):
+    zadd(r, 'foo', {'one_a': 0})
+    zadd(r, 'foo', {'two_a': 0})
+    zadd(r, 'foo', {'two_b': 0})
+    zadd(r, 'foo', {'three_a': 0})
+    assert r.zrevrangebylex('foo', b'+', b'-', 1, 2) == [b'two_a', b'three_a']
+
+
+def test_zrevrangebylex_raises_error(r):
+    zadd(r, 'foo', {'one_a': 0})
+    zadd(r, 'foo', {'two_a': 0})
+    zadd(r, 'foo', {'two_b': 0})
+    zadd(r, 'foo', {'three_a': 0})
+
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebylex('foo', b'[two_b', b'')
+
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebylex('foo', b'two_b', b'-')
+
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebylex('foo', b'two_b', b'(t')
+
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebylex('foo', b'+', b't')
+
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebylex('foo', b'', b'[two_a')
+
+    with pytest.raises(redis.RedisError):
+        r.zrevrangebylex('foo', b'[two_a', b'(two_b', 1)
+
+
+def test_zrevrangebylex_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zrevrangebylex('foo', b'+', b'-')
+
+
+def test_zremrangebyrank(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zremrangebyrank('foo', 0, 1) == 2
+    assert r.zrange('foo', 0, -1) == [b'three']
+
+
+def test_zremrangebyrank_negative_indices(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'three': 3})
+    assert r.zremrangebyrank('foo', -2, -1) == 2
+    assert r.zrange('foo', 0, -1) == [b'one']
+
+
+def test_zremrangebyrank_out_of_bounds(r):
+    zadd(r, 'foo', {'one': 1})
+    assert r.zremrangebyrank('foo', 1, 3) == 0
+
+
+def test_zremrangebyrank_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zremrangebyrank('foo', 1, 3)
+
+
+def test_zremrangebyscore(r):
+    zadd(r, 'foo', {'zero': 0})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'four': 4})
+    # Outside of range.
+    assert r.zremrangebyscore('foo', 5, 10) == 0
+    assert r.zrange('foo', 0, -1) == [b'zero', b'two', b'four']
+    # Middle of range.
+    assert r.zremrangebyscore('foo', 1, 3) == 1
+    assert r.zrange('foo', 0, -1) == [b'zero', b'four']
+    assert r.zremrangebyscore('foo', 1, 3) == 0
+    # Entire range.
+    assert r.zremrangebyscore('foo', 0, 4) == 2
+    assert r.zrange('foo', 0, -1) == []
+
+
+def test_zremrangebyscore_exclusive(r):
+    zadd(r, 'foo', {'zero': 0})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'four': 4})
+    assert r.zremrangebyscore('foo', '(0', 1) == 0
+    assert r.zrange('foo', 0, -1) == [b'zero', b'two', b'four']
+    assert r.zremrangebyscore('foo', '-inf', '(0') == 0
+    assert r.zrange('foo', 0, -1) == [b'zero', b'two', b'four']
+    assert r.zremrangebyscore('foo', '(2', 5) == 1
+    assert r.zrange('foo', 0, -1) == [b'zero', b'two']
+    assert r.zremrangebyscore('foo', 0, '(2') == 1
+    assert r.zrange('foo', 0, -1) == [b'two']
+    assert r.zremrangebyscore('foo', '(1', '(3') == 1
+    assert r.zrange('foo', 0, -1) == []
+
+
+def test_zremrangebyscore_raises_error(r):
+    zadd(r, 'foo', {'zero': 0})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'foo', {'four': 4})
+    with pytest.raises(redis.ResponseError):
+        r.zremrangebyscore('foo', 'three', 1)
+    with pytest.raises(redis.ResponseError):
+        r.zremrangebyscore('foo', 3, 'one')
+    with pytest.raises(redis.ResponseError):
+        r.zremrangebyscore('foo', 3, '1)')
+    with pytest.raises(redis.ResponseError):
+        r.zremrangebyscore('foo', '((3', '1)')
+
+
+def test_zremrangebyscore_badkey(r):
+    assert r.zremrangebyscore('foo', 0, 2) == 0
+
+
+def test_zremrangebyscore_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zremrangebyscore('foo', 0, 2)
+
+
+def test_zremrangebylex(r):
+    zadd(r, 'foo', {'two_a': 0})
+    zadd(r, 'foo', {'two_b': 0})
+    zadd(r, 'foo', {'one_a': 0})
+    zadd(r, 'foo', {'three_a': 0})
+    assert r.zremrangebylex('foo', b'(three_a', b'[two_b') == 2
+    assert r.zremrangebylex('foo', b'(three_a', b'[two_b') == 0
+    assert r.zremrangebylex('foo', b'-', b'(o') == 0
+    assert r.zremrangebylex('foo', b'-', b'[one_a') == 1
+    assert r.zremrangebylex('foo', b'[tw', b'+') == 0
+    assert r.zremrangebylex('foo', b'[t', b'+') == 1
+    assert r.zremrangebylex('foo', b'[t', b'+') == 0
+
+
+def test_zremrangebylex_error(r):
+    zadd(r, 'foo', {'two_a': 0})
+    zadd(r, 'foo', {'two_b': 0})
+    zadd(r, 'foo', {'one_a': 0})
+    zadd(r, 'foo', {'three_a': 0})
+    with pytest.raises(redis.ResponseError):
+        r.zremrangebylex('foo', b'(t', b'two_b')
+
+    with pytest.raises(redis.ResponseError):
+        r.zremrangebylex('foo', b't', b'+')
+
+    with pytest.raises(redis.ResponseError):
+        r.zremrangebylex('foo', b'[two_a', b'')
+
+
+def test_zremrangebylex_badkey(r):
+    assert r.zremrangebylex('foo', b'(three_a', b'[two_b') == 0
+
+
+def test_zremrangebylex_wrong_type(r):
+    r.sadd('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zremrangebylex('foo', b'bar', b'baz')
+
+
+def test_zunionstore(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'bar', {'one': 1})
+    zadd(r, 'bar', {'two': 2})
+    zadd(r, 'bar', {'three': 3})
+    r.zunionstore('baz', ['foo', 'bar'])
+    assert (
+        r.zrange('baz', 0, -1, withscores=True)
+        == [(b'one', 2), (b'three', 3), (b'two', 4)]
+    )
+
+
+def test_zunionstore_sum(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'bar', {'one': 1})
+    zadd(r, 'bar', {'two': 2})
+    zadd(r, 'bar', {'three': 3})
+    r.zunionstore('baz', ['foo', 'bar'], aggregate='SUM')
+    assert (
+        r.zrange('baz', 0, -1, withscores=True)
+        == [(b'one', 2), (b'three', 3), (b'two', 4)]
+    )
+
+
+def test_zunionstore_max(r):
+    zadd(r, 'foo', {'one': 0})
+    zadd(r, 'foo', {'two': 0})
+    zadd(r, 'bar', {'one': 1})
+    zadd(r, 'bar', {'two': 2})
+    zadd(r, 'bar', {'three': 3})
+    r.zunionstore('baz', ['foo', 'bar'], aggregate='MAX')
+    assert (
+        r.zrange('baz', 0, -1, withscores=True)
+        == [(b'one', 1), (b'two', 2), (b'three', 3)]
+    )
+
+
+def test_zunionstore_min(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'bar', {'one': 0})
+    zadd(r, 'bar', {'two': 0})
+    zadd(r, 'bar', {'three': 3})
+    r.zunionstore('baz', ['foo', 'bar'], aggregate='MIN')
+    assert (
+        r.zrange('baz', 0, -1, withscores=True)
+        == [(b'one', 0), (b'two', 0), (b'three', 3)]
+    )
+
+
+def test_zunionstore_weights(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'bar', {'one': 1})
+    zadd(r, 'bar', {'two': 2})
+    zadd(r, 'bar', {'four': 4})
+    r.zunionstore('baz', {'foo': 1, 'bar': 2}, aggregate='SUM')
+    assert (
+        r.zrange('baz', 0, -1, withscores=True)
+        == [(b'one', 3), (b'two', 6), (b'four', 8)]
+    )
+
+
+def test_zunionstore_nan_to_zero(r):
+    zadd(r, 'foo', {'x': math.inf})
+    zadd(r, 'foo2', {'x': math.inf})
+    r.zunionstore('bar', OrderedDict([('foo', 1.0), ('foo2', 0.0)]))
+    # This is different to test_zinterstore_nan_to_zero because of a quirk
+    # in redis. See https://github.com/antirez/redis/issues/3954.
+    assert r.zscore('bar', 'x') == math.inf
+
+
+def test_zunionstore_nan_to_zero2(r):
+    zadd(r, 'foo', {'zero': 0})
+    zadd(r, 'foo2', {'one': 1})
+    zadd(r, 'foo3', {'one': 1})
+    r.zunionstore('bar', {'foo': math.inf}, aggregate='SUM')
+    assert r.zrange('bar', 0, -1, withscores=True) == [(b'zero', 0)]
+    r.zunionstore('bar', OrderedDict([('foo2', math.inf), ('foo3', -math.inf)]))
+    assert r.zrange('bar', 0, -1, withscores=True) == [(b'one', 0)]
+
+
+def test_zunionstore_nan_to_zero_ordering(r):
+    zadd(r, 'foo', {'e1': math.inf})
+    zadd(r, 'bar', {'e1': -math.inf, 'e2': 0.0})
+    r.zunionstore('baz', ['foo', 'bar', 'foo'])
+    assert r.zscore('baz', 'e1') == 0.0
+
+
+def test_zunionstore_mixed_set_types(r):
+    # No score, redis will use 1.0.
+    r.sadd('foo', 'one')
+    r.sadd('foo', 'two')
+    zadd(r, 'bar', {'one': 1})
+    zadd(r, 'bar', {'two': 2})
+    zadd(r, 'bar', {'three': 3})
+    r.zunionstore('baz', ['foo', 'bar'], aggregate='SUM')
+    assert (
+        r.zrange('baz', 0, -1, withscores=True)
+        == [(b'one', 2), (b'three', 3), (b'two', 3)]
+    )
+
+
+def test_zunionstore_badkey(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    r.zunionstore('baz', ['foo', 'bar'], aggregate='SUM')
+    assert r.zrange('baz', 0, -1, withscores=True) == [(b'one', 1), (b'two', 2)]
+    r.zunionstore('baz', {'foo': 1, 'bar': 2}, aggregate='SUM')
+    assert r.zrange('baz', 0, -1, withscores=True) == [(b'one', 1), (b'two', 2)]
+
+
+def test_zunionstore_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zunionstore('baz', ['foo', 'bar'])
+
+
+def test_zinterstore(r):
+    zadd(r, 'foo', {'one': 1})
+    zadd(r, 'foo', {'two': 2})
+    zadd(r, 'bar', {'one': 1})
+    zadd(r, 'bar', {'two': 2})
+    zadd(r, 'bar', {'three': 3})
+    r.zinterstore('baz', ['foo', 'bar'])
+    assert r.zrange('baz', 0, -1, withscores=True) == [(b'one', 2), (b'two', 4)]
+
+
+def test_zinterstore_mixed_set_types(r):
+    r.sadd('foo', 'one')
+    r.sadd('foo', 'two')
+    zadd(r, 'bar', {'one': 1})
+    zadd(r, 'bar', {'two': 2})
+    zadd(r, 'bar', {'three': 3})
+    r.zinterstore('baz', ['foo', 'bar'], aggregate='SUM')
+    assert r.zrange('baz', 0, -1, withscores=True) == [(b'one', 2), (b'two', 3)]
+
+
+def test_zinterstore_max(r):
+    zadd(r, 'foo', {'one': 0})
+    zadd(r, 'foo', {'two': 0})
+    zadd(r, 'bar', {'one': 1})
+    zadd(r, 'bar', {'two': 2})
+    zadd(r, 'bar', {'three': 3})
+    r.zinterstore('baz', ['foo', 'bar'], aggregate='MAX')
+    assert r.zrange('baz', 0, -1, withscores=True) == [(b'one', 1), (b'two', 2)]
+
+
+def test_zinterstore_onekey(r):
+    zadd(r, 'foo', {'one': 1})
+    r.zinterstore('baz', ['foo'], aggregate='MAX')
+    assert r.zrange('baz', 0, -1, withscores=True) == [(b'one', 1)]
+
+
+def test_zinterstore_nokey(r):
+    with pytest.raises(redis.ResponseError):
+        r.zinterstore('baz', [], aggregate='MAX')
+
+
+def test_zinterstore_nan_to_zero(r):
+    zadd(r, 'foo', {'x': math.inf})
+    zadd(r, 'foo2', {'x': math.inf})
+    r.zinterstore('bar', OrderedDict([('foo', 1.0), ('foo2', 0.0)]))
+    assert r.zscore('bar', 'x') == 0.0
+
+
+def test_zunionstore_nokey(r):
+    with pytest.raises(redis.ResponseError):
+        r.zunionstore('baz', [], aggregate='MAX')
+
+
+def test_zinterstore_wrong_type(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError):
+        r.zinterstore('baz', ['foo', 'bar'])
+
+
+def test_empty_zset(r):
+    zadd(r, 'foo', {'one': 1})
+    r.zrem('foo', 'one')
+    assert not r.exists('foo')
+
+
+def test_multidb(r, create_redis):
+    r1 = create_redis(db=0)
+    r2 = create_redis(db=1)
+
+    r1['r1'] = 'r1'
+    r2['r2'] = 'r2'
+
+    assert 'r2' not in r1
+    assert 'r1' not in r2
+
+    assert r1['r1'] == b'r1'
+    assert r2['r2'] == b'r2'
+
+    assert r1.flushall() == True
+
+    assert 'r1' not in r1
+    assert 'r2' not in r2
+
+
+def test_basic_sort(r):
+    r.rpush('foo', '2')
+    r.rpush('foo', '1')
+    r.rpush('foo', '3')
+
+    assert r.sort('foo') == [b'1', b'2', b'3']
+
+
+def test_empty_sort(r):
+    assert r.sort('foo') == []
+
+
+def test_sort_range_offset_range(r):
+    r.rpush('foo', '2')
+    r.rpush('foo', '1')
+    r.rpush('foo', '4')
+    r.rpush('foo', '3')
+
+    assert r.sort('foo', start=0, num=2) == [b'1', b'2']
+
+
+def test_sort_range_offset_range_and_desc(r):
+    r.rpush('foo', '2')
+    r.rpush('foo', '1')
+    r.rpush('foo', '4')
+    r.rpush('foo', '3')
+
+    assert r.sort("foo", start=0, num=1, desc=True) == [b"4"]
+
+
+def test_sort_range_offset_norange(r):
+    with pytest.raises(redis.RedisError):
+        r.sort('foo', start=1)
+
+
+def test_sort_range_with_large_range(r):
+    r.rpush('foo', '2')
+    r.rpush('foo', '1')
+    r.rpush('foo', '4')
+    r.rpush('foo', '3')
+    # num=20 even though len(foo) is 4.
+    assert r.sort('foo', start=1, num=20) == [b'2', b'3', b'4']
+
+
+def test_sort_descending(r):
+    r.rpush('foo', '1')
+    r.rpush('foo', '2')
+    r.rpush('foo', '3')
+    assert r.sort('foo', desc=True) == [b'3', b'2', b'1']
+
+
+def test_sort_alpha(r):
+    r.rpush('foo', '2a')
+    r.rpush('foo', '1b')
+    r.rpush('foo', '2b')
+    r.rpush('foo', '1a')
+
+    assert r.sort('foo', alpha=True) == [b'1a', b'1b', b'2a', b'2b']
+
+
+def test_sort_wrong_type(r):
+    r.set('string', '3')
+    with pytest.raises(redis.ResponseError):
+        r.sort('string')
+
+
+def test_foo(r):
+    r.rpush('foo', '2a')
+    r.rpush('foo', '1b')
+    r.rpush('foo', '2b')
+    r.rpush('foo', '1a')
+    with pytest.raises(redis.ResponseError):
+        r.sort('foo', alpha=False)
+
+
+def test_sort_with_store_option(r):
+    r.rpush('foo', '2')
+    r.rpush('foo', '1')
+    r.rpush('foo', '4')
+    r.rpush('foo', '3')
+
+    assert r.sort('foo', store='bar') == 4
+    assert r.lrange('bar', 0, -1) == [b'1', b'2', b'3', b'4']
+
+
+def test_sort_with_by_and_get_option(r):
+    r.rpush('foo', '2')
+    r.rpush('foo', '1')
+    r.rpush('foo', '4')
+    r.rpush('foo', '3')
+
+    r['weight_1'] = '4'
+    r['weight_2'] = '3'
+    r['weight_3'] = '2'
+    r['weight_4'] = '1'
+
+    r['data_1'] = 'one'
+    r['data_2'] = 'two'
+    r['data_3'] = 'three'
+    r['data_4'] = 'four'
+
+    assert (
+        r.sort('foo', by='weight_*', get='data_*')
+        == [b'four', b'three', b'two', b'one']
+    )
+    assert r.sort('foo', by='weight_*', get='#') == [b'4', b'3', b'2', b'1']
+    assert (
+        r.sort('foo', by='weight_*', get=('data_*', '#'))
+        == [b'four', b'4', b'three', b'3', b'two', b'2', b'one', b'1']
+    )
+    assert r.sort('foo', by='weight_*', get='data_1') == [None, None, None, None]
+
+
+def test_sort_with_hash(r):
+    r.rpush('foo', 'middle')
+    r.rpush('foo', 'eldest')
+    r.rpush('foo', 'youngest')
+    r.hset('record_youngest', 'age', 1)
+    r.hset('record_youngest', 'name', 'baby')
+
+    r.hset('record_middle', 'age', 10)
+    r.hset('record_middle', 'name', 'teen')
+
+    r.hset('record_eldest', 'age', 20)
+    r.hset('record_eldest', 'name', 'adult')
+
+    assert r.sort('foo', by='record_*->age') == [b'youngest', b'middle', b'eldest']
+    assert (
+        r.sort('foo', by='record_*->age', get='record_*->name')
+        == [b'baby', b'teen', b'adult']
+    )
+
+
+def test_sort_with_set(r):
+    r.sadd('foo', '3')
+    r.sadd('foo', '1')
+    r.sadd('foo', '2')
+    assert r.sort('foo') == [b'1', b'2', b'3']
+
+
+def test_pipeline(r):
+    # The pipeline method returns an object for
+    # issuing multiple commands in a batch.
+    p = r.pipeline()
+    p.watch('bam')
+    p.multi()
+    p.set('foo', 'bar').get('foo')
+    p.lpush('baz', 'quux')
+    p.lpush('baz', 'quux2').lrange('baz', 0, -1)
+    res = p.execute()
+
+    # Check return values returned as list.
+    assert res == [True, b'bar', 1, 2, [b'quux2', b'quux']]
+
+    # Check side effects happened as expected.
+    assert r.lrange('baz', 0, -1) == [b'quux2', b'quux']
+
+    # Check that the command buffer has been emptied.
+    assert p.execute() == []
+
+
+def test_pipeline_ignore_errors(r):
+    """Test the pipeline ignoring errors when asked."""
+    with r.pipeline() as p:
+        p.set('foo', 'bar')
+        p.rename('baz', 'bats')
+        with pytest.raises(redis.exceptions.ResponseError):
+            p.execute()
+        assert [] == p.execute()
+    with r.pipeline() as p:
+        p.set('foo', 'bar')
+        p.rename('baz', 'bats')
+        res = p.execute(raise_on_error=False)
+
+        assert [] == p.execute()
+
+        assert len(res) == 2
+        assert isinstance(res[1], redis.exceptions.ResponseError)
+
+
+def test_multiple_successful_watch_calls(r):
+    p = r.pipeline()
+    p.watch('bam')
+    p.multi()
+    p.set('foo', 'bar')
+    # Check that the watched keys buffer has been emptied.
+    p.execute()
+
+    # bam is no longer being watched, so it's ok to modify
+    # it now.
+    p.watch('foo')
+    r.set('bam', 'boo')
+    p.multi()
+    p.set('foo', 'bats')
+    assert p.execute() == [True]
+
+
+def test_pipeline_non_transactional(r):
+    # For our simple-minded model I don't think
+    # there is any observable difference.
+    p = r.pipeline(transaction=False)
+    res = p.set('baz', 'quux').get('baz').execute()
+
+    assert res == [True, b'quux']
+
+
+def test_pipeline_raises_when_watched_key_changed(r):
+    r.set('foo', 'bar')
+    r.rpush('greet', 'hello')
+    p = r.pipeline()
+    try:
+        p.watch('greet', 'foo')
+        nextf = six.ensure_binary(p.get('foo')) + b'baz'
+        # Simulate change happening on another thread.
+        r.rpush('greet', 'world')
+        # Begin pipelining.
+        p.multi()
+        p.set('foo', nextf)
+
+        with pytest.raises(redis.WatchError):
+            p.execute()
+    finally:
+        p.reset()
+
+
+def test_pipeline_succeeds_despite_unwatched_key_changed(r):
+    # Same setup as before except for the params to the WATCH command.
+    r.set('foo', 'bar')
+    r.rpush('greet', 'hello')
+    p = r.pipeline()
+    try:
+        # Only watch one of the 2 keys.
+        p.watch('foo')
+        nextf = six.ensure_binary(p.get('foo')) + b'baz'
+        # Simulate change happening on another thread.
+        r.rpush('greet', 'world')
+        p.multi()
+        p.set('foo', nextf)
+        p.execute()
+
+        # Check the commands were executed.
+        assert r.get('foo') == b'barbaz'
+    finally:
+        p.reset()
+
+
+def test_pipeline_succeeds_when_watching_nonexistent_key(r):
+    r.set('foo', 'bar')
+    r.rpush('greet', 'hello')
+    p = r.pipeline()
+    try:
+        # Also watch a nonexistent key.
+        p.watch('foo', 'bam')
+        nextf = six.ensure_binary(p.get('foo')) + b'baz'
+        # Simulate change happening on another thread.
+        r.rpush('greet', 'world')
+        p.multi()
+        p.set('foo', nextf)
+        p.execute()
+
+        # Check the commands were executed.
+        assert r.get('foo') == b'barbaz'
+    finally:
+        p.reset()
+
+
+def test_watch_state_is_cleared_across_multiple_watches(r):
+    r.set('foo', 'one')
+    r.set('bar', 'baz')
+    p = r.pipeline()
+
+    try:
+        p.watch('foo')
+        # Simulate change happening on another thread.
+        r.set('foo', 'three')
+        p.multi()
+        p.set('foo', 'three')
+        with pytest.raises(redis.WatchError):
+            p.execute()
+
+        # Now watch another key.  It should be ok to change
+        # foo as we're no longer watching it.
+        p.watch('bar')
+        r.set('foo', 'four')
+        p.multi()
+        p.set('bar', 'five')
+        assert p.execute() == [True]
+    finally:
+        p.reset()
+
+
+def test_pipeline_transaction_shortcut(r):
+    # This example taken pretty much from the redis-py documentation.
+    r.set('OUR-SEQUENCE-KEY', 13)
+    calls = []
+
+    def client_side_incr(pipe):
+        calls.append((pipe,))
+        current_value = pipe.get('OUR-SEQUENCE-KEY')
+        next_value = int(current_value) + 1
+
+        if len(calls) < 3:
+            # Simulate a change from another thread.
+            r.set('OUR-SEQUENCE-KEY', next_value)
+
+        pipe.multi()
+        pipe.set('OUR-SEQUENCE-KEY', next_value)
+
+    res = r.transaction(client_side_incr, 'OUR-SEQUENCE-KEY')
+
+    assert res == [True]
+    assert int(r.get('OUR-SEQUENCE-KEY')) == 16
+    assert len(calls) == 3
+
+
+def test_pipeline_transaction_value_from_callable(r):
+    def callback(pipe):
+        # No need to do anything here since we only want the return value
+        return 'OUR-RETURN-VALUE'
+
+    res = r.transaction(callback, 'OUR-SEQUENCE-KEY', value_from_callable=True)
+    assert res == 'OUR-RETURN-VALUE'
+
+
+def test_pipeline_empty(r):
+    p = r.pipeline()
+    assert len(p) == 0
+
+
+def test_pipeline_length(r):
+    p = r.pipeline()
+    p.set('baz', 'quux').get('baz')
+    assert len(p) == 2
+
+
+def test_pipeline_no_commands(r):
+    # Prior to 3.4, redis-py's execute is a nop if there are no commands
+    # queued, so it succeeds even if watched keys have been changed.
+    r.set('foo', '1')
+    p = r.pipeline()
+    p.watch('foo')
+    r.set('foo', '2')
+    if REDIS_VERSION >= '3.4':
+        with pytest.raises(redis.WatchError):
+            p.execute()
+    else:
+        assert p.execute() == []
+
+
+def test_pipeline_failed_transaction(r):
+    p = r.pipeline()
+    p.multi()
+    p.set('foo', 'bar')
+    # Deliberately induce a syntax error
+    p.execute_command('set')
+    # It should be an ExecAbortError, but redis-py tries to DISCARD after the
+    # failed EXEC, which raises a ResponseError.
+    with pytest.raises(redis.ResponseError):
+        p.execute()
+    assert not r.exists('foo')
+
+
+def test_pipeline_srem_no_change(r):
+    # A regression test for a case picked up by hypothesis tests
+    p = r.pipeline()
+    p.watch('foo')
+    r.srem('foo', 'bar')
+    p.multi()
+    p.set('foo', 'baz')
+    p.execute()
+    assert r.get('foo') == b'baz'
+
+
+def test_key_patterns(r):
+    r.mset({'one': 1, 'two': 2, 'three': 3, 'four': 4})
+    assert sorted(r.keys('*o*')) == [b'four', b'one', b'two']
+    assert r.keys('t??') == [b'two']
+    assert sorted(r.keys('*')) == [b'four', b'one', b'three', b'two']
+    assert sorted(r.keys()) == [b'four', b'one', b'three', b'two']
+
+
+def test_ping(r):
+    assert r.ping()
+    assert raw_command(r, 'ping', 'test') == b'test'
+
+
+@redis3_only
+def test_ping_pubsub(r):
+    p = r.pubsub()
+    p.subscribe('channel')
+    p.parse_response()    # Consume the subscribe reply
+    p.ping()
+    assert p.parse_response() == [b'pong', b'']
+    p.ping('test')
+    assert p.parse_response() == [b'pong', b'test']
+
+
+@redis3_only
+def test_swapdb(r, create_redis):
+    r1 = create_redis(1)
+    r.set('foo', 'abc')
+    r.set('bar', 'xyz')
+    r1.set('foo', 'foo')
+    r1.set('baz', 'baz')
+    assert r.swapdb(0, 1)
+    assert r.get('foo') == b'foo'
+    assert r.get('bar') is None
+    assert r.get('baz') == b'baz'
+    assert r1.get('foo') == b'abc'
+    assert r1.get('bar') == b'xyz'
+    assert r1.get('baz') is None
+
+
+@redis3_only
+def test_swapdb_same_db(r):
+    assert r.swapdb(1, 1)
+
+
+def test_save(r):
+    assert r.save()
+
+
+def test_bgsave(r):
+    assert r.bgsave()
+
+
+def test_lastsave(r):
+    assert isinstance(r.lastsave(), datetime)
+
+
+@pytest.mark.slow
+def test_bgsave_timestamp_update(r):
+    early_timestamp = r.lastsave()
+    sleep(1)
+    assert r.bgsave()
+    sleep(1)
+    late_timestamp = r.lastsave()
+    assert early_timestamp < late_timestamp
+
+
+@pytest.mark.slow
+def test_save_timestamp_update(r):
+    early_timestamp = r.lastsave()
+    sleep(1)
+    assert r.save()
+    late_timestamp = r.lastsave()
+    assert early_timestamp < late_timestamp
+
+
+def test_type(r):
+    r.set('string_key', "value")
+    r.lpush("list_key", "value")
+    r.sadd("set_key", "value")
+    zadd(r, "zset_key", {"value": 1})
+    r.hset('hset_key', 'key', 'value')
+
+    assert r.type('string_key') == b'string'
+    assert r.type('list_key') == b'list'
+    assert r.type('set_key') == b'set'
+    assert r.type('zset_key') == b'zset'
+    assert r.type('hset_key') == b'hash'
+    assert r.type('none_key') == b'none'
+
+
+@pytest.mark.slow
+def test_pubsub_subscribe(r):
+    pubsub = r.pubsub()
+    pubsub.subscribe("channel")
+    sleep(1)
+    expected_message = {'type': 'subscribe', 'pattern': None,
+                        'channel': b'channel', 'data': 1}
+    message = pubsub.get_message()
+    keys = list(pubsub.channels.keys())
+
+    key = keys[0]
+    key = (key if type(key) == bytes
+           else bytes(key, encoding='utf-8'))
+
+    assert len(keys) == 1
+    assert key == b'channel'
+    assert message == expected_message
+
+
+@pytest.mark.slow
+def test_pubsub_psubscribe(r):
+    pubsub = r.pubsub()
+    pubsub.psubscribe("channel.*")
+    sleep(1)
+    expected_message = {'type': 'psubscribe', 'pattern': None,
+                        'channel': b'channel.*', 'data': 1}
+
+    message = pubsub.get_message()
+    keys = list(pubsub.patterns.keys())
+    assert len(keys) == 1
+    assert message == expected_message
+
+
+@pytest.mark.slow
+def test_pubsub_unsubscribe(r):
+    pubsub = r.pubsub()
+    pubsub.subscribe('channel-1', 'channel-2', 'channel-3')
+    sleep(1)
+    expected_message = {'type': 'unsubscribe', 'pattern': None,
+                        'channel': b'channel-1', 'data': 2}
+    pubsub.get_message()
+    pubsub.get_message()
+    pubsub.get_message()
+
+    # unsubscribe from one
+    pubsub.unsubscribe('channel-1')
+    sleep(1)
+    message = pubsub.get_message()
+    keys = list(pubsub.channels.keys())
+    assert message == expected_message
+    assert len(keys) == 2
+
+    # unsubscribe from multiple
+    pubsub.unsubscribe()
+    sleep(1)
+    pubsub.get_message()
+    pubsub.get_message()
+    keys = list(pubsub.channels.keys())
+    assert message == expected_message
+    assert len(keys) == 0
+
+
+@pytest.mark.slow
+def test_pubsub_punsubscribe(r):
+    pubsub = r.pubsub()
+    pubsub.psubscribe('channel-1.*', 'channel-2.*', 'channel-3.*')
+    sleep(1)
+    expected_message = {'type': 'punsubscribe', 'pattern': None,
+                        'channel': b'channel-1.*', 'data': 2}
+    pubsub.get_message()
+    pubsub.get_message()
+    pubsub.get_message()
+
+    # unsubscribe from one
+    pubsub.punsubscribe('channel-1.*')
+    sleep(1)
+    message = pubsub.get_message()
+    keys = list(pubsub.patterns.keys())
+    assert message == expected_message
+    assert len(keys) == 2
+
+    # unsubscribe from multiple
+    pubsub.punsubscribe()
+    sleep(1)
+    pubsub.get_message()
+    pubsub.get_message()
+    keys = list(pubsub.patterns.keys())
+    assert len(keys) == 0
+
+
+@pytest.mark.slow
+def test_pubsub_listen(r):
+    def _listen(pubsub, q):
+        count = 0
+        for message in pubsub.listen():
+            q.put(message)
+            count += 1
+            if count == 4:
+                pubsub.close()
+
+    channel = 'ch1'
+    patterns = ['ch1*', 'ch[1]', 'ch?']
+    pubsub = r.pubsub()
+    pubsub.subscribe(channel)
+    pubsub.psubscribe(*patterns)
+    sleep(1)
+    msg1 = pubsub.get_message()
+    msg2 = pubsub.get_message()
+    msg3 = pubsub.get_message()
+    msg4 = pubsub.get_message()
+    assert msg1['type'] == 'subscribe'
+    assert msg2['type'] == 'psubscribe'
+    assert msg3['type'] == 'psubscribe'
+    assert msg4['type'] == 'psubscribe'
+
+    q = Queue()
+    t = threading.Thread(target=_listen, args=(pubsub, q))
+    t.start()
+    msg = 'hello world'
+    r.publish(channel, msg)
+    t.join()
+
+    msg1 = q.get()
+    msg2 = q.get()
+    msg3 = q.get()
+    msg4 = q.get()
+
+    bpatterns = [pattern.encode() for pattern in patterns]
+    bpatterns.append(channel.encode())
+    msg = msg.encode()
+    assert msg1['data'] == msg
+    assert msg1['channel'] in bpatterns
+    assert msg2['data'] == msg
+    assert msg2['channel'] in bpatterns
+    assert msg3['data'] == msg
+    assert msg3['channel'] in bpatterns
+    assert msg4['data'] == msg
+    assert msg4['channel'] in bpatterns
+
+
+@pytest.mark.slow
+def test_pubsub_listen_handler(r):
+    def _handler(message):
+        calls.append(message)
+
+    channel = 'ch1'
+    patterns = {'ch?': _handler}
+    calls = []
+
+    pubsub = r.pubsub()
+    pubsub.subscribe(ch1=_handler)
+    pubsub.psubscribe(**patterns)
+    sleep(1)
+    msg1 = pubsub.get_message()
+    msg2 = pubsub.get_message()
+    assert msg1['type'] == 'subscribe'
+    assert msg2['type'] == 'psubscribe'
+    msg = 'hello world'
+    r.publish(channel, msg)
+    sleep(1)
+    for i in range(2):
+        msg = pubsub.get_message()
+        assert msg is None   # get_message returns None when handler is used
+    pubsub.close()
+    calls.sort(key=lambda call: call['type'])
+    assert calls == [
+        {'pattern': None, 'channel': b'ch1', 'data': b'hello world', 'type': 'message'},
+        {'pattern': b'ch?', 'channel': b'ch1', 'data': b'hello world', 'type': 'pmessage'}
+    ]
+
+
+@pytest.mark.slow
+def test_pubsub_ignore_sub_messages_listen(r):
+    def _listen(pubsub, q):
+        count = 0
+        for message in pubsub.listen():
+            q.put(message)
+            count += 1
+            if count == 4:
+                pubsub.close()
+
+    channel = 'ch1'
+    patterns = ['ch1*', 'ch[1]', 'ch?']
+    pubsub = r.pubsub(ignore_subscribe_messages=True)
+    pubsub.subscribe(channel)
+    pubsub.psubscribe(*patterns)
+    sleep(1)
+
+    q = Queue()
+    t = threading.Thread(target=_listen, args=(pubsub, q))
+    t.start()
+    msg = 'hello world'
+    r.publish(channel, msg)
+    t.join()
+
+    msg1 = q.get()
+    msg2 = q.get()
+    msg3 = q.get()
+    msg4 = q.get()
+
+    bpatterns = [pattern.encode() for pattern in patterns]
+    bpatterns.append(channel.encode())
+    msg = msg.encode()
+    assert msg1['data'] == msg
+    assert msg1['channel'] in bpatterns
+    assert msg2['data'] == msg
+    assert msg2['channel'] in bpatterns
+    assert msg3['data'] == msg
+    assert msg3['channel'] in bpatterns
+    assert msg4['data'] == msg
+    assert msg4['channel'] in bpatterns
+
+
+@pytest.mark.slow
+def test_pubsub_binary(r):
+    def _listen(pubsub, q):
+        for message in pubsub.listen():
+            q.put(message)
+            pubsub.close()
+
+    pubsub = r.pubsub(ignore_subscribe_messages=True)
+    pubsub.subscribe('channel\r\n\xff')
+    sleep(1)
+
+    q = Queue()
+    t = threading.Thread(target=_listen, args=(pubsub, q))
+    t.start()
+    msg = b'\x00hello world\r\n\xff'
+    r.publish('channel\r\n\xff', msg)
+    t.join()
+
+    received = q.get()
+    assert received['data'] == msg
+
+
+@pytest.mark.slow
+def test_pubsub_run_in_thread(r):
+    q = Queue()
+
+    pubsub = r.pubsub()
+    pubsub.subscribe(channel=q.put)
+    pubsub_thread = pubsub.run_in_thread()
+
+    msg = b"Hello World"
+    r.publish("channel", msg)
+
+    retrieved = q.get()
+    assert retrieved["data"] == msg
+
+    pubsub_thread.stop()
+    # Newer versions of redis wait for an unsubscribe message, which sometimes comes early
+    # https://github.com/andymccurdy/redis-py/issues/1150
+    if pubsub.channels:
+        pubsub.channels = {}
+    pubsub_thread.join()
+    assert not pubsub_thread.is_alive()
+
+    pubsub.subscribe(channel=None)
+    with pytest.raises(redis.exceptions.PubSubError):
+        pubsub_thread = pubsub.run_in_thread()
+
+    pubsub.unsubscribe("channel")
+
+    pubsub.psubscribe(channel=None)
+    with pytest.raises(redis.exceptions.PubSubError):
+        pubsub_thread = pubsub.run_in_thread()
+
+
+@pytest.mark.slow
+def test_pubsub_timeout(r):
+    def publish():
+        sleep(0.1)
+        r.publish('channel', 'hello')
+
+    p = r.pubsub()
+    p.subscribe('channel')
+    p.parse_response()   # Drains the subscribe message
+    publish_thread = threading.Thread(target=publish)
+    publish_thread.start()
+    message = p.get_message(timeout=1)
+    assert message == {
+        'type': 'message', 'pattern': None,
+        'channel': b'channel', 'data': b'hello'
+    }
+    publish_thread.join()
+    message = p.get_message(timeout=0.5)
+    assert message is None
+
+
+def test_pfadd(r):
+    key = "hll-pfadd"
+    assert r.pfadd(key, "a", "b", "c", "d", "e", "f", "g") == 1
+    assert r.pfcount(key) == 7
+
+
+def test_pfcount(r):
+    key1 = "hll-pfcount01"
+    key2 = "hll-pfcount02"
+    key3 = "hll-pfcount03"
+    assert r.pfadd(key1, "foo", "bar", "zap") == 1
+    assert r.pfadd(key1, "zap", "zap", "zap") == 0
+    assert r.pfadd(key1, "foo", "bar") == 0
+    assert r.pfcount(key1) == 3
+    assert r.pfadd(key2, "1", "2", "3") == 1
+    assert r.pfcount(key2) == 3
+    assert r.pfcount(key1, key2) == 6
+    assert r.pfadd(key3, "foo", "bar", "zip") == 1
+    assert r.pfcount(key3) == 3
+    assert r.pfcount(key1, key3) == 4
+    assert r.pfcount(key1, key2, key3) == 7
+
+
+def test_pfmerge(r):
+    key1 = "hll-pfmerge01"
+    key2 = "hll-pfmerge02"
+    key3 = "hll-pfmerge03"
+    assert r.pfadd(key1, "foo", "bar", "zap", "a") == 1
+    assert r.pfadd(key2, "a", "b", "c", "foo") == 1
+    assert r.pfmerge(key3, key1, key2)
+    assert r.pfcount(key3) == 6
+
+
+def test_scan(r):
+    # Setup the data
+    for ix in range(20):
+        k = 'scan-test:%s' % ix
+        v = 'result:%s' % ix
+        r.set(k, v)
+    expected = r.keys()
+    assert len(expected) == 20  # Ensure we know what we're testing
+
+    # Test that we page through the results and get everything out
+    results = []
+    cursor = '0'
+    while cursor != 0:
+        cursor, data = r.scan(cursor, count=6)
+        results.extend(data)
+    assert set(expected) == set(results)
+
+    # Now test that the MATCH functionality works
+    results = []
+    cursor = '0'
+    while cursor != 0:
+        cursor, data = r.scan(cursor, match='*7', count=100)
+        results.extend(data)
+    assert b'scan-test:7' in results
+    assert b'scan-test:17' in results
+    assert len(results) == 2
+
+    # Test the match on iterator
+    results = [r for r in r.scan_iter(match='*7')]
+    assert b'scan-test:7' in results
+    assert b'scan-test:17' in results
+    assert len(results) == 2
+
+
+def test_sscan(r):
+    # Setup the data
+    name = 'sscan-test'
+    for ix in range(20):
+        k = 'sscan-test:%s' % ix
+        r.sadd(name, k)
+    expected = r.smembers(name)
+    assert len(expected) == 20  # Ensure we know what we're testing
+
+    # Test that we page through the results and get everything out
+    results = []
+    cursor = '0'
+    while cursor != 0:
+        cursor, data = r.sscan(name, cursor, count=6)
+        results.extend(data)
+    assert set(expected) == set(results)
+
+    # Test the iterator version
+    results = [r for r in r.sscan_iter(name, count=6)]
+    assert set(expected) == set(results)
+
+    # Now test that the MATCH functionality works
+    results = []
+    cursor = '0'
+    while cursor != 0:
+        cursor, data = r.sscan(name, cursor, match='*7', count=100)
+        results.extend(data)
+    assert b'sscan-test:7' in results
+    assert b'sscan-test:17' in results
+    assert len(results) == 2
+
+    # Test the match on iterator
+    results = [r for r in r.sscan_iter(name, match='*7')]
+    assert b'sscan-test:7' in results
+    assert b'sscan-test:17' in results
+    assert len(results) == 2
+
+
+def test_hscan(r):
+    # Setup the data
+    name = 'hscan-test'
+    for ix in range(20):
+        k = 'key:%s' % ix
+        v = 'result:%s' % ix
+        r.hset(name, k, v)
+    expected = r.hgetall(name)
+    assert len(expected) == 20  # Ensure we know what we're testing
+
+    # Test that we page through the results and get everything out
+    results = {}
+    cursor = '0'
+    while cursor != 0:
+        cursor, data = r.hscan(name, cursor, count=6)
+        results.update(data)
+    assert expected == results
+
+    # Test the iterator version
+    results = {}
+    for key, val in r.hscan_iter(name, count=6):
+        results[key] = val
+    assert expected == results
+
+    # Now test that the MATCH functionality works
+    results = {}
+    cursor = '0'
+    while cursor != 0:
+        cursor, data = r.hscan(name, cursor, match='*7', count=100)
+        results.update(data)
+    assert b'key:7' in results
+    assert b'key:17' in results
+    assert len(results) == 2
+
+    # Test the match on iterator
+    results = {}
+    for key, val in r.hscan_iter(name, match='*7'):
+        results[key] = val
+    assert b'key:7' in results
+    assert b'key:17' in results
+    assert len(results) == 2
+
+
+def test_zscan(r):
+    # Setup the data
+    name = 'zscan-test'
+    for ix in range(20):
+        zadd(r, name, {'key:%s' % ix: ix})
+    expected = dict(r.zrange(name, 0, -1, withscores=True))
+
+    # Test the basic version
+    results = {}
+    for key, val in r.zscan_iter(name, count=6):
+        results[key] = val
+    assert results == expected
+
+    # Now test that the MATCH functionality works
+    results = {}
+    cursor = '0'
+    while cursor != 0:
+        cursor, data = r.zscan(name, cursor, match='*7', count=6)
+        results.update(data)
+    assert results == {b'key:7': 7.0, b'key:17': 17.0}
+
+
+@pytest.mark.slow
+def test_set_ex_should_expire_value(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    r.set('foo', 'bar', ex=1)
+    sleep(2)
+    assert r.get('foo') is None
+
+
+@pytest.mark.slow
+def test_set_px_should_expire_value(r):
+    r.set('foo', 'bar', px=500)
+    sleep(1.5)
+    assert r.get('foo') is None
+
+
+@pytest.mark.slow
+def test_psetex_expire_value(r):
+    with pytest.raises(ResponseError):
+        r.psetex('foo', 0, 'bar')
+    r.psetex('foo', 500, 'bar')
+    sleep(1.5)
+    assert r.get('foo') is None
+
+
+@pytest.mark.slow
+def test_psetex_expire_value_using_timedelta(r):
+    with pytest.raises(ResponseError):
+        r.psetex('foo', timedelta(seconds=0), 'bar')
+    r.psetex('foo', timedelta(seconds=0.5), 'bar')
+    sleep(1.5)
+    assert r.get('foo') is None
+
+
+@pytest.mark.slow
+def test_expire_should_expire_key(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    r.expire('foo', 1)
+    sleep(1.5)
+    assert r.get('foo') is None
+    assert r.expire('bar', 1) == False
+
+
+def test_expire_should_return_true_for_existing_key(r):
+    r.set('foo', 'bar')
+    assert r.expire('foo', 1) is True
+
+
+def test_expire_should_return_false_for_missing_key(r):
+    assert r.expire('missing', 1) is False
+
+
+@pytest.mark.slow
+def test_expire_should_expire_key_using_timedelta(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    r.expire('foo', timedelta(seconds=1))
+    sleep(1.5)
+    assert r.get('foo') is None
+    assert r.expire('bar', 1) == False
+
+
+@pytest.mark.slow
+def test_expire_should_expire_immediately_with_millisecond_timedelta(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    r.expire('foo', timedelta(milliseconds=750))
+    assert r.get('foo') is None
+    assert r.expire('bar', 1) == False
+
+
+@pytest.mark.slow
+def test_pexpire_should_expire_key(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    r.pexpire('foo', 150)
+    sleep(0.2)
+    assert r.get('foo') is None
+    assert r.pexpire('bar', 1) == False
+
+
+def test_pexpire_should_return_truthy_for_existing_key(r):
+    r.set('foo', 'bar')
+    assert r.pexpire('foo', 1)
+
+
+def test_pexpire_should_return_falsey_for_missing_key(r):
+    assert not r.pexpire('missing', 1)
+
+
+@pytest.mark.slow
+def test_pexpire_should_expire_key_using_timedelta(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    r.pexpire('foo', timedelta(milliseconds=750))
+    sleep(0.5)
+    assert r.get('foo') == b'bar'
+    sleep(0.5)
+    assert r.get('foo') is None
+    assert r.pexpire('bar', 1) == False
+
+
+@pytest.mark.slow
+def test_expireat_should_expire_key_by_datetime(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    r.expireat('foo', datetime.now() + timedelta(seconds=1))
+    sleep(1.5)
+    assert r.get('foo') is None
+    assert r.expireat('bar', datetime.now()) == False
+
+
+@pytest.mark.slow
+def test_expireat_should_expire_key_by_timestamp(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    r.expireat('foo', int(time() + 1))
+    sleep(1.5)
+    assert r.get('foo') is None
+    assert r.expire('bar', 1) == False
+
+
+def test_expireat_should_return_true_for_existing_key(r):
+    r.set('foo', 'bar')
+    assert r.expireat('foo', int(time() + 1)) is True
+
+
+def test_expireat_should_return_false_for_missing_key(r):
+    assert r.expireat('missing', int(time() + 1)) is False
+
+
+@pytest.mark.slow
+def test_pexpireat_should_expire_key_by_datetime(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    r.pexpireat('foo', datetime.now() + timedelta(milliseconds=150))
+    sleep(0.2)
+    assert r.get('foo') is None
+    assert r.pexpireat('bar', datetime.now()) == False
+
+
+@pytest.mark.slow
+def test_pexpireat_should_expire_key_by_timestamp(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    r.pexpireat('foo', int(time() * 1000 + 150))
+    sleep(0.2)
+    assert r.get('foo') is None
+    assert r.expire('bar', 1) == False
+
+
+def test_pexpireat_should_return_true_for_existing_key(r):
+    r.set('foo', 'bar')
+    assert r.pexpireat('foo', int(time() * 1000 + 150))
+
+
+def test_pexpireat_should_return_false_for_missing_key(r):
+    assert not r.pexpireat('missing', int(time() * 1000 + 150))
+
+
+def test_expire_should_not_handle_floating_point_values(r):
+    r.set('foo', 'bar')
+    with pytest.raises(redis.ResponseError, match='value is not an integer or out of range'):
+        r.expire('something_new', 1.2)
+        r.pexpire('something_new', 1000.2)
+        r.expire('some_unused_key', 1.2)
+        r.pexpire('some_unused_key', 1000.2)
+
+
+def test_ttl_should_return_minus_one_for_non_expiring_key(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    assert r.ttl('foo') == -1
+
+
+def test_ttl_should_return_minus_two_for_non_existent_key(r):
+    assert r.get('foo') is None
+    assert r.ttl('foo') == -2
+
+
+def test_pttl_should_return_minus_one_for_non_expiring_key(r):
+    r.set('foo', 'bar')
+    assert r.get('foo') == b'bar'
+    assert r.pttl('foo') == -1
+
+
+def test_pttl_should_return_minus_two_for_non_existent_key(r):
+    assert r.get('foo') is None
+    assert r.pttl('foo') == -2
+
+
+def test_persist(r):
+    r.set('foo', 'bar', ex=20)
+    assert r.persist('foo') == 1
+    assert r.ttl('foo') == -1
+    assert r.persist('foo') == 0
+
+
+def test_set_existing_key_persists(r):
+    r.set('foo', 'bar', ex=20)
+    r.set('foo', 'foo')
+    assert r.ttl('foo') == -1
+
+
+def test_eval_set_value_to_arg(r):
+    r.eval('redis.call("SET", KEYS[1], ARGV[1])', 1, 'foo', 'bar')
+    val = r.get('foo')
+    assert val == b'bar'
+
+
+def test_eval_conditional(r):
+    lua = """
+    local val = redis.call("GET", KEYS[1])
+    if val == ARGV[1] then
+        redis.call("SET", KEYS[1], ARGV[2])
+    else
+        redis.call("SET", KEYS[1], ARGV[1])
+    end
+    """
+    r.eval(lua, 1, 'foo', 'bar', 'baz')
+    val = r.get('foo')
+    assert val == b'bar'
+    r.eval(lua, 1, 'foo', 'bar', 'baz')
+    val = r.get('foo')
+    assert val == b'baz'
+
+
+def test_eval_table(r):
+    lua = """
+    local a = {}
+    a[1] = "foo"
+    a[2] = "bar"
+    a[17] = "baz"
+    return a
+    """
+    val = r.eval(lua, 0)
+    assert val == [b'foo', b'bar']
+
+
+def test_eval_table_with_nil(r):
+    lua = """
+    local a = {}
+    a[1] = "foo"
+    a[2] = nil
+    a[3] = "bar"
+    return a
+    """
+    val = r.eval(lua, 0)
+    assert val == [b'foo']
+
+
+def test_eval_table_with_numbers(r):
+    lua = """
+    local a = {}
+    a[1] = 42
+    return a
+    """
+    val = r.eval(lua, 0)
+    assert val == [42]
+
+
+def test_eval_nested_table(r):
+    lua = """
+    local a = {}
+    a[1] = {}
+    a[1][1] = "foo"
+    return a
+    """
+    val = r.eval(lua, 0)
+    assert val == [[b'foo']]
+
+
+def test_eval_iterate_over_argv(r):
+    lua = """
+    for i, v in ipairs(ARGV) do
+    end
+    return ARGV
+    """
+    val = r.eval(lua, 0, "a", "b", "c")
+    assert val == [b"a", b"b", b"c"]
+
+
+def test_eval_iterate_over_keys(r):
+    lua = """
+    for i, v in ipairs(KEYS) do
+    end
+    return KEYS
+    """
+    val = r.eval(lua, 2, "a", "b", "c")
+    assert val == [b"a", b"b"]
+
+
+def test_eval_mget(r):
+    r.set('foo1', 'bar1')
+    r.set('foo2', 'bar2')
+    val = r.eval('return redis.call("mget", "foo1", "foo2")', 2, 'foo1', 'foo2')
+    assert val == [b'bar1', b'bar2']
+
+
+@redis2_only
+def test_eval_mget_none(r):
+    r.set('foo1', None)
+    r.set('foo2', None)
+    val = r.eval('return redis.call("mget", "foo1", "foo2")', 2, 'foo1', 'foo2')
+    assert val == [b'None', b'None']
+
+
+def test_eval_mget_not_set(r):
+    val = r.eval('return redis.call("mget", "foo1", "foo2")', 2, 'foo1', 'foo2')
+    assert val == [None, None]
+
+
+def test_eval_hgetall(r):
+    r.hset('foo', 'k1', 'bar')
+    r.hset('foo', 'k2', 'baz')
+    val = r.eval('return redis.call("hgetall", "foo")', 1, 'foo')
+    sorted_val = sorted([val[:2], val[2:]])
+    assert sorted_val == [[b'k1', b'bar'], [b'k2', b'baz']]
+
+
+def test_eval_hgetall_iterate(r):
+    r.hset('foo', 'k1', 'bar')
+    r.hset('foo', 'k2', 'baz')
+    lua = """
+    local result = redis.call("hgetall", "foo")
+    for i, v in ipairs(result) do
+    end
+    return result
+    """
+    val = r.eval(lua, 1, 'foo')
+    sorted_val = sorted([val[:2], val[2:]])
+    assert sorted_val == [[b'k1', b'bar'], [b'k2', b'baz']]
+
+
+@redis2_only
+def test_eval_list_with_nil(r):
+    r.lpush('foo', 'bar')
+    r.lpush('foo', None)
+    r.lpush('foo', 'baz')
+    val = r.eval('return redis.call("lrange", KEYS[1], 0, 2)', 1, 'foo')
+    assert val == [b'baz', b'None', b'bar']
+
+
+def test_eval_invalid_command(r):
+    with pytest.raises(ResponseError):
+        r.eval(
+            'return redis.call("FOO")',
+            0
+        )
+
+
+def test_eval_syntax_error(r):
+    with pytest.raises(ResponseError):
+        r.eval('return "', 0)
+
+
+def test_eval_runtime_error(r):
+    with pytest.raises(ResponseError):
+        r.eval('error("CRASH")', 0)
+
+
+def test_eval_more_keys_than_args(r):
+    with pytest.raises(ResponseError):
+        r.eval('return 1', 42)
+
+
+def test_eval_numkeys_float_string(r):
+    with pytest.raises(ResponseError):
+        r.eval('return KEYS[1]', '0.7', 'foo')
+
+
+def test_eval_numkeys_integer_string(r):
+    val = r.eval('return KEYS[1]', "1", "foo")
+    assert val == b'foo'
+
+
+def test_eval_numkeys_negative(r):
+    with pytest.raises(ResponseError):
+        r.eval('return KEYS[1]', -1, "foo")
+
+
+def test_eval_numkeys_float(r):
+    with pytest.raises(ResponseError):
+        r.eval('return KEYS[1]', 0.7, "foo")
+
+
+def test_eval_global_variable(r):
+    # Redis doesn't allow script to define global variables
+    with pytest.raises(ResponseError):
+        r.eval('a=10', 0)
+
+
+def test_eval_global_and_return_ok(r):
+    # Redis doesn't allow script to define global variables
+    with pytest.raises(ResponseError):
+        r.eval(
+            '''
+            a=10
+            return redis.status_reply("Everything is awesome")
+            ''',
+            0
+        )
+
+
+def test_eval_convert_number(r):
+    # Redis forces all Lua numbers to integer
+    val = r.eval('return 3.2', 0)
+    assert val == 3
+    val = r.eval('return 3.8', 0)
+    assert val == 3
+    val = r.eval('return -3.8', 0)
+    assert val == -3
+
+
+def test_eval_convert_bool(r):
+    # Redis converts true to 1 and false to nil (which redis-py converts to None)
+    assert r.eval('return false', 0) is None
+    val = r.eval('return true', 0)
+    assert val == 1
+    assert not isinstance(val, bool)
+
+
+def test_eval_call_bool(r):
+    # Redis doesn't allow Lua bools to be passed to [p]call
+    with pytest.raises(redis.ResponseError,
+                       match=r'Lua redis\(\) command arguments must be strings or integers'):
+        r.eval('return redis.call("SET", KEYS[1], true)', 1, "testkey")
+
+
+@redis2_only
+def test_eval_none_arg(r):
+    val = r.eval('return ARGV[1] == "None"', 0, None)
+    assert val
+
+
+def test_eval_return_error(r):
+    with pytest.raises(redis.ResponseError, match='Testing') as exc_info:
+        r.eval('return {err="Testing"}', 0)
+    assert isinstance(exc_info.value.args[0], str)
+    with pytest.raises(redis.ResponseError, match='Testing') as exc_info:
+        r.eval('return redis.error_reply("Testing")', 0)
+    assert isinstance(exc_info.value.args[0], str)
+
+
+def test_eval_return_redis_error(r):
+    with pytest.raises(redis.ResponseError) as exc_info:
+        r.eval('return redis.pcall("BADCOMMAND")', 0)
+    assert isinstance(exc_info.value.args[0], str)
+
+
+def test_eval_return_ok(r):
+    val = r.eval('return {ok="Testing"}', 0)
+    assert val == b'Testing'
+    val = r.eval('return redis.status_reply("Testing")', 0)
+    assert val == b'Testing'
+
+
+def test_eval_return_ok_nested(r):
+    val = r.eval(
+        '''
+        local a = {}
+        a[1] = {ok="Testing"}
+        return a
+        ''',
+        0
+    )
+    assert val == [b'Testing']
+
+
+def test_eval_return_ok_wrong_type(r):
+    with pytest.raises(redis.ResponseError):
+        r.eval('return redis.status_reply(123)', 0)
+
+
+def test_eval_pcall(r):
+    val = r.eval(
+        '''
+        local a = {}
+        a[1] = redis.pcall("foo")
+        return a
+        ''',
+        0
+    )
+    assert isinstance(val, list)
+    assert len(val) == 1
+    assert isinstance(val[0], ResponseError)
+
+
+def test_eval_pcall_return_value(r):
+    with pytest.raises(ResponseError):
+        r.eval('return redis.pcall("foo")', 0)
+
+
+def test_eval_delete(r):
+    r.set('foo', 'bar')
+    val = r.get('foo')
+    assert val == b'bar'
+    val = r.eval('redis.call("DEL", KEYS[1])', 1, 'foo')
+    assert val is None
+
+
+def test_eval_exists(r):
+    val = r.eval('return redis.call("exists", KEYS[1]) == 0', 1, 'foo')
+    assert val == 1
+
+
+def test_eval_flushdb(r):
+    r.set('foo', 'bar')
+    val = r.eval(
+        '''
+        local value = redis.call("FLUSHDB");
+        return type(value) == "table" and value.ok == "OK";
+        ''', 0
+    )
+    assert val == 1
+
+
+def test_eval_flushall(r, create_redis):
+    r1 = create_redis(db=0)
+    r2 = create_redis(db=1)
+
+    r1['r1'] = 'r1'
+    r2['r2'] = 'r2'
+
+    val = r.eval(
+        '''
+        local value = redis.call("FLUSHALL");
+        return type(value) == "table" and value.ok == "OK";
+        ''', 0
+    )
+
+    assert val == 1
+    assert 'r1' not in r1
+    assert 'r2' not in r2
+
+
+def test_eval_incrbyfloat(r):
+    r.set('foo', 0.5)
+    val = r.eval(
+        '''
+        local value = redis.call("INCRBYFLOAT", KEYS[1], 2.0);
+        return type(value) == "string" and tonumber(value) == 2.5;
+        ''', 1, 'foo'
+    )
+    assert val == 1
+
+
+def test_eval_lrange(r):
+    r.rpush('foo', 'a', 'b')
+    val = r.eval(
+        '''
+        local value = redis.call("LRANGE", KEYS[1], 0, -1);
+        return type(value) == "table" and value[1] == "a" and value[2] == "b";
+        ''', 1, 'foo'
+    )
+    assert val == 1
+
+
+def test_eval_ltrim(r):
+    r.rpush('foo', 'a', 'b', 'c', 'd')
+    val = r.eval(
+        '''
+        local value = redis.call("LTRIM", KEYS[1], 1, 2);
+        return type(value) == "table" and value.ok == "OK";
+        ''', 1, 'foo'
+    )
+    assert val == 1
+    assert r.lrange('foo', 0, -1) == [b'b', b'c']
+
+
+def test_eval_lset(r):
+    r.rpush('foo', 'a', 'b')
+    val = r.eval(
+        '''
+        local value = redis.call("LSET", KEYS[1], 0, "z");
+        return type(value) == "table" and value.ok == "OK";
+        ''', 1, 'foo'
+    )
+    assert val == 1
+    assert r.lrange('foo', 0, -1) == [b'z', b'b']
+
+
+def test_eval_sdiff(r):
+    r.sadd('foo', 'a', 'b', 'c', 'f', 'e', 'd')
+    r.sadd('bar', 'b')
+    val = r.eval(
+        '''
+        local value = redis.call("SDIFF", KEYS[1], KEYS[2]);
+        if type(value) ~= "table" then
+            return redis.error_reply(type(value) .. ", should be table");
+        else
+            return value;
+        end
+        ''', 2, 'foo', 'bar')
+    # Note: while fakeredis sorts the result when using Lua, this isn't
+    # actually part of the redis contract (see
+    # https://github.com/antirez/redis/issues/5538), and for Redis 5 we
+    # need to sort val to pass the test.
+    assert sorted(val) == [b'a', b'c', b'd', b'e', b'f']
+
+
+def test_script(r):
+    script = r.register_script('return ARGV[1]')
+    result = script(args=[42])
+    assert result == b'42'
+
+
+@pytest.mark.parametrize('create_redis', ['FakeStrictRedis'], indirect=True)
+def test_lua_log(r, caplog):
+    logger = fakeredis._server.LOGGER
+    script = """
+        redis.log(redis.LOG_DEBUG, "debug")
+        redis.log(redis.LOG_VERBOSE, "verbose")
+        redis.log(redis.LOG_NOTICE, "notice")
+        redis.log(redis.LOG_WARNING, "warning")
+    """
+    script = r.register_script(script)
+    with caplog.at_level('DEBUG'):
+        script()
+    assert caplog.record_tuples == [
+        (logger.name, logging.DEBUG, 'debug'),
+        (logger.name, logging.INFO, 'verbose'),
+        (logger.name, logging.INFO, 'notice'),
+        (logger.name, logging.WARNING, 'warning')
+    ]
+
+
+def test_lua_log_no_message(r):
+    script = "redis.log(redis.LOG_DEBUG)"
+    script = r.register_script(script)
+    with pytest.raises(redis.ResponseError):
+        script()
+
+
+@pytest.mark.parametrize('create_redis', ['FakeStrictRedis'], indirect=True)
+def test_lua_log_different_types(r, caplog):
+    logger = fakeredis._server.LOGGER
+    script = "redis.log(redis.LOG_DEBUG, 'string', 1, true, 3.14, 'string')"
+    script = r.register_script(script)
+    with caplog.at_level('DEBUG'):
+        script()
+    assert caplog.record_tuples == [
+        (logger.name, logging.DEBUG, 'string 1 3.14 string')
+    ]
+
+
+def test_lua_log_wrong_level(r):
+    script = "redis.log(10, 'string')"
+    script = r.register_script(script)
+    with pytest.raises(redis.ResponseError):
+        script()
+
+
+@pytest.mark.parametrize('create_redis', ['FakeStrictRedis'], indirect=True)
+def test_lua_log_defined_vars(r, caplog):
+    logger = fakeredis._server.LOGGER
+    script = """
+        local var='string'
+        redis.log(redis.LOG_DEBUG, var)
+    """
+    script = r.register_script(script)
+    with caplog.at_level('DEBUG'):
+        script()
+    assert caplog.record_tuples == [(logger.name, logging.DEBUG, 'string')]
+
+
+@redis3_only
+def test_unlink(r):
+    r.set('foo', 'bar')
+    r.unlink('foo')
+    assert r.get('foo') is None
+
+
+@redis2_only
+@pytest.mark.parametrize('create_redis', ['FakeRedis', 'Redis'], indirect=True)
+class TestLegacy:
+    def test_setex(self, r):
+        assert r.setex('foo', 'bar', 100) == True
+        assert r.get('foo') == b'bar'
+
+    def test_setex_using_timedelta(self, r):
+        assert r.setex('foo', 'bar', timedelta(seconds=100)) == True
+        assert r.get('foo') == b'bar'
+
+    def test_lrem_positive_count(self, r):
+        r.lpush('foo', 'same')
+        r.lpush('foo', 'same')
+        r.lpush('foo', 'different')
+        r.lrem('foo', 'same', 2)
+        assert r.lrange('foo', 0, -1) == [b'different']
+
+    def test_lrem_negative_count(self, r):
+        r.lpush('foo', 'removeme')
+        r.lpush('foo', 'three')
+        r.lpush('foo', 'two')
+        r.lpush('foo', 'one')
+        r.lpush('foo', 'removeme')
+        r.lrem('foo', 'removeme', -1)
         # Should remove it from the end of the list,
         # leaving the 'removeme' from the front of the list alone.
-        assert self.redis.lrange('foo', 0, -1) == [b'removeme', b'one', b'two', b'three']
+        assert r.lrange('foo', 0, -1) == [b'removeme', b'one', b'two', b'three']
 
-    def test_lrem_zero_count(self):
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'one')
-        self.redis.lrem('foo', 'one')
-        assert self.redis.lrange('foo', 0, -1) == []
+    def test_lrem_zero_count(self, r):
+        r.lpush('foo', 'one')
+        r.lpush('foo', 'one')
+        r.lpush('foo', 'one')
+        r.lrem('foo', 'one')
+        assert r.lrange('foo', 0, -1) == []
 
-    def test_lrem_default_value(self):
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'one')
-        self.redis.lpush('foo', 'one')
-        self.redis.lrem('foo', 'one')
-        assert self.redis.lrange('foo', 0, -1) == []
+    def test_lrem_default_value(self, r):
+        r.lpush('foo', 'one')
+        r.lpush('foo', 'one')
+        r.lpush('foo', 'one')
+        r.lrem('foo', 'one')
+        assert r.lrange('foo', 0, -1) == []
 
-    def test_lrem_does_not_exist(self):
-        self.redis.lpush('foo', 'one')
-        self.redis.lrem('foo', 'one')
+    def test_lrem_does_not_exist(self, r):
+        r.lpush('foo', 'one')
+        r.lrem('foo', 'one')
         # These should be noops.
-        self.redis.lrem('foo', 'one', -2)
-        self.redis.lrem('foo', 'one', 2)
+        r.lrem('foo', 'one', -2)
+        r.lrem('foo', 'one', 2)
 
-    def test_lrem_return_value(self):
-        self.redis.lpush('foo', 'one')
-        count = self.redis.lrem('foo', 'one', 0)
+    def test_lrem_return_value(self, r):
+        r.lpush('foo', 'one')
+        count = r.lrem('foo', 'one', 0)
         assert count == 1
-        assert self.redis.lrem('foo', 'one') == 0
+        assert r.lrem('foo', 'one') == 0
 
-    def test_zadd_deprecated(self):
-        result = self.redis.zadd('foo', 'one', 1)
+    def test_zadd_deprecated(self, r):
+        result = r.zadd('foo', 'one', 1)
         assert result == 1
-        assert self.redis.zrange('foo', 0, -1) == [b'one']
+        assert r.zrange('foo', 0, -1) == [b'one']
 
-    def test_zadd_missing_required_params(self):
+    def test_zadd_missing_required_params(self, r):
         with pytest.raises(redis.RedisError):
             # Missing the 'score' param.
-            self.redis.zadd('foo', 'one')
+            r.zadd('foo', 'one')
         with pytest.raises(redis.RedisError):
             # Missing the 'value' param.
-            self.redis.zadd('foo', None, score=1)
+            r.zadd('foo', None, score=1)
         with pytest.raises(redis.RedisError):
-            self.redis.zadd('foo')
+            r.zadd('foo')
 
-    def test_zadd_with_single_keypair(self):
-        result = self.redis.zadd('foo', bar=1)
+    def test_zadd_with_single_keypair(self, r):
+        result = r.zadd('foo', bar=1)
         assert result == 1
-        assert self.redis.zrange('foo', 0, -1) == [b'bar']
+        assert r.zrange('foo', 0, -1) == [b'bar']
 
-    def test_zadd_with_multiple_keypairs(self):
-        result = self.redis.zadd('foo', bar=1, baz=9)
+    def test_zadd_with_multiple_keypairs(self, r):
+        result = r.zadd('foo', bar=1, baz=9)
         assert result == 2
-        assert self.redis.zrange('foo', 0, -1) == [b'bar', b'baz']
+        assert r.zrange('foo', 0, -1) == [b'bar', b'baz']
 
-    def test_zadd_with_name_is_non_string(self):
-        result = self.redis.zadd('foo', 1, 9)
+    def test_zadd_with_name_is_non_string(self, r):
+        result = r.zadd('foo', 1, 9)
         assert result == 1
-        assert self.redis.zrange('foo', 0, -1) == [b'1']
+        assert r.zrange('foo', 0, -1) == [b'1']
 
-    def test_ttl_should_return_none_for_non_expiring_key(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        assert self.redis.ttl('foo') is None
+    def test_ttl_should_return_none_for_non_expiring_key(self, r):
+        r.set('foo', 'bar')
+        assert r.get('foo') == b'bar'
+        assert r.ttl('foo') is None
 
-    def test_ttl_should_return_value_for_expiring_key(self):
-        self.redis.set('foo', 'bar')
-        self.redis.expire('foo', 1)
-        assert self.redis.ttl('foo') == 1
-        self.redis.expire('foo', 2)
-        assert self.redis.ttl('foo') == 2
+    def test_ttl_should_return_value_for_expiring_key(self, r):
+        r.set('foo', 'bar')
+        r.expire('foo', 1)
+        assert r.ttl('foo') == 1
+        r.expire('foo', 2)
+        assert r.ttl('foo') == 2
         # See https://github.com/antirez/redis/blob/unstable/src/db.c#L632
         ttl = 1000000000
-        self.redis.expire('foo', ttl)
-        assert self.redis.ttl('foo') == ttl
+        r.expire('foo', ttl)
+        assert r.ttl('foo') == ttl
 
-    def test_pttl_should_return_none_for_non_expiring_key(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == b'bar'
-        assert self.redis.pttl('foo') is None
+    def test_pttl_should_return_none_for_non_expiring_key(self, r):
+        r.set('foo', 'bar')
+        assert r.get('foo') == b'bar'
+        assert r.pttl('foo') is None
 
-    def test_pttl_should_return_value_for_expiring_key(self):
+    def test_pttl_should_return_value_for_expiring_key(self, r):
         d = 100
-        self.redis.set('foo', 'bar')
-        self.redis.expire('foo', 1)
-        assert 1000 - d <= self.redis.pttl('foo') <= 1000
-        self.redis.expire('foo', 2)
-        assert 2000 - d <= self.redis.pttl('foo') <= 2000
+        r.set('foo', 'bar')
+        r.expire('foo', 1)
+        assert 1000 - d <= r.pttl('foo') <= 1000
+        r.expire('foo', 2)
+        assert 2000 - d <= r.pttl('foo') <= 2000
         ttl = 1000000000
         # See https://github.com/antirez/redis/blob/unstable/src/db.c#L632
-        self.redis.expire('foo', ttl)
-        assert ttl * 1000 - d <= self.redis.pttl('foo') <= ttl * 1000
+        r.expire('foo', ttl)
+        assert ttl * 1000 - d <= r.pttl('foo') <= ttl * 1000
 
-    def test_expire_should_not_handle_floating_point_values(self):
-        self.redis.set('foo', 'bar')
+    def test_expire_should_not_handle_floating_point_values(self, r):
+        r.set('foo', 'bar')
         with pytest.raises(redis.ResponseError, match='value is not an integer or out of range'):
-            self.redis.expire('something_new', 1.2)
-            self.redis.pexpire('something_new', 1000.2)
-            self.redis.expire('some_unused_key', 1.2)
-            self.redis.pexpire('some_unused_key', 1000.2)
+            r.expire('something_new', 1.2)
+            r.pexpire('something_new', 1000.2)
+            r.expire('some_unused_key', 1.2)
+            r.pexpire('some_unused_key', 1000.2)
 
-    def test_lock(self):
-        lock = self.redis.lock('foo')
+    def test_lock(self, r):
+        lock = r.lock('foo')
         assert lock.acquire()
-        assert self.redis.exists('foo')
+        assert r.exists('foo')
         lock.release()
-        assert not self.redis.exists('foo')
-        with self.redis.lock('bar'):
-            assert self.redis.exists('bar')
-        assert not self.redis.exists('bar')
+        assert not r.exists('foo')
+        with r.lock('bar'):
+            assert r.exists('bar')
+        assert not r.exists('bar')
 
-    def test_unlock_without_lock(self):
-        lock = self.redis.lock('foo')
+    def test_unlock_without_lock(self, r):
+        lock = r.lock('foo')
         with pytest.raises(redis.exceptions.LockError):
             lock.release()
 
     @pytest.mark.slow
-    def test_unlock_expired(self):
-        lock = self.redis.lock('foo', timeout=0.01, sleep=0.001)
+    def test_unlock_expired(self, r):
+        lock = r.lock('foo', timeout=0.01, sleep=0.001)
         assert lock.acquire()
         sleep(0.1)
         with pytest.raises(redis.exceptions.LockError):
             lock.release()
 
     @pytest.mark.slow
-    def test_lock_blocking_timeout(self):
-        lock = self.redis.lock('foo')
+    def test_lock_blocking_timeout(self, r):
+        lock = r.lock('foo')
         assert lock.acquire()
-        lock2 = self.redis.lock('foo')
+        lock2 = r.lock('foo')
         assert not lock2.acquire(blocking_timeout=1)
 
-    def test_lock_nonblocking(self):
-        lock = self.redis.lock('foo')
+    def test_lock_nonblocking(self, r):
+        lock = r.lock('foo')
         assert lock.acquire()
-        lock2 = self.redis.lock('foo')
+        lock2 = r.lock('foo')
         assert not lock2.acquire(blocking=False)
 
-    def test_lock_twice(self):
-        lock = self.redis.lock('foo')
+    def test_lock_twice(self, r):
+        lock = r.lock('foo')
         assert lock.acquire(blocking=False)
         assert not lock.acquire(blocking=False)
 
-    def test_acquiring_lock_different_lock_release(self):
-        lock1 = self.redis.lock('foo')
-        lock2 = self.redis.lock('foo')
+    def test_acquiring_lock_different_lock_release(self, r):
+        lock1 = r.lock('foo')
+        lock2 = r.lock('foo')
         assert lock1.acquire(blocking=False)
         assert not lock2.acquire(blocking=False)
 
@@ -4275,94 +4737,54 @@ class TestFakeRedis:
         assert lock2.acquire(blocking=False)
         assert not lock1.acquire(blocking=False)
 
-    def test_lock_extend(self):
-        lock = self.redis.lock('foo', timeout=2)
+    def test_lock_extend(self, r):
+        lock = r.lock('foo', timeout=2)
         lock.acquire()
         lock.extend(3)
-        ttl = int(self.redis.pttl('foo'))
+        ttl = int(r.pttl('foo'))
         assert 4000 < ttl <= 5000
 
-    def test_lock_extend_exceptions(self):
-        lock1 = self.redis.lock('foo', timeout=2)
+    def test_lock_extend_exceptions(self, r):
+        lock1 = r.lock('foo', timeout=2)
         with pytest.raises(redis.exceptions.LockError):
             lock1.extend(3)
-        lock2 = self.redis.lock('foo')
+        lock2 = r.lock('foo')
         lock2.acquire()
         with pytest.raises(redis.exceptions.LockError):
             lock2.extend(3)  # Cannot extend a lock with no timeout
 
     @pytest.mark.slow
-    def test_lock_extend_expired(self):
-        lock = self.redis.lock('foo', timeout=0.01, sleep=0.001)
+    def test_lock_extend_expired(self, r):
+        lock = r.lock('foo', timeout=0.01, sleep=0.001)
         lock.acquire()
         sleep(0.1)
         with pytest.raises(redis.exceptions.LockError):
             lock.extend(3)
 
 
-class DecodeMixin:
-    decode_responses = True
+@pytest.mark.decode_responses
+class TestDecodeResponses:
+    def test_decode_str(self, r):
+        r.set('foo', 'bar')
+        assert r.get('foo') == 'bar'
 
-    def test_decode_str(self):
-        self.redis.set('foo', 'bar')
-        assert self.redis.get('foo') == 'bar'
+    def test_decode_set(self, r):
+        r.sadd('foo', 'member1')
+        assert r.smembers('foo') == {'member1'}
 
-    def test_decode_set(self):
-        self.redis.sadd('foo', 'member1')
-        assert self.redis.smembers('foo') == {'member1'}
+    def test_decode_list(self, r):
+        r.rpush('foo', 'a', 'b')
+        assert r.lrange('foo', 0, -1) == ['a', 'b']
 
-    def test_decode_list(self):
-        self.redis.rpush('foo', 'a', 'b')
-        assert self.redis.lrange('foo', 0, -1) == ['a', 'b']
+    def test_decode_dict(self, r):
+        r.hset('foo', 'key', 'value')
+        assert r.hgetall('foo') == {'key': 'value'}
 
-    def test_decode_dict(self):
-        self.redis.hset('foo', 'key', 'value')
-        assert self.redis.hgetall('foo') == {'key': 'value'}
-
-    def test_decode_error(self):
-        self.redis.set('foo', 'bar')
+    def test_decode_error(self, r):
+        r.set('foo', 'bar')
         with pytest.raises(ResponseError) as exc_info:
-            self.redis.hset('foo', 'bar', 'baz')
+            r.hset('foo', 'bar', 'baz')
         assert isinstance(exc_info.value.args[0], str)
-
-
-class TestFakeStrictRedisBase:
-    def setup(self):
-        self.server = fakeredis.FakeServer()
-        self.redis = self.create_redis()
-        self.redis.flushall()
-
-    def teardown(self):
-        self.redis.flushall()
-        del self.redis
-
-
-class TestFakeStrictRedis(NoDecodeMixin, TestFakeStrictRedisBase):
-    def create_redis(self, db=0):
-        return fakeredis.FakeStrictRedis(db=db, server=self.server)
-
-
-class TestFakeStrictRedisDecodeResponses(DecodeMixin, TestFakeStrictRedisBase):
-    def create_redis(self, db=0):
-        return fakeredis.FakeStrictRedis(db=db, decode_responses=True, server=self.server)
-
-
-@redis_must_be_running
-class TestRealRedis(TestFakeRedis):
-    def create_redis(self, db=0):
-        return redis.Redis('localhost', port=6379, db=db)
-
-
-@redis_must_be_running
-class TestRealStrictRedis(TestFakeStrictRedis):
-    def create_redis(self, db=0):
-        return redis.StrictRedis('localhost', port=6379, db=db)
-
-
-@redis_must_be_running
-class TestRealStrictRedisDecodeResponses(TestFakeStrictRedisDecodeResponses):
-    def create_redis(self, db=0):
-        return redis.StrictRedis('localhost', port=6379, db=db, decode_responses=True)
 
 
 class TestInitArgs:
@@ -4450,420 +4872,406 @@ class TestInitArgs:
         assert 'db=11' in rep
 
 
+@pytest.mark.disconnected
+@pytest.mark.parametrize('create_redis', ['FakeStrictRedis'], indirect=True)
 class TestFakeStrictRedisConnectionErrors:
-    # Wrap some redis commands to abstract differences between redis-py 2 and 3.
-    def zadd(self, key, d):
-        if REDIS3:
-            return self.redis.zadd(key, d)
-        else:
-            return self.redis.zadd(key, **d)
-
-    def create_redis(self):
-        return fakeredis.FakeStrictRedis(db=0, connected=False)
-
-    def setup(self):
-        self.redis = self.create_redis()
-
-    def teardown(self):
-        del self.redis
-
-    def test_flushdb(self):
+    def test_flushdb(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.flushdb()
+            r.flushdb()
 
-    def test_flushall(self):
+    def test_flushall(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.flushall()
+            r.flushall()
 
-    def test_append(self):
+    def test_append(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.append('key', 'value')
+            r.append('key', 'value')
 
-    def test_bitcount(self):
+    def test_bitcount(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.bitcount('key', 0, 20)
+            r.bitcount('key', 0, 20)
 
-    def test_decr(self):
+    def test_decr(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.decr('key', 2)
+            r.decr('key', 2)
 
-    def test_exists(self):
+    def test_exists(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.exists('key')
+            r.exists('key')
 
-    def test_expire(self):
+    def test_expire(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.expire('key', 20)
+            r.expire('key', 20)
 
-    def test_pexpire(self):
+    def test_pexpire(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.pexpire('key', 20)
+            r.pexpire('key', 20)
 
-    def test_echo(self):
+    def test_echo(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.echo('value')
+            r.echo('value')
 
-    def test_get(self):
+    def test_get(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.get('key')
+            r.get('key')
 
-    def test_getbit(self):
+    def test_getbit(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.getbit('key', 2)
+            r.getbit('key', 2)
 
-    def test_getset(self):
+    def test_getset(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.getset('key', 'value')
+            r.getset('key', 'value')
 
-    def test_incr(self):
+    def test_incr(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.incr('key')
+            r.incr('key')
 
-    def test_incrby(self):
+    def test_incrby(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.incrby('key')
+            r.incrby('key')
 
-    def test_ncrbyfloat(self):
+    def test_ncrbyfloat(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.incrbyfloat('key')
+            r.incrbyfloat('key')
 
-    def test_keys(self):
+    def test_keys(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.keys()
+            r.keys()
 
-    def test_mget(self):
+    def test_mget(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.mget(['key1', 'key2'])
+            r.mget(['key1', 'key2'])
 
-    def test_mset(self):
+    def test_mset(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.mset({'key': 'value'})
+            r.mset({'key': 'value'})
 
-    def test_msetnx(self):
+    def test_msetnx(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.msetnx({'key': 'value'})
+            r.msetnx({'key': 'value'})
 
-    def test_persist(self):
+    def test_persist(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.persist('key')
+            r.persist('key')
 
-    def test_rename(self):
-        server = self.redis.connection_pool.connection_kwargs['server']
+    def test_rename(self, r):
+        server = r.connection_pool.connection_kwargs['server']
         server.connected = True
-        self.redis.set('key1', 'value')
+        r.set('key1', 'value')
         server.connected = False
         with pytest.raises(redis.ConnectionError):
-            self.redis.rename('key1', 'key2')
+            r.rename('key1', 'key2')
         server.connected = True
-        assert self.redis.exists('key1')
+        assert r.exists('key1')
 
-    def test_eval(self):
+    def test_eval(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.eval('', 0)
+            r.eval('', 0)
 
-    def test_lpush(self):
+    def test_lpush(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.lpush('name', 1, 2)
+            r.lpush('name', 1, 2)
 
-    def test_lrange(self):
+    def test_lrange(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.lrange('name', 1, 5)
+            r.lrange('name', 1, 5)
 
-    def test_llen(self):
+    def test_llen(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.llen('name')
+            r.llen('name')
 
-    def test_lrem(self):
+    def test_lrem(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.lrem('name', 2, 2)
+            r.lrem('name', 2, 2)
 
-    def test_rpush(self):
+    def test_rpush(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.rpush('name', 1)
+            r.rpush('name', 1)
 
-    def test_lpop(self):
+    def test_lpop(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.lpop('name')
+            r.lpop('name')
 
-    def test_lset(self):
+    def test_lset(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.lset('name', 1, 4)
+            r.lset('name', 1, 4)
 
-    def test_rpushx(self):
+    def test_rpushx(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.rpushx('name', 1)
+            r.rpushx('name', 1)
 
-    def test_ltrim(self):
+    def test_ltrim(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.ltrim('name', 1, 4)
+            r.ltrim('name', 1, 4)
 
-    def test_lindex(self):
+    def test_lindex(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.lindex('name', 1)
+            r.lindex('name', 1)
 
-    def test_lpushx(self):
+    def test_lpushx(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.lpushx('name', 1)
+            r.lpushx('name', 1)
 
-    def test_rpop(self):
+    def test_rpop(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.rpop('name')
+            r.rpop('name')
 
-    def test_linsert(self):
+    def test_linsert(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.linsert('name', 'where', 'refvalue', 'value')
+            r.linsert('name', 'where', 'refvalue', 'value')
 
-    def test_rpoplpush(self):
+    def test_rpoplpush(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.rpoplpush('src', 'dst')
+            r.rpoplpush('src', 'dst')
 
-    def test_blpop(self):
+    def test_blpop(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.blpop('keys')
+            r.blpop('keys')
 
-    def test_brpop(self):
+    def test_brpop(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.brpop('keys')
+            r.brpop('keys')
 
-    def test_brpoplpush(self):
+    def test_brpoplpush(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.brpoplpush('src', 'dst')
+            r.brpoplpush('src', 'dst')
 
-    def test_hdel(self):
+    def test_hdel(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hdel('name')
+            r.hdel('name')
 
-    def test_hexists(self):
+    def test_hexists(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hexists('name', 'key')
+            r.hexists('name', 'key')
 
-    def test_hget(self):
+    def test_hget(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hget('name', 'key')
+            r.hget('name', 'key')
 
-    def test_hgetall(self):
+    def test_hgetall(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hgetall('name')
+            r.hgetall('name')
 
-    def test_hincrby(self):
+    def test_hincrby(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hincrby('name', 'key')
+            r.hincrby('name', 'key')
 
-    def test_hincrbyfloat(self):
+    def test_hincrbyfloat(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hincrbyfloat('name', 'key')
+            r.hincrbyfloat('name', 'key')
 
-    def test_hkeys(self):
+    def test_hkeys(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hkeys('name')
+            r.hkeys('name')
 
-    def test_hlen(self):
+    def test_hlen(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hlen('name')
+            r.hlen('name')
 
-    def test_hset(self):
+    def test_hset(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hset('name', 'key', 1)
+            r.hset('name', 'key', 1)
 
-    def test_hsetnx(self):
+    def test_hsetnx(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hsetnx('name', 'key', 2)
+            r.hsetnx('name', 'key', 2)
 
-    def test_hmset(self):
+    def test_hmset(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hmset('name', {'key': 1})
+            r.hmset('name', {'key': 1})
 
-    def test_hmget(self):
+    def test_hmget(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hmget('name', ['a', 'b'])
+            r.hmget('name', ['a', 'b'])
 
-    def test_hvals(self):
+    def test_hvals(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hvals('name')
+            r.hvals('name')
 
-    def test_sadd(self):
+    def test_sadd(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.sadd('name', 1, 2)
+            r.sadd('name', 1, 2)
 
-    def test_scard(self):
+    def test_scard(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.scard('name')
+            r.scard('name')
 
-    def test_sdiff(self):
+    def test_sdiff(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.sdiff(['a', 'b'])
+            r.sdiff(['a', 'b'])
 
-    def test_sdiffstore(self):
+    def test_sdiffstore(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.sdiffstore('dest', ['a', 'b'])
+            r.sdiffstore('dest', ['a', 'b'])
 
-    def test_sinter(self):
+    def test_sinter(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.sinter(['a', 'b'])
+            r.sinter(['a', 'b'])
 
-    def test_sinterstore(self):
+    def test_sinterstore(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.sinterstore('dest', ['a', 'b'])
+            r.sinterstore('dest', ['a', 'b'])
 
-    def test_sismember(self):
+    def test_sismember(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.sismember('name', 20)
+            r.sismember('name', 20)
 
-    def test_smembers(self):
+    def test_smembers(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.smembers('name')
+            r.smembers('name')
 
-    def test_smove(self):
+    def test_smove(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.smove('src', 'dest', 20)
+            r.smove('src', 'dest', 20)
 
-    def test_spop(self):
+    def test_spop(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.spop('name')
+            r.spop('name')
 
-    def test_srandmember(self):
+    def test_srandmember(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.srandmember('name')
+            r.srandmember('name')
 
-    def test_srem(self):
+    def test_srem(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.srem('name')
+            r.srem('name')
 
-    def test_sunion(self):
+    def test_sunion(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.sunion(['a', 'b'])
+            r.sunion(['a', 'b'])
 
-    def test_sunionstore(self):
+    def test_sunionstore(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.sunionstore('dest', ['a', 'b'])
+            r.sunionstore('dest', ['a', 'b'])
 
-    def test_zadd(self):
+    def test_zadd(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.zadd('name', {'key': 'value'})
+            zadd(r, 'name', {'key': 'value'})
 
-    def test_zcard(self):
+    def test_zcard(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zcard('name')
+            r.zcard('name')
 
-    def test_zcount(self):
+    def test_zcount(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zcount('name', 1, 5)
+            r.zcount('name', 1, 5)
 
-    def test_zincrby(self):
+    def test_zincrby(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zincrby('name', 1, 1)
+            r.zincrby('name', 1, 1)
 
-    def test_zinterstore(self):
+    def test_zinterstore(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zinterstore('dest', ['a', 'b'])
+            r.zinterstore('dest', ['a', 'b'])
 
-    def test_zrange(self):
+    def test_zrange(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zrange('name', 1, 5)
+            r.zrange('name', 1, 5)
 
-    def test_zrangebyscore(self):
+    def test_zrangebyscore(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zrangebyscore('name', 1, 5)
+            r.zrangebyscore('name', 1, 5)
 
-    def test_rangebylex(self):
+    def test_rangebylex(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zrangebylex('name', 1, 4)
+            r.zrangebylex('name', 1, 4)
 
-    def test_zrem(self):
+    def test_zrem(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zrem('name', 'value')
+            r.zrem('name', 'value')
 
-    def test_zremrangebyrank(self):
+    def test_zremrangebyrank(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zremrangebyrank('name', 1, 5)
+            r.zremrangebyrank('name', 1, 5)
 
-    def test_zremrangebyscore(self):
+    def test_zremrangebyscore(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zremrangebyscore('name', 1, 5)
+            r.zremrangebyscore('name', 1, 5)
 
-    def test_zremrangebylex(self):
+    def test_zremrangebylex(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zremrangebylex('name', 1, 5)
+            r.zremrangebylex('name', 1, 5)
 
-    def test_zlexcount(self):
+    def test_zlexcount(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zlexcount('name', 1, 5)
+            r.zlexcount('name', 1, 5)
 
-    def test_zrevrange(self):
+    def test_zrevrange(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zrevrange('name', 1, 5, 1)
+            r.zrevrange('name', 1, 5, 1)
 
-    def test_zrevrangebyscore(self):
+    def test_zrevrangebyscore(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zrevrangebyscore('name', 5, 1)
+            r.zrevrangebyscore('name', 5, 1)
 
-    def test_zrevrangebylex(self):
+    def test_zrevrangebylex(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zrevrangebylex('name', 5, 1)
+            r.zrevrangebylex('name', 5, 1)
 
-    def test_zrevran(self):
+    def test_zrevran(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zrevrank('name', 2)
+            r.zrevrank('name', 2)
 
-    def test_zscore(self):
+    def test_zscore(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zscore('name', 2)
+            r.zscore('name', 2)
 
-    def test_zunionstor(self):
+    def test_zunionstor(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.zunionstore('dest', ['1', '2'])
+            r.zunionstore('dest', ['1', '2'])
 
-    def test_pipeline(self):
+    def test_pipeline(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.pipeline().watch('key')
+            r.pipeline().watch('key')
 
-    def test_transaction(self):
+    def test_transaction(self, r):
         with pytest.raises(redis.ConnectionError):
             def func(a):
                 return a * a
 
-            self.redis.transaction(func, 3)
+            r.transaction(func, 3)
 
-    def test_lock(self):
+    def test_lock(self, r):
         with pytest.raises(redis.ConnectionError):
-            with self.redis.lock('name'):
+            with r.lock('name'):
                 pass
 
-    def test_pubsub(self):
+    def test_pubsub(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.pubsub().subscribe('channel')
+            r.pubsub().subscribe('channel')
 
-    def test_pfadd(self):
+    def test_pfadd(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.pfadd('name', 1)
+            r.pfadd('name', 1)
 
-    def test_pfmerge(self):
+    def test_pfmerge(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.pfmerge('dest', 'a', 'b')
+            r.pfmerge('dest', 'a', 'b')
 
-    def test_scan(self):
+    def test_scan(self, r):
         with pytest.raises(redis.ConnectionError):
-            list(self.redis.scan())
+            list(r.scan())
 
-    def test_sscan(self):
+    def test_sscan(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.sscan('name')
+            r.sscan('name')
 
-    def test_hscan(self):
+    def test_hscan(self, r):
         with pytest.raises(redis.ConnectionError):
-            self.redis.hscan('name')
+            r.hscan('name')
 
-    def test_scan_iter(self):
+    def test_scan_iter(self, r):
         with pytest.raises(redis.ConnectionError):
-            list(self.redis.scan_iter())
+            list(r.scan_iter())
 
-    def test_sscan_iter(self):
+    def test_sscan_iter(self, r):
         with pytest.raises(redis.ConnectionError):
-            list(self.redis.sscan_iter('name'))
+            list(r.sscan_iter('name'))
 
-    def test_hscan_iter(self):
+    def test_hscan_iter(self, r):
         with pytest.raises(redis.ConnectionError):
-            list(self.redis.hscan_iter('name'))
+            list(r.hscan_iter('name'))
 
 
 class TestPubSubConnected:

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -71,13 +71,6 @@ def is_redis_running():
         return True
 
 
-@pytest.fixture
-def fake_server(request):
-    server = fakeredis.FakeServer()
-    server.connected = request.node.get_closest_marker('disconnected') is None
-    return server
-
-
 @pytest.fixture(params=['StrictRedis', 'FakeStrictRedis'])
 def create_redis(request):
     name = request.param

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -128,18 +128,18 @@ def test_dbsize(r):
 def test_flushdb(r):
     r.set('foo', 'bar')
     assert r.keys() == [b'foo']
-    assert r.flushdb() == True
+    assert r.flushdb() is True
     assert r.keys() == []
 
 
 def test_set_then_get(r):
-    assert r.set('foo', 'bar') == True
+    assert r.set('foo', 'bar') is True
     assert r.get('foo') == b'bar'
 
 
 @redis2_only
 def test_set_None_value(r):
-    assert r.set('foo', None) == True
+    assert r.set('foo', None) is True
     assert r.get('foo') == b'None'
 
 
@@ -150,22 +150,22 @@ def test_set_float_value(r):
 
 
 def test_saving_non_ascii_chars_as_value(r):
-    assert r.set('foo', 'Ñandu') == True
+    assert r.set('foo', 'Ñandu') is True
     assert r.get('foo') == 'Ñandu'.encode()
 
 
 def test_saving_unicode_type_as_value(r):
-    assert r.set('foo', 'Ñandu') == True
+    assert r.set('foo', 'Ñandu') is True
     assert r.get('foo') == 'Ñandu'.encode()
 
 
 def test_saving_non_ascii_chars_as_key(r):
-    assert r.set('Ñandu', 'foo') == True
+    assert r.set('Ñandu', 'foo') is True
     assert r.get('Ñandu') == b'foo'
 
 
 def test_saving_unicode_type_as_key(r):
-    assert r.set('Ñandu', 'foo') == True
+    assert r.set('Ñandu', 'foo') is True
     assert r.get('Ñandu') == b'foo'
 
 
@@ -186,7 +186,7 @@ def test_get_does_not_exist(r):
 
 
 def test_get_with_non_str_keys(r):
-    assert r.set('2', 'bar') == True
+    assert r.set('2', 'bar') is True
     assert r.get(2) == b'bar'
 
 
@@ -197,7 +197,7 @@ def test_get_invalid_type(r):
 
 
 def test_set_non_str_keys(r):
-    assert r.set(2, 'bar') == True
+    assert r.set(2, 'bar') is True
     assert r.get(2) == b'bar'
     assert r.get('2') == b'bar'
 
@@ -618,31 +618,31 @@ def test_mset_with_no_keys(r):
 
 
 def test_mset(r):
-    assert r.mset({'foo': 'one', 'bar': 'two'}) == True
-    assert r.mset({'foo': 'one', 'bar': 'two'}) == True
+    assert r.mset({'foo': 'one', 'bar': 'two'}) is True
+    assert r.mset({'foo': 'one', 'bar': 'two'}) is True
     assert r.mget('foo', 'bar') == [b'one', b'two']
 
 
 @redis2_only
 def test_mset_accepts_kwargs(r):
-    assert r.mset(foo='one', bar='two') == True
-    assert r.mset(foo='one', baz='three') == True
+    assert r.mset(foo='one', bar='two') is True
+    assert r.mset(foo='one', baz='three') is True
     assert r.mget('foo', 'bar', 'baz') == [b'one', b'two', b'three']
 
 
 def test_msetnx(r):
-    assert r.msetnx({'foo': 'one', 'bar': 'two'}) == True
-    assert r.msetnx({'bar': 'two', 'baz': 'three'}) == False
+    assert r.msetnx({'foo': 'one', 'bar': 'two'}) is True
+    assert r.msetnx({'bar': 'two', 'baz': 'three'}) is False
     assert r.mget('foo', 'bar', 'baz') == [b'one', b'two', None]
 
 
 def test_setex(r):
-    assert r.setex('foo', 100, 'bar') == True
+    assert r.setex('foo', 100, 'bar') is True
     assert r.get('foo') == b'bar'
 
 
 def test_setex_using_timedelta(r):
-    assert r.setex('foo', timedelta(seconds=100), 'bar') == True
+    assert r.setex('foo', timedelta(seconds=100), 'bar') is True
     assert r.get('foo') == b'bar'
 
 
@@ -652,22 +652,22 @@ def test_setex_using_float(r):
 
 
 def test_set_ex(r):
-    assert r.set('foo', 'bar', ex=100) == True
+    assert r.set('foo', 'bar', ex=100) is True
     assert r.get('foo') == b'bar'
 
 
 def test_set_ex_using_timedelta(r):
-    assert r.set('foo', 'bar', ex=timedelta(seconds=100)) == True
+    assert r.set('foo', 'bar', ex=timedelta(seconds=100)) is True
     assert r.get('foo') == b'bar'
 
 
 def test_set_px(r):
-    assert r.set('foo', 'bar', px=100) == True
+    assert r.set('foo', 'bar', px=100) is True
     assert r.get('foo') == b'bar'
 
 
 def test_set_px_using_timedelta(r):
-    assert r.set('foo', 'bar', px=timedelta(milliseconds=100)) == True
+    assert r.set('foo', 'bar', px=timedelta(milliseconds=100)) is True
     assert r.get('foo') == b'bar'
 
 
@@ -720,14 +720,14 @@ def test_setex_using_timedelta_raises_wrong_ex(r):
 
 
 def test_setnx(r):
-    assert r.setnx('foo', 'bar') == True
+    assert r.setnx('foo', 'bar') is True
     assert r.get('foo') == b'bar'
-    assert r.setnx('foo', 'baz') == False
+    assert r.setnx('foo', 'baz') is False
     assert r.get('foo') == b'bar'
 
 
 def test_set_nx(r):
-    assert r.set('foo', 'bar', nx=True) == True
+    assert r.set('foo', 'bar', nx=True) is True
     assert r.get('foo') == b'bar'
     assert r.set('foo', 'bar', nx=True) is None
     assert r.get('foo') == b'bar'
@@ -736,7 +736,7 @@ def test_set_nx(r):
 def test_set_xx(r):
     assert r.set('foo', 'bar', xx=True) is None
     r.set('foo', 'bar')
-    assert r.set('foo', 'bar', xx=True) == True
+    assert r.set('foo', 'bar', xx=True) is True
 
 
 def test_del_operator(r):
@@ -747,7 +747,7 @@ def test_del_operator(r):
 
 def test_delete(r):
     r['foo'] = 'bar'
-    assert r.delete('foo') == True
+    assert r.delete('foo') == 1
     assert r.get('foo') is None
 
 
@@ -781,7 +781,7 @@ def test_delete_multiple(r):
 
 
 def test_delete_nonexistent_key(r):
-    assert r.delete('foo') == False
+    assert r.delete('foo') == 0
 
 
 # Tests for the list type.
@@ -1426,14 +1426,14 @@ def test_hdel(r):
     r.hset('foo', 'k2', 'v2')
     r.hset('foo', 'k3', 'v3')
     assert r.hget('foo', 'k1') == b'v1'
-    assert r.hdel('foo', 'k1') == True
+    assert r.hdel('foo', 'k1') == 1
     assert r.hget('foo', 'k1') is None
-    assert r.hdel('foo', 'k1') == False
+    assert r.hdel('foo', 'k1') == 0
     # Since redis>=2.7.6 returns number of deleted items.
     assert r.hdel('foo', 'k2', 'k3') == 2
     assert r.hget('foo', 'k2') is None
     assert r.hget('foo', 'k3') is None
-    assert r.hdel('foo', 'k2', 'k3') == False
+    assert r.hdel('foo', 'k2', 'k3') == 0
 
 
 def test_hdel_wrong_type(r):
@@ -1510,8 +1510,8 @@ def test_hincrbyfloat_precision(r):
 
 
 def test_hsetnx(r):
-    assert r.hsetnx('foo', 'newkey', 'v1') == True
-    assert r.hsetnx('foo', 'newkey', 'v1') == False
+    assert r.hsetnx('foo', 'newkey', 'v1') == 1
+    assert r.hsetnx('foo', 'newkey', 'v1') == 0
     assert r.hget('foo', 'newkey') == b'v1'
 
 
@@ -1522,7 +1522,7 @@ def test_hmsetset_empty_raises_error(r):
 
 def test_hmsetset(r):
     r.hset('foo', 'k1', 'v1')
-    assert r.hmset('foo', {'k2': 'v2', 'k3': 'v3'}) == True
+    assert r.hmset('foo', {'k2': 'v2', 'k3': 'v3'}) is True
 
 
 @redis2_only
@@ -1741,9 +1741,9 @@ def test_sinterstore(r):
 
 
 def test_sismember(r):
-    assert r.sismember('foo', 'member1') == False
+    assert r.sismember('foo', 'member1') is False
     r.sadd('foo', 'member1')
-    assert r.sismember('foo', 'member1') == True
+    assert r.sismember('foo', 'member1') is True
 
 
 def test_sismember_wrong_type(r):
@@ -1778,12 +1778,12 @@ def test_smembers_runtime_error(r):
 def test_smove(r):
     r.sadd('foo', 'member1')
     r.sadd('foo', 'member2')
-    assert r.smove('foo', 'bar', 'member1') == True
+    assert r.smove('foo', 'bar', 'member1') is True
     assert r.smembers('bar') == {b'member1'}
 
 
 def test_smove_non_existent_key(r):
-    assert r.smove('foo', 'bar', 'member1') == False
+    assert r.smove('foo', 'bar', 'member1') is False
 
 
 def test_smove_wrong_type(r):
@@ -1840,15 +1840,15 @@ def test_srandmember_wrong_type(r):
 def test_srem(r):
     r.sadd('foo', 'member1', 'member2', 'member3', 'member4')
     assert r.smembers('foo') == {b'member1', b'member2', b'member3', b'member4'}
-    assert r.srem('foo', 'member1') == True
+    assert r.srem('foo', 'member1') == 1
     assert r.smembers('foo') == {b'member2', b'member3', b'member4'}
-    assert r.srem('foo', 'member1') == False
+    assert r.srem('foo', 'member1') == 0
     # Since redis>=2.7.6 returns number of deleted items.
     assert r.srem('foo', 'member2', 'member3') == 2
     assert r.smembers('foo') == {b'member4'}
-    assert r.srem('foo', 'member3', 'member4') == True
+    assert r.srem('foo', 'member3', 'member4') == 1
     assert r.smembers('foo') == set()
-    assert r.srem('foo', 'member3', 'member4') == False
+    assert r.srem('foo', 'member3', 'member4') == 0
 
 
 def test_srem_wrong_type(r):
@@ -2229,14 +2229,14 @@ def test_zrem(r):
     zadd(r, 'foo', {'two': 2})
     zadd(r, 'foo', {'three': 3})
     zadd(r, 'foo', {'four': 4})
-    assert r.zrem('foo', 'one') == True
+    assert r.zrem('foo', 'one') == 1
     assert r.zrange('foo', 0, -1) == [b'two', b'three', b'four']
     # Since redis>=2.7.6 returns number of deleted items.
     assert r.zrem('foo', 'two', 'three') == 2
     assert r.zrange('foo', 0, -1) == [b'four']
-    assert r.zrem('foo', 'three', 'four') == True
+    assert r.zrem('foo', 'three', 'four') == 1
     assert r.zrange('foo', 0, -1) == []
-    assert r.zrem('foo', 'three', 'four') == False
+    assert r.zrem('foo', 'three', 'four') == 0
 
 
 def test_zrem_non_existent_member(r):
@@ -2245,7 +2245,7 @@ def test_zrem_non_existent_member(r):
 
 def test_zrem_numeric_member(r):
     zadd(r, 'foo', {'128': 13.0, '129': 12.0})
-    assert r.zrem('foo', 128) == True
+    assert r.zrem('foo', 128) == 1
     assert r.zrange('foo', 0, -1) == [b'129']
 
 
@@ -2461,7 +2461,7 @@ def test_zrevrangebyscore_cast_scores(r):
     expected_with_cast_round = [(b'two_a_also', 2.0), (b'two', 2.0)]
     assert (
         r.zrevrangebyscore('foo', 3, 2, withscores=True)
-         == expected_without_cast_round
+        == expected_without_cast_round
     )
     assert (
         r.zrevrangebyscore('foo', 3, 2, withscores=True,
@@ -2951,7 +2951,7 @@ def test_multidb(r, create_redis):
     assert r1['r1'] == b'r1'
     assert r2['r2'] == b'r2'
 
-    assert r1.flushall() == True
+    assert r1.flushall() is True
 
     assert 'r1' not in r1
     assert 'r2' not in r2
@@ -3921,7 +3921,7 @@ def test_expire_should_expire_key(r):
     r.expire('foo', 1)
     sleep(1.5)
     assert r.get('foo') is None
-    assert r.expire('bar', 1) == False
+    assert r.expire('bar', 1) is False
 
 
 def test_expire_should_return_true_for_existing_key(r):
@@ -3940,7 +3940,7 @@ def test_expire_should_expire_key_using_timedelta(r):
     r.expire('foo', timedelta(seconds=1))
     sleep(1.5)
     assert r.get('foo') is None
-    assert r.expire('bar', 1) == False
+    assert r.expire('bar', 1) is False
 
 
 @pytest.mark.slow
@@ -3949,7 +3949,7 @@ def test_expire_should_expire_immediately_with_millisecond_timedelta(r):
     assert r.get('foo') == b'bar'
     r.expire('foo', timedelta(milliseconds=750))
     assert r.get('foo') is None
-    assert r.expire('bar', 1) == False
+    assert r.expire('bar', 1) is False
 
 
 @pytest.mark.slow
@@ -3959,7 +3959,7 @@ def test_pexpire_should_expire_key(r):
     r.pexpire('foo', 150)
     sleep(0.2)
     assert r.get('foo') is None
-    assert r.pexpire('bar', 1) == False
+    assert r.pexpire('bar', 1) == 0
 
 
 def test_pexpire_should_return_truthy_for_existing_key(r):
@@ -3980,7 +3980,7 @@ def test_pexpire_should_expire_key_using_timedelta(r):
     assert r.get('foo') == b'bar'
     sleep(0.5)
     assert r.get('foo') is None
-    assert r.pexpire('bar', 1) == False
+    assert r.pexpire('bar', 1) == 0
 
 
 @pytest.mark.slow
@@ -3990,7 +3990,7 @@ def test_expireat_should_expire_key_by_datetime(r):
     r.expireat('foo', datetime.now() + timedelta(seconds=1))
     sleep(1.5)
     assert r.get('foo') is None
-    assert r.expireat('bar', datetime.now()) == False
+    assert r.expireat('bar', datetime.now()) is False
 
 
 @pytest.mark.slow
@@ -4000,7 +4000,7 @@ def test_expireat_should_expire_key_by_timestamp(r):
     r.expireat('foo', int(time() + 1))
     sleep(1.5)
     assert r.get('foo') is None
-    assert r.expire('bar', 1) == False
+    assert r.expire('bar', 1) is False
 
 
 def test_expireat_should_return_true_for_existing_key(r):
@@ -4019,7 +4019,7 @@ def test_pexpireat_should_expire_key_by_datetime(r):
     r.pexpireat('foo', datetime.now() + timedelta(milliseconds=150))
     sleep(0.2)
     assert r.get('foo') is None
-    assert r.pexpireat('bar', datetime.now()) == False
+    assert r.pexpireat('bar', datetime.now()) == 0
 
 
 @pytest.mark.slow
@@ -4029,7 +4029,7 @@ def test_pexpireat_should_expire_key_by_timestamp(r):
     r.pexpireat('foo', int(time() * 1000 + 150))
     sleep(0.2)
     assert r.get('foo') is None
-    assert r.expire('bar', 1) == False
+    assert r.expire('bar', 1) is False
 
 
 def test_pexpireat_should_return_true_for_existing_key(r):
@@ -4558,11 +4558,11 @@ def test_unlink(r):
 @pytest.mark.parametrize('create_redis', ['FakeRedis', 'Redis'], indirect=True)
 class TestLegacy:
     def test_setex(self, r):
-        assert r.setex('foo', 'bar', 100) == True
+        assert r.setex('foo', 'bar', 100) is True
         assert r.get('foo') == b'bar'
 
     def test_setex_using_timedelta(self, r):
-        assert r.setex('foo', 'bar', timedelta(seconds=100)) == True
+        assert r.setex('foo', 'bar', timedelta(seconds=100)) is True
         assert r.get('foo') == b'bar'
 
     def test_lrem_positive_count(self, r):
@@ -4850,10 +4850,10 @@ class TestInitArgs:
         fake_conn = db.connection_pool.make_connection()
         assert fake_conn.socket_connect_timeout == 11
         assert fake_conn.socket_timeout == 12
-        assert fake_conn.socket_keepalive == True
+        assert fake_conn.socket_keepalive is True
         assert fake_conn.socket_keepalive_options == {60: 30}
         assert fake_conn.socket_type == 1
-        assert fake_conn.retry_on_timeout == True
+        assert fake_conn.retry_on_timeout is True
 
         # Make fallback logic match redis-py
         db = fakeredis.FakeStrictRedis.from_url(

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -110,7 +110,8 @@ def r(request, create_redis):
     yield r
     if connected:
         r.flushall()
-    r.close()
+    if hasattr(r, 'close'):
+        r.close()     # Older versions of redis-py don't have this method
 
 
 def test_large_command(r):

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from time import sleep, time
 from redis.exceptions import ResponseError
 from collections import OrderedDict

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -3011,11 +3011,11 @@ class TestFakeStrictRedis:
     def test_swapdb_same_db(self):
         assert self.redis.swapdb(1, 1)
 
-    def test_bgsave(self):
-        assert self.redis.bgsave()
-
     def test_save(self):
         assert self.redis.save()
+
+    def test_bgsave(self):
+        assert self.redis.bgsave()
 
     def test_lastsave(self):
         assert isinstance(self.redis.lastsave(), datetime)

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -1967,30 +1967,18 @@ def test_zadd_with_nx(r, input, return_value, state):
 
 
 @redis3_only
-def test_zadd_with_ch(r):
-    zadd(r, 'foo', {'four': 4.0, 'three': 3.0})
-
-    updates = [
-        UpdateCommand(
-            input={'four': 4.0, 'three': 1.0},
-            expected_return_value=1,
-            expected_state=[(b'four', 4.0), (b'three', 1.0)]),
-        UpdateCommand(
-            input={'four': 4.0, 'three': 3.0, 'zero': 0.0},
-            expected_return_value=2,
-            expected_state=[(b'four', 4.0), (b'three', 3.0), (b'zero', 0.0)]),
-        UpdateCommand(
-            input={'two': 2.0, 'one': 1.0},
-            expected_return_value=2,
-            expected_state=[(b'four', 4.0), (b'three', 3.0), (b'two', 2.0), (b'one', 1.0), (b'zero', 0.0)]),
+@pytest.mark.parametrize(
+    'input,return_value,state',
+    [
+        ({'four': 4.0, 'three': 1.0}, 1, [(b'three', 1.0), (b'four', 4.0)]),
+        ({'four': 4.0, 'three': 1.0, 'zero': 0.0}, 2, [(b'zero', 0.0), (b'three', 1.0), (b'four', 4.0)]),
+        ({'two': 2.0, 'one': 1.0}, 2, [(b'one', 1.0), (b'two', 2.0), (b'three', 3.0), (b'four', 4.0)])
     ]
-
-    for update in updates:
-        assert zadd(r, 'foo', update.input, ch=True) == update.expected_return_value
-        assert (
-            sorted(r.zrange('foo', 0, -1, withscores=True))
-            == sorted(update.expected_state)
-        )
+)
+def test_zadd_with_ch(r, input, return_value, state):
+    zadd(r, 'foo', {'four': 4.0, 'three': 3.0})
+    assert zadd(r, 'foo', input, ch=True) == return_value
+    assert r.zrange('foo', 0, -1, withscores=True) == state
 
 
 @redis3_only


### PR DESCRIPTION
I wouldn't try to review everything - there are a *lot* of mechanical changes. Interesting bits are the smaller files and anything with pytest decorators (`@pytest.fixture`, `@pytest.mark`).