### PR TITLE
Add support for the RESTORE ABSTTL option.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -275,10 +275,8 @@ cluster
 generic
 -------
 
- * dump
  * migrate
  * object
- * restore
  * touch
  * wait
 
@@ -369,6 +367,10 @@ bugs in Github.
    deleted or renamed during iteration. They also won't necessarily iterate in
    the same chunk sizes or the same order as redis.
 
+8. DUMP/RESTORE will not return or expect data in the RDB format. Instead the
+   `pickle` module is used to mimic an opaque and non-standard format.
+   **WARNING**: Do not use RESTORE with untrusted data, as a malicious pickle
+   can execute arbitrary code.
 
 Contributing
 ============

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -2330,10 +2330,14 @@ class FakeSocket:
     @command((Key(), Int, bytes), (bytes,))
     def restore(self, key, ttl, value, *args):
         replace = False
+        absttl = False
         i = 0
         while i < len(args):
             if casematch(args[i], b'replace') and not replace:
                 replace = True
+                i += 1
+            elif casematch(args[i], b'absttl') and not absttl:
+                absttl = True
                 i += 1
             else:
                 raise SimpleError(SYNTAX_ERROR_MSG)
@@ -2346,6 +2350,8 @@ class FakeSocket:
             raise redis.ResponseError(RESTORE_INVALID_TTL_MSG)
         if ttl == 0:
             expireat = None
+        elif absttl:
+            expireat = ttl / 1000.0
         else:
             expireat = self._db.time + ttl / 1000.0
         key.value = pickle.loads(value)

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -11,6 +11,7 @@ import itertools
 import hashlib
 import weakref
 import queue
+import pickle
 from collections import defaultdict
 from collections.abc import MutableMapping
 
@@ -80,6 +81,9 @@ LOG_INVALID_DEBUG_LEVEL_MSG = "ERR Invalid debug level."
 LUA_COMMAND_ARG_MSG = "ERR Lua redis() command arguments must be strings or integers"
 LUA_WRONG_NUMBER_ARGS_MSG = "ERR wrong number or type of arguments"
 SCRIPT_ERROR_MSG = "ERR Error running script (call to f_{}): @user_script:?: {}"
+RESTORE_KEY_EXISTS = "BUSYKEY Target key name already exists."
+RESTORE_INVALID_CHECKSUM_MSG = "ERR DUMP payload version or checksum are wrong"
+RESTORE_INVALID_TTL_MSG = "ERR Invalid TTL value, must be >= 0"
 
 FLAG_NO_SCRIPT = 's'      # Command not allowed in scripts
 
@@ -2314,6 +2318,39 @@ class FakeSocket:
         now_s = now_us // 1000000
         now_us %= 1000000
         return [str(now_s).encode(), str(now_us).encode()]
+
+    # Generic commands
+
+    @command((Key(),))
+    def dump(self, key):
+        value = pickle.dumps(key.value)
+        checksum = hashlib.sha1(value).digest()
+        return checksum + value
+
+    @command((Key(), Int, bytes), (bytes,))
+    def restore(self, key, ttl, value, *args):
+        replace = False
+        i = 0
+        while i < len(args):
+            if casematch(args[i], b'replace') and not replace:
+                replace = True
+                i += 1
+            else:
+                raise SimpleError(SYNTAX_ERROR_MSG)
+        if key and not replace:
+            raise redis.ResponseError(RESTORE_KEY_EXISTS)
+        checksum, value = value[:20], value[20:]
+        if hashlib.sha1(value).digest() != checksum:
+            raise redis.ResponseError(RESTORE_INVALID_CHECKSUM_MSG)
+        if ttl < 0:
+            raise redis.ResponseError(RESTORE_INVALID_TTL_MSG)
+        if ttl == 0:
+            expireat = None
+        else:
+            expireat = self._db.time + ttl / 1000.0
+        key.value = pickle.loads(value)
+        key.expireat = expireat
+        return OK
 
     # Script commands
     # script debug and script kill will probably not be supported

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -141,6 +141,51 @@ def test_flushdb(r):
     assert r.keys() == []
 
 
+def test_dump_restore(r):
+    r.set('foo', 'bar')
+    dump = r.dump('foo')
+    r.restore('baz', 0, dump)
+    assert r.get('baz') == b'bar'
+    assert r.ttl('baz') == -1
+
+
+def test_dump_restore_ttl(r):
+    r.set('foo', 'bar')
+    dump = r.dump('foo')
+    r.restore('baz', 2000, dump)
+    assert r.get('baz') == b'bar'
+    assert 1000 <= r.pttl('baz') <= 2000
+
+
+def test_dump_restore_replace(r):
+    r.set('foo', 'bar')
+    dump = r.dump('foo')
+    r.set('foo', 'baz')
+    r.restore('foo', 0, dump, replace=True)
+    assert r.get('foo') == b'bar'
+
+
+def test_restore_exists(r):
+    r.set('foo', 'bar')
+    dump = r.dump('foo')
+    with pytest.raises(ResponseError):
+        r.restore('foo', 0, dump)
+
+
+def test_restore_invalid_dump(r):
+    r.set('foo', 'bar')
+    dump = r.dump('foo')
+    with pytest.raises(ResponseError):
+        r.restore('baz', 0, dump[:-1])
+
+
+def test_restore_invalid_ttl(r):
+    r.set('foo', 'bar')
+    dump = r.dump('foo')
+    with pytest.raises(ResponseError):
+        r.restore('baz', -1, dump)
+
+
 def test_set_then_get(r):
     assert r.set('foo', 'bar') is True
     assert r.get('foo') == b'bar'

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -165,6 +165,15 @@ def test_dump_restore_replace(r):
     assert r.get('foo') == b'bar'
 
 
+def test_dump_restore_absttl(r):
+    r.set('foo', 'bar')
+    dump = r.dump('foo')
+    ttl = int(time() * 1000) + 2000
+    r.restore('baz', ttl, dump, absttl=True)
+    assert r.get('baz') == b'bar'
+    assert 1000 <= r.pttl('baz') <= 2000
+
+
 def test_restore_exists(r):
     r.set('foo', 'bar')
     dump = r.dump('foo')


### PR DESCRIPTION
As explained in https://github.com/jamesls/fakeredis/pull/285#issuecomment-731658636 the provided test will fail until `redis-py` adds support for the option.