### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,26 @@ jobs:
     - env: REDIS_PY="3.4.1"
     - env: REDIS_PY="3.5.0"
     - env: REDIS_PY="3.5.*" COVERAGE="yes"
+    - python: 3.6
+      arch: ppc64le
+    - python: 3.7
+      arch: ppc64le
+    - python: 3.8
+      arch: ppc64le
+    - env: REDIS_PY="3.0.1"
+      arch: ppc64le
+    - env: REDIS_PY="3.1.0"
+      arch: ppc64le
+    - env: REDIS_PY="3.2.1"
+      arch: ppc64le
+    - env: REDIS_PY="3.3.11"
+      arch: ppc64le
+    - env: REDIS_PY="3.4.1"
+      arch: ppc64le
+    - env: REDIS_PY="3.5.0"
+      arch: ppc64le
+    - env: REDIS_PY="3.5.*" COVERAGE="yes"
+      arch: ppc64le
 cache:
   - pip
 services:


### PR DESCRIPTION
I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro 
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.


This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and 
ISVs, and while we don't use this package directly,we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or 
third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

Please help to verify and merge.