### PR TITLE
Align `FakeConnection` constructor signature to base class

### DIFF
--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 import threading
 import math
@@ -2655,39 +2654,10 @@ class FakeSelector(BaseSelector):
 class FakeConnection(redis.Connection):
     description_format = "FakeConnection<db=%(db)s>"
 
-    def __init__(self, server, db=0, username=None, password=None,
-                 socket_timeout=None, socket_connect_timeout=None,
-                 socket_keepalive=False, socket_keepalive_options=None,
-                 socket_type=0, retry_on_timeout=False,
-                 encoding='utf-8', encoding_errors='strict',
-                 decode_responses=False, parser_class=_DummyParser,
-                 socket_read_size=65536, health_check_interval=0,
-                 client_name=None):
-        self.pid = os.getpid()
-        self.db = db
-        self.username = username
-        self.client_name = client_name
-        self.password = password
-        # Allow socket attributes to be passed in and saved even if they aren't used
-        self.socket_timeout = socket_timeout
-        self.socket_connect_timeout = socket_connect_timeout or socket_timeout
-        self.socket_keepalive = socket_keepalive
-        self.socket_keepalive_options = socket_keepalive_options or {}
-        self.socket_type = socket_type
-        self.retry_on_timeout = retry_on_timeout
-        self.encoder = redis.connection.Encoder(encoding, encoding_errors, decode_responses)
-        self._description_args = {'db': self.db}
-        self._connect_callbacks = []
-        self._buffer_cutoff = 6000
-        self._server = server
-        # self._parser isn't used for anything, but some of the
-        # base class methods depend on it and it's easier not to
-        # override them.
-        self._parser = parser_class(socket_read_size=socket_read_size)
-        self._sock = None
-        # added in redis==3.3.0
-        self.health_check_interval = health_check_interval
-        self.next_health_check = 0
+    def __init__(self, *args, **kwargs):
+        self._server = kwargs.pop('server')
+        self._description_args = {'db': kwargs.get('db', 0)}
+        super().__init__(*args, **kwargs)
 
     def connect(self):
         super().connect()

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -2656,7 +2656,6 @@ class FakeConnection(redis.Connection):
 
     def __init__(self, *args, **kwargs):
         self._server = kwargs.pop('server')
-        self._description_args = {'db': kwargs.get('db', 0)}
         super().__init__(*args, **kwargs)
 
     def connect(self):

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -4988,6 +4988,7 @@ class TestInitArgs:
         db.set('foo', 'bar')
         assert db.get('foo') == 'bar'
 
+    @redis3_only
     def test_can_allow_extra_args(self):
         db = fakeredis.FakeStrictRedis.from_url(
             'redis://localhost:6379/0',


### PR DESCRIPTION
As `FakeConnection` is a subclass of the `Connection` class in `redis-py`, in order to honor OOP substitutability principle, the signature of the constructor should be aligned with the one of the base class. That means it should contain at least all the parameters of the base class.

This automatically fixes a problem occurring when the connection object is dynamically instantiated within the context of the default connection pool class in `redis-py`, named `ConnectionPool`, and when, in turn, the latter is dynamically instantiated using its standard `from_url` factory method. In such scenario the instantiation of the connection object fails because the `FakeConnection` class misses both `host` and `port` parameters in its constructor signature.

That happens because the `from_url` factory method above, given a canonical Redis URL, guesses several connection parameters values, among which `host`, `username`, `password`, `path`, and `db`, which values override any other corresponding value passed to the factory method itself via the connection variadic arguments.

Aligning the `FakeConnection` constructor signature to the one of its base class, by including the `host` and `port` parameters, is helpful in contexts where there's no direct control over the instantiantiation of Redis clients, connections and connection pools objects (e.g. `django-redis` library): whilst preserving current behavior, this avoids to workaround the issue by defining either custom connection factories or custom connection pools.

Closes #234 