### PR TITLE
Fix an RPOP corner case that only worked for LPOP

### DIFF
--- a/fakeredis/_server.py
+++ b/fakeredis/_server.py
@@ -1853,7 +1853,7 @@ class FakeSocket:
                 key.update(new_value)
         return OK
 
-    @command((Key(list),), (Int(),))
+    @command((Key(),), (Int(),))
     def rpop(self, key, *args):
         return self._list_pop(lambda count: slice(None, -count - 1, -1), key, *args)
 


### PR DESCRIPTION
Popping 0 elements from a list in Redis 6.2.6 is not an error even if
the key is the wrong type. This was correctly implemented for LPOP, but
for RPOP it wasn't done correctly (picked up by hypothesis).
