### PR TITLE
Add pytest fixture + plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,9 +97,25 @@ Fakeredis implements the same interface as `redis-py`_, the
 popular redis client for python, and models the responses
 of redis 6.0 (although most new feature in 6.0 are not supported).
 
+Pytest Fixture via Plugin
+------------
+You can also use the pytest fixture by declaring ``fakeredis.plugins`` in your plugins
+and including ``_fake_redis`` in your test parameters.
+
+.. code-block:: python
+
+  import redis
+  import fakeredis
+
+  pytest_plugins = "fakeredis.plugins"
+
+
+  def test_fake_redis_plugin(_fake_redis):
+      assert isinstance(redis.Redis(), fakeredis.FakeStrictRedis)
+
+
 Support for aioredis
 ====================
-
 You can also use fakeredis to mock out aioredis_.  This is a much newer
 addition to fakeredis (added in 1.4.0) with less testing, so your mileage may
 vary. Both version 1 and version 2 (which have very different APIs) are

--- a/fakeredis/plugins.py
+++ b/fakeredis/plugins.py
@@ -1,0 +1,11 @@
+from typing import Type
+from unittest import mock
+import pytest
+
+import fakeredis
+
+
+@pytest.fixture
+def _fake_redis() -> Type[fakeredis.FakeStrictRedis]:
+    with mock.patch("redis.Redis", fakeredis.FakeStrictRedis):
+        yield fakeredis.FakeStrictRedis

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -1,0 +1,8 @@
+import redis
+import fakeredis
+
+pytest_plugins = "fakeredis.plugins"
+
+
+def test_fake_redis_plugin(_fake_redis):
+    assert isinstance(redis.Redis(), fakeredis.FakeStrictRedis)


### PR DESCRIPTION
This PR adds a pytest fixture which users can import via plugin:

```python
import redis
import fakeredis

pytest_plugins = "fakeredis.plugins"


def test_something(_fake_redis):
    assert isinstance(redis.Redis(), fakeredis.FakeStrictRedis)
    ....

```