### PR TITLE
Handle indefinite timeout for PUBSUB commands

### DIFF
--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -2573,7 +2573,7 @@ class FakeSelector(BaseSelector):
     def check_can_read(self, timeout):
         if self.sock.responses.qsize():
             return True
-        if timeout <= 0:
+        if timeout is not None and timeout <= 0:
             return False
 
         # A sleep/poll loop is easier to mock out than messing with condition
@@ -2584,7 +2584,7 @@ class FakeSelector(BaseSelector):
                 return True
             time.sleep(0.01)
             now = time.time()
-            if now > start + timeout:
+            if timeout is not None and now > start + timeout:
                 return False
 
     def check_is_ready_for_command(self, timeout):

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -3646,7 +3646,19 @@ def test_pubsub_run_in_thread(r):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("timeout_value", [1, None])
+@pytest.mark.parametrize(
+    "timeout_value",
+    [
+        1,
+        pytest.param(
+            None,
+            marks=pytest.mark.skipif(
+                REDIS_VERSION >= "3.2" and REDIS_VERSION < "3.3",
+                reason="This test is not applicable to redis-py 3.2"
+            )
+        )
+    ]
+)
 def test_pubsub_timeout(r, timeout_value):
     def publish():
         sleep(0.1)

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -3646,7 +3646,8 @@ def test_pubsub_run_in_thread(r):
 
 
 @pytest.mark.slow
-def test_pubsub_timeout(r):
+@pytest.mark.parametrize("timeout_value", [1, None])
+def test_pubsub_timeout(r, timeout_value):
     def publish():
         sleep(0.1)
         r.publish('channel', 'hello')
@@ -3656,14 +3657,17 @@ def test_pubsub_timeout(r):
     p.parse_response()   # Drains the subscribe message
     publish_thread = threading.Thread(target=publish)
     publish_thread.start()
-    message = p.get_message(timeout=1)
+    message = p.get_message(timeout=timeout_value)
     assert message == {
         'type': 'message', 'pattern': None,
         'channel': b'channel', 'data': b'hello'
     }
     publish_thread.join()
-    message = p.get_message(timeout=0.5)
-    assert message is None
+
+    if timeout_value is not None:
+        # For infinite timeout case don't wait for the message that will never appear.
+        message = p.get_message(timeout=timeout_value)
+        assert message is None
 
 
 def test_pfadd(r):


### PR DESCRIPTION
Handle indefinite timeout for `PUBSUB` commands.

Indefinite timeout test is disabled for `py-redis` 3.2. This version introduced new default selector based on  `select.poll`, which itself supports indefinite polling via setting the `timeout` to `None`, but `py-redis` in this version scales the `timeout` by 1000 without type checking before passing it to the polling object, which renders this feature unavailable. Affected versions are 3.2.0 and 3.2.1, so the whole 3.2 family.

Fixes #274