### PR TITLE
SINTER[STORE] requires keys to be sets

### DIFF
--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -1900,13 +1900,11 @@ class FakeSocket:
     def sdiffstore(self, dst, *keys):
         return self._setop(lambda a, b: a - b, False, dst, *keys)
 
-    # The following keys can't be marked as sets because of the
-    # stop_if_empty early-out.
-    @command((Key(set),), (Key(),))
+    @command((Key(set),), (Key(set),))
     def sinter(self, *keys):
         return self._setop(lambda a, b: a & b, True, None, *keys)
 
-    @command((Key(), Key(set)), (Key(),))
+    @command((Key(), Key(set)), (Key(set),))
     def sinterstore(self, dst, *keys):
         return self._setop(lambda a, b: a & b, True, dst, *keys)
 


### PR DESCRIPTION
Starting with Redis 6.0.15 this behaviour changed.
The definition of SINTER[STORE] states:

"Keys that do not exist are considered to be empty sets."

At the same time SINTER only accepts set:

"intersection of all the given sets"

Both quotes from: https://redis.io/commands/sinter.

The behaviour of Redis 6.0.14 was that it ignored the type of later keys
if it found an empty set and returned that. Radis 6.0.15 changed this
behaviour to return a WRONGTYPE if it finds a non set key in the
arguments.

Example to reproduce:

127.0.0.1:6379> FLUSHALL
OK
127.0.0.1:6379> SINTER a b
(empty array)
127.0.0.1:6379> SET b something
OK
127.0.0.1:6379> SINTER a b
(error) WRONGTYPE Operation against a key holding the wrong kind of value

Cf. https://github.com/redis/redis/issues/9273.