### PR TITLE
Add support for TYPE option to SCAN command.

### DIFF
--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -908,16 +908,18 @@ class FakeSocket:
         result_cursor = cursor + count
         result_data = []
 
-        match_key = match_type = lambda key: True
-        if pattern is not None:
-            match_key = compile_pattern(pattern).match
-        if type is not None:
-            match_type = lambda key: self.type(self._db[key]).value == type
+        regex = compile_pattern(pattern) if pattern is not None else None
+
+        def _match_key(key):
+            return regex.match(key) if pattern is not None else True
+
+        def _match_type(key):
+            return self.type(self._db[key]).value == type if type else True
 
         if pattern is not None or type is not None:
             for val in itertools.islice(data, cursor, result_cursor):
                 compare_val = val[0] if isinstance(val, tuple) else val
-                if match_key(compare_val) and match_type(compare_val):
+                if _match_key(compare_val) and _match_type(compare_val):
                     result_data.append(val)
         else:
             result_data = data[cursor:result_cursor]

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-mock
-redis==3.4.1       # Latest at time of writing
+redis==3.5.3       # Latest at time of writing
 six
 sortedcontainers
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pytest-asyncio==0.14.0    # via -r requirements.in
 pytest-cov==2.8.1         # via -r requirements.in
 pytest-mock==3.2.0        # via -r requirements.in
 pytest==5.4.3             # via -r requirements.in, pytest-asyncio, pytest-cov, pytest-mock
-redis==3.4.1              # via -r requirements.in
+redis==3.5.3              # via -r requirements.in
 six==1.14.0               # via -r requirements.in, packaging
 sortedcontainers==2.1.0   # via -r requirements.in, hypothesis
 wcwidth==0.1.8            # via pytest

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -1633,6 +1633,8 @@ def test_scan_iter_multiple_pages_with_match(r):
     assert actual == set(all_keys)
 
 
+@pytest.mark.skipif(REDIS_VERSION < '3.5', reason="Test is only applicable to redis-py 3.5+")
+@pytest.mark.min_server('6.0')
 def test_scan_iter_multiple_pages_with_type(r):
     all_keys = key_val_dict(size=100)
     assert all(r.set(k, v) for k, v in all_keys.items())

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -1643,7 +1643,7 @@ def test_scan_iter_multiple_pages_with_type(r):
     zadd(r, 'zset2', {'andanother': 1})
     actual = set(r.scan_iter(_type='string'))
     assert actual == set(all_keys)
-    actual = set(r.scan_iter(_type='zset'))
+    actual = set(r.scan_iter(_type='ZSET'))
     assert actual == {b'zset1', b'zset2'}
 
 

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -1633,6 +1633,18 @@ def test_scan_iter_multiple_pages_with_match(r):
     assert actual == set(all_keys)
 
 
+def test_scan_iter_multiple_pages_with_type(r):
+    all_keys = key_val_dict(size=100)
+    assert all(r.set(k, v) for k, v in all_keys.items())
+    # Now add a few keys of another type
+    zadd(r, 'zset1', {'otherkey': 1})
+    zadd(r, 'zset2', {'andanother': 1})
+    actual = set(r.scan_iter(_type='string'))
+    assert actual == set(all_keys)
+    actual = set(r.scan_iter(_type='zset'))
+    assert actual == {b'zset1', b'zset2'}
+
+
 def test_scan_multiple_pages_with_count_arg(r):
     all_keys = key_val_dict(size=100)
     assert all(r.set(k, v) for k, v in all_keys.items())


### PR DESCRIPTION
In Redis 6.0 there's a new option for the SCAN command that allows to limit types of returned keys. This PR adds this option.