### PR TITLE
Add support for DUMP and RESTORE commands.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -275,10 +275,8 @@ cluster
 generic
 -------
 
- * dump
  * migrate
  * object
- * restore
  * touch
  * wait
 
@@ -369,6 +367,10 @@ bugs in Github.
    deleted or renamed during iteration. They also won't necessarily iterate in
    the same chunk sizes or the same order as redis.
 
+8. DUMP/RESTORE will not return or expect data in the RDB format. Instead the
+   `pickle` module is used to mimic an opaque and non-standard format.
+   **WARNING**: Do not use RESTORE with untrusted data, as a malicious pickle
+   can execute arbitrary code.
 
 Contributing
 ============


### PR DESCRIPTION
One caveat is that they don't use the RDB format but pickle seemed like a good candidate to mimic what is expected to be an opaque and non-standard format.

https://redis.io/commands/dump

`DUMP key`

> Serialize the value stored at key in a Redis-specific format and return it to the user. The returned value can be synthesized back into a Redis key using the RESTORE command.

> The serialization format is opaque and non-standard, however it has a few semantic characteristics:

> It contains a 64-bit checksum that is used to make sure errors will be detected. The RESTORE command makes sure to check the checksum before synthesizing a key using the serialized value.

Opted for `sha1` here.

> Values are encoded in the same format used by RDB.

This could unfortunately not be achieve as it would be impractical.

https://redis.io/commands/restore

`RESTORE key ttl serialized-value`

> If `ttl` is 0 the key is created without any expire, otherwise the specified expire time (**in milliseconds**) is set.