### PR TITLE
Defer the cleanup in FakeSocket.close

### DIFF
--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -695,12 +695,11 @@ class FakeSocket:
         This is called with the server lock held, but it may be some time after
         self.close.
         """
-        with self._server.lock:
-            for subs in self._server.subscribers.values():
-                subs.discard(self)
-            for subs in self._server.psubscribers.values():
-                subs.discard(self)
-            self._clear_watches()
+        for subs in self._server.subscribers.values():
+            subs.discard(self)
+        for subs in self._server.psubscribers.values():
+            subs.discard(self)
+        self._clear_watches()
 
     def close(self):
         # Mark ourselves for cleanup. This might be called from

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -695,9 +695,9 @@ class FakeSocket:
         This is called with the server lock held, but it may be some time after
         self.close.
         """
-        for subs in self._server.subscribers.values():
+        for subs in server.subscribers.values():
             subs.discard(self)
-        for subs in self._server.psubscribers.values():
+        for subs in server.psubscribers.values():
             subs.discard(self)
         self._clear_watches()
 

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -671,7 +671,7 @@ class FakeSocket:
         # atomically, and the code below then protects us against this.
         responses = self.responses
         if responses:
-            self.responses.put(msg)
+            responses.put(msg)
 
     def pause(self):
         self._paused = True

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -4694,6 +4694,7 @@ def test_unlink(r):
     assert r.get('foo') is None
 
 
+@pytest.mark.skipif(REDIS_VERSION < "3.4", reason="Test requires redis-py 3.4+")
 @pytest.mark.fake
 def test_socket_cleanup_pubsub(fake_server):
     r1 = fakeredis.FakeStrictRedis(server=fake_server)

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -4694,6 +4694,33 @@ def test_unlink(r):
     assert r.get('foo') is None
 
 
+@pytest.mark.fake
+def test_socket_cleanup_pubsub(fake_server):
+    r1 = fakeredis.FakeStrictRedis(server=fake_server)
+    r2 = fakeredis.FakeStrictRedis(server=fake_server)
+    ps = r1.pubsub()
+    with ps:
+        ps.subscribe('test')
+        ps.psubscribe('test*')
+    r2.publish('test', 'foo')
+
+
+@pytest.mark.fake
+def test_socket_cleanup_watch(fake_server):
+    r1 = fakeredis.FakeStrictRedis(server=fake_server)
+    r2 = fakeredis.FakeStrictRedis(server=fake_server)
+    pipeline = r1.pipeline(transaction=False)
+    # This needs some poking into redis-py internals to ensure that we reach
+    # FakeSocket._cleanup. We need to close the socket while there is still
+    # a watch in place, but not allow it to be garbage collected (hence we
+    # set 'sock' even though it is unused).
+    with pipeline:
+        pipeline.watch('test')
+        sock = pipeline.connection._sock  # noqa: F841
+        pipeline.connection.disconnect()
+    r2.set('test', 'foo')
+
+
 @redis2_only
 @pytest.mark.parametrize(
     'create_redis',


### PR DESCRIPTION
It can be called from the garbage collector in the middle of other code
that is holding the server lock, so could deadlock. It now just appends
itself to a cleanup list, and the next command does the cleanup.

Closes #297.