### PR TITLE
Packaging modernisation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include COPYING
-include README.rst

--- a/fakeredis/__init__.py
+++ b/fakeredis/__init__.py
@@ -1,4 +1,4 @@
 from ._server import FakeServer, FakeRedis, FakeStrictRedis, FakeConnection   # noqa: F401
 
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'

--- a/fakeredis/aioredis.py
+++ b/fakeredis/aioredis.py
@@ -1,9 +1,8 @@
-import distutils.version
-
 import aioredis
+import packaging.version
 
 
-if aioredis.__version__ >= distutils.version.StrictVersion('2.0.0a1'):
+if packaging.version.Version(aioredis.__version__) >= packaging.version.Version('2.0.0a1'):
     from ._aioredis2 import FakeConnection, FakeRedis  # noqa: F401
 else:
     from ._aioredis1 import (  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools-scm"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
 [options]
 packages = fakeredis
 install_requires =
+    packaging
     # Minor version updates to redis tend to break fakeredis. If you
     # need to use fakeredis with a newer redis, please submit a PR that
     # relaxes this restriction and adds it to the Github Actions tests.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,43 @@
+[metadata]
+name = fakeredis
+version = attr: fakeredis.__version__
+description = Fake implementation of redis API for testing purposes.
+long_description = file: README.rst
+long_description_content_type = test/x-rst
+license = BSD
+url = https://github.com/jamesls/fakeredis
+author = James Saryerwinnie
+author_email = js@jamesls.com
+maintainer = Bruce Merry
+maintainer_email = bmerry@sarao.ac.za
+classifiers =
+    Development Status :: 5 - Production/Stable
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+[options]
+packages = fakeredis
+install_requires =
+    # Minor version updates to redis tend to break fakeredis. If you
+    # need to use fakeredis with a newer redis, please submit a PR that
+    # relaxes this restriction and adds it to the Github Actions tests.
+    redis<3.6.0
+    six>=1.12
+    sortedcontainers
+python_requires = >=3.5
+
+[options.extras_require]
+lua =
+    lupa
+aioredis =
+    aioredis
+
+# Tool configurations below here
+
 [flake8]
 max-line-length = 119
 

--- a/setup.py
+++ b/setup.py
@@ -1,39 +1,4 @@
-import os
-
 from setuptools import setup
 
 
-setup(
-    name='fakeredis',
-    version='1.6.0',
-    description="Fake implementation of redis API for testing purposes.",
-    long_description=open(os.path.join(os.path.dirname(__file__),
-                                       'README.rst')).read(),
-    license='BSD',
-    url="https://github.com/jamesls/fakeredis",
-    author='James Saryerwinnie',
-    author_email='js@jamesls.com',
-    maintainer='Bruce Merry',
-    maintainer_email='bmerry@ska.ac.za',
-    packages=['fakeredis'],
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9'
-    ],
-    python_requires='>=3.5',
-    install_requires=[
-        # Minor version updates to redis tend to break fakeredis. If you
-        # need to use fakeredis with a newer redis, please submit a PR that
-        # relaxes this restriction and adds it to the Github Actions tests.
-        'redis<3.6.0', 'six>=1.12', 'sortedcontainers'
-    ],
-    extras_require={
-        'lua': ['lupa'],
-        'aioredis': ['aioredis']
-    }
-)
+setup()

--- a/test/test_aioredis1.py
+++ b/test/test_aioredis1.py
@@ -1,6 +1,6 @@
 import asyncio
-import distutils.version
 
+from packaging.version import Version
 import pytest
 import aioredis
 from async_generator import yield_, async_generator
@@ -8,7 +8,7 @@ from async_generator import yield_, async_generator
 import fakeredis.aioredis
 
 
-aioredis2 = aioredis.__version__ >= distutils.version.StrictVersion('2.0.0a1')
+aioredis2 = Version(aioredis.__version__) >= Version('2.0.0a1')
 pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.skipif(aioredis2, reason="Test is only applicable to aioredis 1.x")

--- a/test/test_aioredis2.py
+++ b/test/test_aioredis2.py
@@ -1,7 +1,7 @@
 import asyncio
-import distutils.version
 import re
 
+from packaging.version import Version
 import pytest
 import aioredis
 import async_timeout
@@ -10,7 +10,7 @@ from async_generator import yield_, async_generator
 import fakeredis.aioredis
 
 
-aioredis2 = aioredis.__version__ >= distutils.version.StrictVersion('2.0.0a1')
+aioredis2 = Version(aioredis.__version__) >= Version('2.0.0a1')
 pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.skipif(not aioredis2, reason="Test is only applicable to aioredis 2.x")


### PR DESCRIPTION
- Add a pyproject.toml file (with setuptools_scm, so that pypa-build
  will include everything from SCM in the build; and remove MANIFEST.in)
- Move all the metadata from setup.py to setup.cfg (setup.py is left
  just to support editable builds).
- Use `attr:` in setup.cfg to get the version programmatically instead
  of repeating it.
- Replace distutils.version with packaging.version (the former will be deprecated by PEP 632).
- Update my email address