### PR TITLE
Updates to support newer redis and redis-py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,32 +9,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy-3.7"]
         redis-py: ["3.5.3"]
         aioredis: ["2.0.0"]
         include:
-          - python-version: "3.10"
+          - python-version: "3.9"
             redis-py: "2.10.6"
             aioredis: "1.3.1"
-          - python-version: "3.10"
+          - python-version: "3.9"
             redis-py: "3.0.1"
             aioredis: "1.3.1"
-          - python-version: "3.10"
+          - python-version: "3.9"
             redis-py: "3.1.0"
             aioredis: "1.3.1"
-          - python-version: "3.10"
+          - python-version: "3.9"
             redis-py: "3.2.1"
             aioredis: "1.3.1"
-          - python-version: "3.10"
+          - python-version: "3.9"
             redis-py: "3.3.11"
             aioredis: "1.3.1"
-          - python-version: "3.10"
+          - python-version: "3.9"
             redis-py: "3.4.1"
             aioredis: "1.3.1"
-          - python-version: "3.10"
+          - python-version: "3.9"
             redis-py: "3.5.3"
             aioredis: "1.3.1"
-          - python-version: "3.10"
+          - python-version: "3.9"
             redis-py: "3.5.*"
             aioredis: "2.0.0"
             coverage: yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,32 +9,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy-3.7"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
         redis-py: ["3.5.3"]
         aioredis: ["2.0.0"]
         include:
-          - python-version: "3.9"
+          - python-version: "3.10"
             redis-py: "2.10.6"
             aioredis: "1.3.1"
-          - python-version: "3.9"
+          - python-version: "3.10"
             redis-py: "3.0.1"
             aioredis: "1.3.1"
-          - python-version: "3.9"
+          - python-version: "3.10"
             redis-py: "3.1.0"
             aioredis: "1.3.1"
-          - python-version: "3.9"
+          - python-version: "3.10"
             redis-py: "3.2.1"
             aioredis: "1.3.1"
-          - python-version: "3.9"
+          - python-version: "3.10"
             redis-py: "3.3.11"
             aioredis: "1.3.1"
-          - python-version: "3.9"
+          - python-version: "3.10"
             redis-py: "3.4.1"
             aioredis: "1.3.1"
-          - python-version: "3.9"
+          - python-version: "3.10"
             redis-py: "3.5.3"
             aioredis: "1.3.1"
-          - python-version: "3.9"
+          - python-version: "3.10"
             redis-py: "3.5.*"
             aioredis: "2.0.0"
             coverage: yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
             coverage: yes
     services:
       redis:
-        image: redis:6.0.10
+        image: redis:6.2.6
         ports:
           - 6379:6379
     steps:

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -1902,13 +1902,11 @@ class FakeSocket:
     def sdiffstore(self, dst, *keys):
         return self._setop(lambda a, b: a - b, False, dst, *keys)
 
-    # The following keys can't be marked as sets because of the
-    # stop_if_empty early-out.
-    @command((Key(set),), (Key(),))
+    @command((Key(set),), (Key(set),))
     def sinter(self, *keys):
         return self._setop(lambda a, b: a & b, True, None, *keys)
 
-    @command((Key(), Key(set)), (Key(),))
+    @command((Key(), Key(set)), (Key(set),))
     def sinterstore(self, dst, *keys):
         return self._setop(lambda a, b: a & b, True, dst, *keys)
 

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -2562,7 +2562,7 @@ class FakeSocket:
         elif casematch(subcmd, b'exists'):
             return [int(sha1 in self._server.script_cache) for sha1 in args]
         elif casematch(subcmd, b'flush'):
-            if len(args) != 0:
+            if len(args) > 1 or (len(args) == 1 and casenorm(args[0]) not in {b'sync', b'async'}):
                 raise SimpleError(BAD_SUBCOMMAND_MSG.format('SCRIPT'))
             self._server.script_cache = {}
             return OK

--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -2355,8 +2355,10 @@ class FakeSocket:
     # Server commands
     # TODO: lots
 
-    @command((), flags='s')
-    def bgsave(self):
+    @command((), (bytes,), flags='s')
+    def bgsave(self, *args):
+        if len(args) > 1 or (len(args) == 1 and not casematch(args[0], b'schedule')):
+            raise SimpleError(SYNTAX_ERROR_MSG)
         self._server.lastsave = int(time.time())
         return BGSAVE_STARTED
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ hypothesis==5.41.4
     # via -r requirements.in
 iniconfig==1.1.1
     # via pytest
-lupa==1.9
+lupa==1.10
     # via -r requirements.in
 mccabe==0.6.1
     # via flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ pyflakes==2.2.0
     # via flake8
 pyparsing==2.4.7
     # via packaging
-pytest==6.1.2
+pytest==6.2.5
     # via
     #   -r requirements.in
     #   pytest-asyncio

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
 
 [options]
 packages = fakeredis

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 packages = fakeredis

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     # Minor version updates to redis tend to break fakeredis. If you
     # need to use fakeredis with a newer redis, please submit a PR that
     # relaxes this restriction and adds it to the Github Actions tests.
-    redis<3.6.0
+    redis<4.1.0
     six>=1.12
     sortedcontainers
 python_requires = >=3.5

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -3454,6 +3454,10 @@ def test_save(r):
 
 def test_bgsave(r):
     assert r.bgsave()
+    with pytest.raises(ResponseError):
+        r.execute_command('BGSAVE', 'SCHEDULE', 'FOO')
+    with pytest.raises(ResponseError):
+        r.execute_command('BGSAVE', 'FOO')
 
 
 def test_lastsave(r):

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -1041,6 +1041,22 @@ def test_lpop_wrong_type(r):
         r.lpop('foo')
 
 
+@pytest.mark.min_server('6.2')
+def test_lpop_count(r):
+    assert r.rpush('foo', 'one') == 1
+    assert r.rpush('foo', 'two') == 2
+    assert r.rpush('foo', 'three') == 3
+    assert raw_command(r, 'lpop', 'foo', 2) == [b'one', b'two']
+    # See https://github.com/redis/redis/issues/9680
+    assert raw_command(r, 'lpop', 'foo', 0) is None
+
+
+@pytest.mark.min_server('6.2')
+def test_lpop_count_negative(r):
+    with pytest.raises(redis.ResponseError):
+        raw_command(r, 'lpop', 'foo', -1)
+
+
 def test_lset(r):
     r.rpush('foo', 'one')
     r.rpush('foo', 'two')
@@ -1146,6 +1162,22 @@ def test_rpop_wrong_type(r):
     r.set('foo', 'bar')
     with pytest.raises(redis.ResponseError):
         r.rpop('foo')
+
+
+@pytest.mark.min_server('6.2')
+def test_rpop_count(r):
+    assert r.rpush('foo', 'one') == 1
+    assert r.rpush('foo', 'two') == 2
+    assert r.rpush('foo', 'three') == 3
+    assert raw_command(r, 'rpop', 'foo', 2) == [b'three', b'two']
+    # See https://github.com/redis/redis/issues/9680
+    assert raw_command(r, 'rpop', 'foo', 0) is None
+
+
+@pytest.mark.min_server('6.2')
+def test_rpop_count_negative(r):
+    with pytest.raises(redis.ResponseError):
+        raw_command(r, 'rpop', 'foo', -1)
 
 
 def test_linsert_before(r):

--- a/test/test_fakeredis.py
+++ b/test/test_fakeredis.py
@@ -5008,10 +5008,10 @@ class TestInitArgs:
         assert db2.get('foo') == b'foo2'
 
     def test_from_url_db_value_error(self):
-        # In ValueError, should default to 0
+        # In case of ValueError, should default to 0, or be absent in redis-py 4.0
         db = fakeredis.FakeStrictRedis.from_url(
             'redis://localhost:6379/a')
-        assert db.connection_pool.connection_kwargs['db'] == 0
+        assert db.connection_pool.connection_kwargs.get('db', 0) == 0
 
     def test_can_pass_through_extra_args(self):
         db = fakeredis.FakeStrictRedis.from_url(

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -239,7 +239,7 @@ list_commands = (
                st.sampled_from(['before', 'after', 'BEFORE', 'AFTER']) | st.binary(),
                values, values)
     | commands(st.just('llen'), keys)
-    | commands(st.sampled_from(['lpop', 'rpop']), keys)
+    | commands(st.sampled_from(['lpop', 'rpop']), keys, st.just(None) | st.integers())
     | commands(st.sampled_from(['lpush', 'lpushx', 'rpush', 'rpushx']), keys, st.lists(values))
     | commands(st.just('lrange'), keys, counts, counts)
     | commands(st.just('lrem'), keys, counts, values)


### PR DESCRIPTION
There are a few sorts of changes here:
- new commands (or options on commands) needed because redis-py 4.0 pre-releases depend on them
- other adjustments needed for compatibility with redis-py 4.0 pre-releases.
- tweaks to command behaviour to be compatible with redis 6.2.6 on some corner cases where it behaves differently to 6.0.10.

It doesn't work with redis-py 4.0.0rc1 due to https://github.com/redis/redis-py/issues/1669, but it should be in a much better position once redis-py gets rid of various assumptions of a 6.2 server.